### PR TITLE
Fix Upgrade-4.0.7.php: Type error: Too few arguments to function Moll…

### DIFF
--- a/upgrade/Upgrade-4.0.7.php
+++ b/upgrade/Upgrade-4.0.7.php
@@ -72,7 +72,8 @@ function upgrade_module_4_0_7($module)
     $module->registerHook('actionAdminControllerSetMedia');
     $module->registerHook('actionValidateOrder');
 
-    $installer = new \Mollie\Install\Installer($module);
+    /** @var \Mollie\Install\Installer $installer */
+    $installer = $module->getContainer(\Mollie\Install\Installer::class);
     $installed = true;
 
     $installed &= $installer->installTab('AdminMollieAjax', 0, 'AdminMollieAjax', false);


### PR DESCRIPTION
…ie\Install\Installer::__construct()

Load Installer from container. Fixes error:
Type error: Too few arguments to function Mollie\Install\Installer::__construct(), 1 passed in /httpdocs/modules/mollie/upgrade/Upgrade-4.0.7.php on line 75 and exactly 2 expected

