### PR TITLE
PIPRES-214: Stop add to cart action on subscription product fix

### DIFF
--- a/mollie.php
+++ b/mollie.php
@@ -972,7 +972,6 @@ class Mollie extends PaymentModule
         $orderListActionBuilder = $module->getService(\Mollie\Presenter\OrderListActionBuilder::class);
 
         return $orderListActionBuilder->buildOrderPaymentResendButton($orderId);
-        return $orderListActionBuilder->buildOrderPaymentResendButton($orderId);
     }
 
     public function updateApiKey($shopId = null)
@@ -1018,7 +1017,7 @@ class Mollie extends PaymentModule
 
         http_response_code(Response::HTTP_BAD_REQUEST);
 
-        die(json_encode(
+        exit(json_encode(
             [
                 'hasError' => $hasError,
                 'errors' => $errors,

--- a/mollie.php
+++ b/mollie.php
@@ -349,7 +349,7 @@ class Mollie extends PaymentModule
 
             Media::addJsDef([
                 'mollieSubAjaxUrl' => $this->context->link->getModuleLink('mollie', 'ajax'),
-                'isVersionHigherThan176' => PsVersionUtility::isPsVersionHigherOrEqualsThan(_PS_VERSION_, '1.7.7.0'),
+                'isVersionGreaterThan176' => PsVersionUtility::isPsVersionGreaterOrEqualTo(_PS_VERSION_, '1.7.7.0'),
             ]);
         }
         if (!$paymentMethod || !$paymentMethod->enabled) {
@@ -893,7 +893,7 @@ class Mollie extends PaymentModule
 
     public function hookDisplayProductActions($params)
     {
-        if (PsVersionUtility::isPsVersionHigherOrEqualsThan(_PS_VERSION_, '1.7.6.0')) {
+        if (PsVersionUtility::isPsVersionGreaterOrEqualTo(_PS_VERSION_, '1.7.6.0')) {
             return $this->display(__FILE__, 'views/templates/front/apple_pay_direct.tpl');
         }
 
@@ -907,7 +907,7 @@ class Mollie extends PaymentModule
 
     public function hookDisplayProductAdditionalInfo()
     {
-        if (!PsVersionUtility::isPsVersionHigherOrEqualsThan(_PS_VERSION_, '1.7.6.0')) {
+        if (!PsVersionUtility::isPsVersionGreaterOrEqualTo(_PS_VERSION_, '1.7.6.0')) {
             return $this->display(__FILE__, 'views/templates/front/apple_pay_direct.tpl');
         }
 
@@ -1001,7 +1001,7 @@ class Mollie extends PaymentModule
 
     public function hookActionAjaxDieCartControllerDisplayAjaxUpdateBefore(array $params): void
     {
-        if (PsVersionUtility::isPsVersionHigherOrEqualsThan(_PS_VERSION_, '1.7.7.0')) {
+        if (PsVersionUtility::isPsVersionHigherThan(_PS_VERSION_, '1.7.7.0')) {
             return;
         }
 

--- a/mollie.php
+++ b/mollie.php
@@ -991,6 +991,22 @@ class Mollie extends PaymentModule
         }
     }
 
+    public function hookActionAjaxDieCartControllerdisplayAjaxUpdateBefore(array $params): void
+    {
+//        TODO doesn't work as ps_shoppingcart.js logic only triggers on updateCart emitted event
+//        http_response_code(500);
+//
+//        die((
+//            json_encode(
+//                [
+//                    'success' => true,
+//                    'isValid' => false,
+//                    'message' => 'test-message',
+//                ]
+//            )
+//        ));
+    }
+
     private function setApiKey($shopId = null)
     {
         /** @var \Mollie\Repository\ModuleRepository $moduleRepository */

--- a/mollie.php
+++ b/mollie.php
@@ -1001,7 +1001,7 @@ class Mollie extends PaymentModule
 
     public function hookActionAjaxDieCartControllerDisplayAjaxUpdateBefore(array $params): void
     {
-        if (PsVersionUtility::isPsVersionHigherThan(_PS_VERSION_, '1.7.7.0')) {
+        if (PsVersionUtility::isPsVersionGreaterOrEqualTo(_PS_VERSION_, '1.7.7.0')) {
             return;
         }
 

--- a/mollie.php
+++ b/mollie.php
@@ -349,7 +349,7 @@ class Mollie extends PaymentModule
 
             Media::addJsDef([
                 'mollieSubAjaxUrl' => $this->context->link->getModuleLink('mollie', 'ajax'),
-                'isVersionGreaterThan176' => PsVersionUtility::isPsVersionGreaterOrEqualTo(_PS_VERSION_, '1.7.7.0'),
+                'isVersionLessThan177' => PsVersionUtility::isPsVersionLessThan(_PS_VERSION_, '1.7.7.0'),
             ]);
         }
         if (!$paymentMethod || !$paymentMethod->enabled) {

--- a/mollie.php
+++ b/mollie.php
@@ -349,7 +349,7 @@ class Mollie extends PaymentModule
 
             Media::addJsDef([
                 'mollieSubAjaxUrl' => $this->context->link->getModuleLink('mollie', 'ajax'),
-                'isVersionLessThan177' => PsVersionUtility::isPsVersionLessThan(_PS_VERSION_, '1.7.7.0'),
+                'isVersionGreaterOrEqualTo177' => PsVersionUtility::isPsVersionGreaterOrEqualTo(_PS_VERSION_, '1.7.7.0'),
             ]);
         }
         if (!$paymentMethod || !$paymentMethod->enabled) {

--- a/src/Utility/PsVersionUtility.php
+++ b/src/Utility/PsVersionUtility.php
@@ -18,4 +18,9 @@ class PsVersionUtility
     {
         return version_compare($psVersion, $targetVersion, '>=');
     }
+
+    public static function isPsVersionLessThan(string $psVersion, string $targetVersion)
+    {
+        return version_compare($psVersion, $targetVersion, '<');
+    }
 }

--- a/src/Utility/PsVersionUtility.php
+++ b/src/Utility/PsVersionUtility.php
@@ -14,8 +14,8 @@ namespace Mollie\Utility;
 
 class PsVersionUtility
 {
-    public static function isPsVersionHigherThen(string $psVersion, string $higherThen, string $operator = '>=')
+    public static function isPsVersionHigherOrEqualsThan(string $psVersion, string $targetVersion)
     {
-        return version_compare($psVersion, $higherThen, '>=');
+        return version_compare($psVersion, $targetVersion, '>=');
     }
 }

--- a/src/Utility/PsVersionUtility.php
+++ b/src/Utility/PsVersionUtility.php
@@ -14,7 +14,7 @@ namespace Mollie\Utility;
 
 class PsVersionUtility
 {
-    public static function isPsVersionHigherOrEqualsThan(string $psVersion, string $targetVersion)
+    public static function isPsVersionGreaterOrEqualTo(string $psVersion, string $targetVersion)
     {
         return version_compare($psVersion, $targetVersion, '>=');
     }

--- a/src/Utility/PsVersionUtility.php
+++ b/src/Utility/PsVersionUtility.php
@@ -18,9 +18,4 @@ class PsVersionUtility
     {
         return version_compare($psVersion, $targetVersion, '>=');
     }
-
-    public static function isPsVersionLessThan(string $psVersion, string $targetVersion)
-    {
-        return version_compare($psVersion, $targetVersion, '<');
-    }
 }

--- a/subscription/Install/HookInstaller.php
+++ b/subscription/Install/HookInstaller.php
@@ -38,7 +38,7 @@ class HookInstaller extends AbstractInstaller
             'actionObjectAddressUpdateAfter',
             'actionObjectAddressDeleteAfter',
             'actionBeforeCartUpdateQty',
-            'actionAjaxDieCartControllerdisplayAjaxUpdateBefore',
+            'actionAjaxDieCartControllerDisplayAjaxUpdateBefore',
         ];
     }
 }

--- a/subscription/Install/HookInstaller.php
+++ b/subscription/Install/HookInstaller.php
@@ -37,6 +37,8 @@ class HookInstaller extends AbstractInstaller
             'actionObjectAddressAddAfter',
             'actionObjectAddressUpdateAfter',
             'actionObjectAddressDeleteAfter',
+            'actionBeforeCartUpdateQty',
+            'actionAjaxDieCartControllerdisplayAjaxUpdateBefore',
         ];
     }
 }

--- a/tests/Unit/Utility/PsVersionUtilityTest.php
+++ b/tests/Unit/Utility/PsVersionUtilityTest.php
@@ -20,9 +20,9 @@ class PsVersionUtilityTest extends TestCase
     /**
      * @dataProvider psVersionsProvider
      */
-    public function testIsPsVersionHigherThen(string $psVersion, string $higherThen, bool $result)
+    public function testIsPsVersionHigherOrEqualsThan(string $psVersion, string $higherThen, bool $result)
     {
-        $isHigherThenGivenVersion = PsVersionUtility::isPsVersionHigherThen($psVersion, $higherThen);
+        $isHigherThenGivenVersion = PsVersionUtility::isPsVersionHigherOrEqualsThan($psVersion, $higherThen);
         $this->assertEquals($result, $isHigherThenGivenVersion);
     }
 

--- a/tests/Unit/Utility/PsVersionUtilityTest.php
+++ b/tests/Unit/Utility/PsVersionUtilityTest.php
@@ -20,9 +20,9 @@ class PsVersionUtilityTest extends TestCase
     /**
      * @dataProvider psVersionsProvider
      */
-    public function testIsPsVersionHigherOrEqualsThan(string $psVersion, string $higherThen, bool $result)
+    public function testIsPsVersionGreaterOrEqualTo(string $psVersion, string $higherThen, bool $result)
     {
-        $isHigherThenGivenVersion = PsVersionUtility::isPsVersionHigherOrEqualsThan($psVersion, $higherThen);
+        $isHigherThenGivenVersion = PsVersionUtility::isPsVersionGreaterOrEqualTo($psVersion, $higherThen);
         $this->assertEquals($result, $isHigherThenGivenVersion);
     }
 

--- a/views/js/front/subscription/product.js
+++ b/views/js/front/subscription/product.js
@@ -1,14 +1,37 @@
 $(document).ready(function () {
-    prestashop.on('updateCart', function() {
-        const productDetails = JSON.parse(document.getElementById('product-details').dataset.product);
-        const product =
-            {
-                'id_product': productDetails.id_product,
-                'id_product_attribute': productDetails.id_product_attribute,
-            }
+    $(document).ajaxComplete(function (event, xhr, settings) {
+      if (isVersionHigherThan176) {
+        return;
+      }
 
-        validateProduct(product);
+      if (
+        settings.url.toLowerCase().indexOf('controller=cart') > 0 &&
+        settings.data.toLowerCase().indexOf('action=update') > 0 &&
+        settings.data.toLowerCase().indexOf('add=1') > 0
+      ) {
+        validateProduct(getProductData());
+      }
     });
+
+    prestashop.on('updateCart', function() {
+        validateProduct(getProductData());
+    });
+
+    function getProductData()
+    {
+      let productDetails = $('#product-details').attr('data-product');
+
+      if (productDetails.length < 1) {
+        return;
+      }
+
+      productDetails = JSON.parse(productDetails);
+
+      return {
+        'id_product': productDetails.id_product,
+        'id_product_attribute': productDetails.id_product_attribute,
+      }
+    }
 
     function validateProduct(product)
     {

--- a/views/js/front/subscription/product.js
+++ b/views/js/front/subscription/product.js
@@ -1,6 +1,6 @@
 $(document).ready(function () {
     $(document).ajaxComplete(function (event, xhr, settings) {
-      if (isVersionGreaterThan176) {
+      if (!isVersionLessThan177) {
         return;
       }
 

--- a/views/js/front/subscription/product.js
+++ b/views/js/front/subscription/product.js
@@ -1,6 +1,6 @@
 $(document).ready(function () {
     $(document).ajaxComplete(function (event, xhr, settings) {
-      if (isVersionHigherThan176) {
+      if (isVersionGreaterThan176) {
         return;
       }
 

--- a/views/js/front/subscription/product.js
+++ b/views/js/front/subscription/product.js
@@ -1,6 +1,6 @@
 $(document).ready(function () {
     $(document).ajaxComplete(function (event, xhr, settings) {
-      if (!isVersionLessThan177) {
+      if (isVersionGreaterOrEqualTo177) {
         return;
       }
 
@@ -14,7 +14,7 @@ $(document).ready(function () {
     });
 
     prestashop.on('updateCart', function() {
-        validateProduct(getProductData());
+      validateProduct(getProductData());
     });
 
     function getProductData()
@@ -22,7 +22,7 @@ $(document).ready(function () {
       let productDetails = $('#product-details').attr('data-product');
 
       if (productDetails.length < 1) {
-        return;
+        return null;
       }
 
       productDetails = JSON.parse(productDetails);
@@ -35,6 +35,10 @@ $(document).ready(function () {
 
     function validateProduct(product)
     {
+        if (!product) {
+          return;
+        }
+
         $.ajax({
             url: mollieSubAjaxUrl,
             method: 'GET',
@@ -45,10 +49,9 @@ $(document).ready(function () {
             },
             success: function (response) {
                 response = jQuery.parseJSON(response);
+
                 if (!response.isValid) {
                     successMsg(response.message);
-
-                    return false;
                 }
             }
         })

--- a/views/js/front/subscription/product.js
+++ b/views/js/front/subscription/product.js
@@ -1,16 +1,10 @@
 $(document).ready(function () {
-    $(document).ajaxComplete(function (event, xhr, settings) {
-      if (isVersionGreaterOrEqualTo177) {
+    prestashop.on('handleError', function(parameters) {
+      if (parameters.eventType !== 'addProductToCart' || isVersionGreaterOrEqualTo177) {
         return;
       }
 
-      if (
-        settings.url.toLowerCase().indexOf('controller=cart') > 0 &&
-        settings.data.toLowerCase().indexOf('action=update') > 0 &&
-        settings.data.toLowerCase().indexOf('add=1') > 0
-      ) {
-        validateProduct(getProductData());
-      }
+      validateProduct(getProductData());
     });
 
     prestashop.on('updateCart', function() {


### PR DESCRIPTION
Problem: existing logic for denying product for adding it to the cart (making it available_for_order = false) doesn't work for 1.7.6 version as ps_shoppingcart still shows added to cart modal with no actual added product to cart.

Issue persists only on 1.7.6 version, due to ps_shoppingcart.js file not checking if updateCart emitted action has any errors inside. ps_shoppingcart shows "added to cart" modal, even though operation failed. 
Tested solution on 1.7.6, 1.7.7, 1.7.8