### PR TITLE
MOLIM-233 backorder status fix when buying product with 0qty

### DIFF
--- a/src/Service/TransactionService.php
+++ b/src/Service/TransactionService.php
@@ -406,7 +406,7 @@ class TransactionService
             $orderDetail = new OrderDetail($detail['id_order_detail']);
             if (
                 Configuration::get('PS_STOCK_MANAGEMENT') &&
-                ($orderDetail->getStockState() || $orderDetail->product_quantity_in_stock < 0)
+                ($orderDetail->getStockState() || $orderDetail->product_quantity_in_stock <= 0)
             ) {
                 return true;
             }


### PR DESCRIPTION
Fixed an issue when a user customer buys a product that has 0 quantity in stock the status becomes "Payment accepted".
![image](https://user-images.githubusercontent.com/37104879/126760980-adf05151-56cc-4568-ac46-84bf794c6ad4.png)
With this fix status "On backorder (paid)" is being set when a customer buys product with 0 qty