### PR TITLE
Fix for missing template error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ views/js/app/dist/**
 views/js/app/node_modules/**
 yarn.lock
 package-lock.json
+.idea/

--- a/controllers/front/return.php
+++ b/controllers/front/return.php
@@ -156,6 +156,10 @@ class MollieReturnModuleFrontController extends ModuleFrontController
 
         $this->context->smarty->assign($data);
         $this->context->smarty->assign('link', $this->context->link);
-        $this->setTemplate('mollie_return.tpl');
+        if (version_compare(_PS_VERSION_, '1.7.0.0', '<')) {
+            $this->setTemplate('mollie_return.tpl');
+        } else {
+            $this->setTemplate('module:mollie/views/templates/front/mollie_return.tpl');
+        }
     }
 }


### PR DESCRIPTION
Prestashop 1.7.2.4 will report that the mollie_return.tpl file is missing when not using module: for the filename. This causes an error in development mode.