### PR TITLE
PIPRES-217: Upgrade SQL file issue fix

### DIFF
--- a/upgrade/Upgrade-6.0.0.php
+++ b/upgrade/Upgrade-6.0.0.php
@@ -27,14 +27,16 @@ function upgrade_module_6_0_0(Mollie $module): bool
     ';
 
     /** only add it if it doesn't exist */
-    if (!(int) Db::getInstance()->getValue($sql)) {
+    if (!Db::getInstance()->getValue($sql)) {
         $sql = '
         ALTER TABLE ' . _DB_PREFIX_ . 'mollie_payments
         ADD `mandate_id` VARCHAR(64);
         ';
 
         try {
-            Db::getInstance()->execute($sql);
+            if (!Db::getInstance()->execute($sql)) {
+                return false;
+            }
         } catch (Exception $e) {
             return false;
         }
@@ -47,7 +49,7 @@ function upgrade_module_6_0_0(Mollie $module): bool
     ';
 
     /** only add it if it doesn't exist */
-    if (!(int) Db::getInstance()->getValue($sql)) {
+    if (!Db::getInstance()->getValue($sql)) {
         $sql = '
         ALTER TABLE ' . _DB_PREFIX_ . 'mol_payment_method
         ADD COLUMN min_amount decimal(20,6) DEFAULT 0,
@@ -55,7 +57,9 @@ function upgrade_module_6_0_0(Mollie $module): bool
         ';
 
         try {
-            Db::getInstance()->execute($sql);
+            if (!Db::getInstance()->execute($sql)) {
+                return false;
+            }
         } catch (Exception $e) {
             return false;
         }

--- a/upgrade/Upgrade-6.0.0.php
+++ b/upgrade/Upgrade-6.0.0.php
@@ -21,38 +21,42 @@ if (!defined('_PS_VERSION_')) {
 function upgrade_module_6_0_0(Mollie $module): bool
 {
     $sql = '
-    SELECT COUNT(*) AS count
-    FROM information_schema.columns
-    WHERE table_name = "' . _DB_PREFIX_ . 'mollie_payments" AND column_name = \'mandate_id\';
+    SELECT COUNT(*) > 0 AS count
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = "' . _DB_NAME_ . '" AND TABLE_NAME = "' . _DB_PREFIX_ . 'mollie_payments" AND COLUMN_NAME = "mandate_id"
     ';
 
     /** only add it if it doesn't exist */
-    if (!Db::getInstance()->execute($sql)) {
+    if (!(int) Db::getInstance()->getValue($sql)) {
         $sql = '
         ALTER TABLE ' . _DB_PREFIX_ . 'mollie_payments
         ADD `mandate_id` VARCHAR(64);
         ';
 
-        if (!Db::getInstance()->execute($sql)) {
+        try {
+            Db::getInstance()->execute($sql);
+        } catch (Exception $e) {
             return false;
         }
     }
 
     $sql = '
-    SELECT COUNT(*) AS count
+    SELECT COUNT(*) > 0 AS count
     FROM information_schema.columns
-    WHERE table_name = "' . _DB_PREFIX_ . 'mol_payment_method" AND column_name = \'min_amount\';
+    WHERE TABLE_SCHEMA = "' . _DB_NAME_ . '" AND table_name = "' . _DB_PREFIX_ . 'mol_payment_method" AND column_name = "min_amount";
     ';
 
     /** only add it if it doesn't exist */
-    if (!Db::getInstance()->execute($sql)) {
+    if (!(int) Db::getInstance()->getValue($sql)) {
         $sql = '
         ALTER TABLE ' . _DB_PREFIX_ . 'mol_payment_method
         ADD COLUMN min_amount decimal(20,6) DEFAULT 0,
         ADD COLUMN max_amount decimal(20,6) DEFAULT 0;
         ';
 
-        if (!Db::getInstance()->execute($sql)) {
+        try {
+            Db::getInstance()->execute($sql);
+        } catch (Exception $e) {
             return false;
         }
     }


### PR DESCRIPTION
Previous SQL call failed due to several reasons:

- Without specifying table_schema (db name), query tries to check other PrestaShop databases if there are ones.
- execute() returns bool of result. But result was not straight value, it was key->value pair so it always failed. getValue returns first row's value so now it gives us correct result.