### PR TITLE
Fix code that adjusts order total with fee

### DIFF
--- a/controllers/front/payment.php
+++ b/controllers/front/payment.php
@@ -375,8 +375,8 @@ class MolliePaymentModuleFrontController extends ModuleFrontController
 
         $orderid = Order::getOrderByCartId($cartId);
         $order = new Order($orderid);
-        $order->total_paid_tax_excl = $orderFeeNumber->plus( new Number((string) $order->total_paid_tax_excl));
-        $order->total_paid_tax_incl = $orderFeeNumber->plus( new Number((string) $order->total_paid_tax_incl));
+        $order->total_paid_tax_excl = (string) $orderFeeNumber->plus( new Number((string) $order->total_paid_tax_excl));
+        $order->total_paid_tax_incl = (string) $orderFeeNumber->plus( new Number((string) $order->total_paid_tax_incl));
         $order->total_paid = $totalPrice->toPrecision(2);
         $order->reference = $orderReference;
         $order->update();


### PR DESCRIPTION
Code that adjusts order total results in \PrestaShop\Decimal\Number object
being stored inside $order->total_paid_tax_excl property.

This is definitely not an expected value.

Prestashop "survives" this by pure luck, as the value is converted to
string during sql update. That might not be the case in the future.

In thirtybees platform this leads to invalid value being stored inside
database table already.