### PR TITLE
PIPREs-213: Subscription duplicate cart validaor improvements

### DIFF
--- a/controllers/front/subscriptionWebhook.php
+++ b/controllers/front/subscriptionWebhook.php
@@ -50,6 +50,7 @@ class MollieSubscriptionWebhookModuleFrontController extends AbstractMollieContr
     protected function executeWebhook()
     {
         $transactionId = Tools::getValue('id');
+
         if (!$transactionId) {
             $this->respond('failed', HttpStatusCode::HTTP_UNPROCESSABLE_ENTITY, 'Missing transaction id');
         }

--- a/subscription/Validator/CanProductBeAddedToCartValidator.php
+++ b/subscription/Validator/CanProductBeAddedToCartValidator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Mollie\Subscription\Validator;
 
 use Mollie\Adapter\CartAdapter;
+use Mollie\Adapter\ToolsAdapter;
 use Mollie\Subscription\Exception\ProductValidationException;
 use Mollie\Subscription\Exception\SubscriptionProductValidationException;
 
@@ -16,10 +17,17 @@ class CanProductBeAddedToCartValidator
     /** @var SubscriptionProductValidator */
     private $subscriptionProduct;
 
-    public function __construct(CartAdapter $cart, SubscriptionProductValidator $subscriptionProduct)
-    {
+    /** @var ToolsAdapter */
+    private $tools;
+
+    public function __construct(
+        CartAdapter $cart,
+        SubscriptionProductValidator $subscriptionProduct,
+        ToolsAdapter $tools
+    ) {
         $this->cart = $cart;
         $this->subscriptionProduct = $subscriptionProduct;
+        $this->tools = $tools;
     }
 
     /**
@@ -33,6 +41,12 @@ class CanProductBeAddedToCartValidator
      */
     public function validate(int $productAttributeId): bool
     {
+        $isSubscriptionDuplicateProduct = $this->tools->getValue('controller');
+
+        if ($isSubscriptionDuplicateProduct === 'subscriptionWebhook') {
+            return true;
+        }
+
         $isNewSubscriptionProduct = $this->subscriptionProduct->validate($productAttributeId);
 
         if ($isNewSubscriptionProduct) {
@@ -61,7 +75,7 @@ class CanProductBeAddedToCartValidator
         // if it's the same product we can add more of the same product
         if ($numberOfProductsInCart === 1) {
             $cartProduct = reset($cartProducts);
-            //TODO this doesn't work if I, as a customer, currently have other products in cart.
+
             $isTheSameProduct = $productAttributeId === (int) $cartProduct['id_product_attribute'];
 
             if (!$isTheSameProduct) {


### PR DESCRIPTION
On cart duplicate, updateQty method is called. In mollie.php we use `hookActionCartUpdateQuantityBefore` to validate if product can be added to cart. This validation is only needed when customer is manipulating cart. But subscription duplicate functionality already duplicates valid cart so we needed to avoid this check.