### PR TITLE
PIPRES-213: Subscription address delete fix

### DIFF
--- a/subscription/Handler/CustomerAddressUpdateHandler.php
+++ b/subscription/Handler/CustomerAddressUpdateHandler.php
@@ -7,10 +7,7 @@ use MolRecurringOrder;
 
 /**
  * NOTE: this handler is used specifically for address update,
- * where address was already used for subscription product.
- *
- * actionObjectAddressAddAfter and actionObjectAddressUpdateAfter hooks are called one after another
- * to get previous address and current address IDs.
+ * when address was already used for original subscription order.
  */
 class CustomerAddressUpdateHandler
 {

--- a/subscription/Handler/CustomerAddressUpdateHandler.php
+++ b/subscription/Handler/CustomerAddressUpdateHandler.php
@@ -35,8 +35,7 @@ class CustomerAddressUpdateHandler
             ->findAll()
             ->where('id_customer', '=', $customerId)
             ->sqlWhere('id_address_delivery = ' . $oldAddressId . ' OR id_address_invoice = ' . $oldAddressId)
-            ->getAll()
-        ;
+            ->getAll();
 
         if (!$orders) {
             //NOTE: No exception is needed as there could be no subscription orders with the old address
@@ -44,19 +43,17 @@ class CustomerAddressUpdateHandler
         }
 
         foreach ($orders as $order) {
-            $updatedOrder = new MolRecurringOrder($order->id_mol_recurring_orders_product);
-
             if ((int) $order->id_address_delivery === $oldAddressId) {
-                $updatedOrder->id_address_delivery = $newAddressId;
+                $order->id_address_delivery = $newAddressId;
             }
 
             if ((int) $order->id_address_invoice === $oldAddressId) {
-                $updatedOrder->id_address_invoice = $newAddressId;
+                $order->id_address_invoice = $newAddressId;
             }
 
-            $updatedOrder->date_update = $this->clock->getCurrentDate();
+            $order->date_update = $this->clock->getCurrentDate();
 
-            $updatedOrder->update();
+            $order->update();
         }
     }
 }

--- a/subscription/Install/HookInstaller.php
+++ b/subscription/Install/HookInstaller.php
@@ -37,6 +37,7 @@ class HookInstaller extends AbstractInstaller
             'actionObjectAddressAddAfter',
             'actionObjectAddressUpdateAfter',
             'actionPresentOrder',
+            'actionObjectAddressDeleteAfter',
         ];
     }
 }

--- a/subscription/Traits/HookTraits.php
+++ b/subscription/Traits/HookTraits.php
@@ -6,6 +6,7 @@ use Address;
 use Mollie\Adapter\ToolsAdapter;
 use Mollie\Decorator\RecurringOrderLazyArray;
 use Mollie\Subscription\Handler\CustomerAddressUpdateHandler;
+use Mollie\Subscription\Repository\RecurringOrderRepositoryInterface;
 use MollieRecurringOrderDetailModuleFrontController;
 use MolRecurringOrder;
 use Order;
@@ -44,9 +45,52 @@ trait HookTraits
         /** @var CustomerAddressUpdateHandler $subscriptionShippingAddressUpdateHandler */
         $subscriptionShippingAddressUpdateHandler = $this->getService(CustomerAddressUpdateHandler::class);
 
-        $subscriptionShippingAddressUpdateHandler->handle($address->id_customer, $this->newAddressId, $address->id);
+        $subscriptionShippingAddressUpdateHandler->handle((int) $address->id_customer, (int) $this->newAddressId, (int) $address->id);
 
         $this->newAddressId = null;
+    }
+
+    public function hookActionObjectAddressDeleteAfter(array $params): void
+    {
+        /** @var Address $deletedAddress */
+        $deletedAddress = $params['object'];
+
+        /** @var RecurringOrderRepositoryInterface $recurringOrderRepository */
+        $recurringOrderRepository = $this->getService(RecurringOrderRepositoryInterface::class);
+
+//        TODO reuse customerAddressUpdateHandler, this case is different as we don't need to save deleted address if it's not linked with subscription address.
+
+        /** @var \MolRecurringOrder[]|null $orders */
+        $orders = $recurringOrderRepository
+            ->findAll()
+            ->where('id_customer', '=', (int) $deletedAddress->id_customer)
+            ->sqlWhere('id_address_delivery = ' . (int) $deletedAddress->id . ' OR id_address_invoice = ' . (int) $deletedAddress->id)
+            ->getAll();
+
+        if (!$orders) {
+            return;
+        }
+
+        $newAddress = $deletedAddress;
+
+        $newAddress->id = 0;
+        $newAddress->deleted = 1;
+
+        $newAddress->save();
+
+        foreach ($orders as $order) {
+            if ((int) $order->id_address_delivery === $deletedAddress->id) {
+                $order->id_address_delivery = $newAddress->id;
+            }
+
+            if ((int) $order->id_address_invoice === $deletedAddress->id) {
+                $order->id_address_invoice = $newAddress->id;
+            }
+
+            $order->date_update = $this->clock->getCurrentDate();
+
+            $order->update();
+        }
     }
 
     public function hookActionPresentOrder(array &$params): void

--- a/subscription/Traits/HookTraits.php
+++ b/subscription/Traits/HookTraits.php
@@ -11,7 +11,6 @@ use MollieRecurringOrderDetailModuleFrontController;
 use MolRecurringOrder;
 use Order;
 use PrestaShop\PrestaShop\Adapter\Presenter\Order\OrderLazyArray;
-use PrestaShopCollection;
 
 /**
  * NOTE: used this hook trait as we need to access private property's data during single code execution.
@@ -92,7 +91,7 @@ trait HookTraits
         $newAddress = $deletedAddress;
 
         $newAddress->id = 0;
-        $newAddress->deleted = 1;
+        $newAddress->deleted = true;
 
         /*
          * NOTE: this triggers addAfter hook, which replaces old ID with the new one


### PR DESCRIPTION
improved whole logic: deleteAfter hook creates copy address, which is saved by another hook into recurring_order table. AddAfter hook replaces recurring_order address with the new one and updateAfter just updates date_updated.

Cases:

- If address is being updated for the first time, soft delete is triggered (address was linked with ps order) and addAfter hook is called (as new address is created)
- If address is being updated not the first time and it was not used in ps order: updateAfter will just update date_updated as Id didn't change.
- If address is being deleted, we let delete it and from the old object we re-create address, which is saved by addAfter hook into recurring_order table.