### PR TITLE
PIPRES-226: Max amount error message fix

### DIFF
--- a/controllers/admin/AdminMollieSettingsController.php
+++ b/controllers/admin/AdminMollieSettingsController.php
@@ -58,6 +58,9 @@ class AdminMollieSettingsController extends ModuleAdminController
 
         Media::addJsDef([
             'description_message' => addslashes($this->module->l('Enter a description')),
+            'min_amount_message' => addslashes($this->l('You have entered incorrect min amount')),
+            'max_amount_message' => addslashes($this->l('You have entered incorrect max amount')),
+
             'payment_api' => addslashes(Mollie\Config\Config::MOLLIE_PAYMENTS_API),
             'ajaxUrl' => addslashes($this->context->link->getAdminLink('AdminMollieAjax')),
         ]);


### PR DESCRIPTION
For some reason messages were deleted and errors were thrown due to missing variables.

![image](https://github.com/mollie/PrestaShop/assets/61560082/da92009e-be4e-438f-9418-d923504dd373)
