### PR TITLE
PIPRES-217: Duplicating menu tabs on upgrade fix

### DIFF
--- a/upgrade/Upgrade-6.0.0.php
+++ b/upgrade/Upgrade-6.0.0.php
@@ -80,6 +80,29 @@ function upgrade_module_6_0_0(Mollie $module): bool
         return false;
     }
 
+    // only for 1.7.6 version
+    if (version_compare(_PS_VERSION_, '1.7.7.0', '<')) {
+        $sql = '
+        DELETE FROM `' . _DB_PREFIX_ . 'authorization_role`
+        WHERE `slug` = "ROLE_MOD_TAB_' . $module::ADMIN_MOLLIE_CONTROLLER . '_CREATE"
+        OR `slug` = "ROLE_MOD_TAB_' . $module::ADMIN_MOLLIE_CONTROLLER . '_READ"
+        OR `slug` = "ROLE_MOD_TAB_' . $module::ADMIN_MOLLIE_CONTROLLER . '_UPDATE"
+        OR `slug` = "ROLE_MOD_TAB_' . $module::ADMIN_MOLLIE_CONTROLLER . '_DELETE"
+        OR `slug` = "ROLE_MOD_TAB_' . $module::ADMIN_MOLLIE_AJAX_CONTROLLER . '_CREATE"
+        OR `slug` = "ROLE_MOD_TAB_' . $module::ADMIN_MOLLIE_AJAX_CONTROLLER . '_READ"
+        OR `slug` = "ROLE_MOD_TAB_' . $module::ADMIN_MOLLIE_AJAX_CONTROLLER . '_UPDATE"
+        OR `slug` = "ROLE_MOD_TAB_' . $module::ADMIN_MOLLIE_AJAX_CONTROLLER . '_DELETE";
+        ';
+
+        try {
+            if (!Db::getInstance()->execute($sql)) {
+                return false;
+            }
+        } catch (Exception $e) {
+            return false;
+        }
+    }
+
     //todo: maybe move to container
     $installer = new \Mollie\Install\Installer(
         $module,

--- a/upgrade/Upgrade-6.0.0.php
+++ b/upgrade/Upgrade-6.0.0.php
@@ -65,6 +65,21 @@ function upgrade_module_6_0_0(Mollie $module): bool
         }
     }
 
+    $sql = '
+    DELETE t, tl
+    FROM `' . _DB_PREFIX_ . 'tab` t
+    JOIN `' . _DB_PREFIX_ . 'tab_lang` tl ON t.id_tab = tl.id_tab
+    WHERE t.class_name IN (\'' . $module::ADMIN_MOLLIE_CONTROLLER . '\', \'' . $module::ADMIN_MOLLIE_AJAX_CONTROLLER . '\');
+    ';
+
+    try {
+        if (!Db::getInstance()->execute($sql)) {
+            return false;
+        }
+    } catch (Exception $e) {
+        return false;
+    }
+
     //todo: maybe move to container
     $installer = new \Mollie\Install\Installer(
         $module,


### PR DESCRIPTION
After upgrade old controller tabs stayed in the database, causing duplicate menu items. Manually removing it before registering new tabs.
On 1.7.6. authorization_roles table was causing issues as on this specific presta version there is no check before if such entries exist. Inserting on top of it caused exceptions.