### PR TITLE
Fix the Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,14 @@ php:
 
 sudo: false
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+install:
+- travis_retry composer install --no-interaction
+
 script:
+- composer validate --strict
 - find mollie tests -name *.php | xargs -n 1 -P4 php -l
-- phpunit -c tests/phpunit.xml
+- vendor/bin/phpunit -c tests/phpunit.xml

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,20 @@
+{
+    "name": "mollie/prestashop",
+    "description": "Mollie module for Prestashop",
+    "homepage": "https://www.mollie.com",
+    "authors": [
+        {
+            "name": "Mollie B.V.",
+            "email": "info@mollie.com"
+        }
+    ],
+    "license": "BSD-2-Clause",
+    "require": {
+        "php": ">=5.3.0",
+        "ext-curl": "*",
+        "ext-openssl": "*"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "4.8.*"
+    }
+}


### PR DESCRIPTION
The default installed version of PhpUnit for PHP 7.0 and 7.1 is
incompatible with our tests, so build with a hardcoded version of
PhpUnit.