### PR TITLE
Update CartAdapter.php

### DIFF
--- a/src/Adapter/CartAdapter.php
+++ b/src/Adapter/CartAdapter.php
@@ -15,7 +15,7 @@ class CartAdapter
     }
 
     public function getProducts(): array
-    {
-        return Context::getContext()->cart->getProducts();
+    { 
+        return Context::getContext()->cart ? Context::getContext()->cart->getProducts() : [];
     }
-}
+} 


### PR DESCRIPTION
When another module attempts to add a product to a shopping cart that doesn't yet exist, the module returns an error because it's unable to retrieve the shopping cart from the current context. This issue may be caused by the cart not being initialized or created prior to the product addition attempt. I returned an empty array (of products) when the cart isn't initialized.