### PR TITLE
PIPRES-65: tax append to cart summary improvements

### DIFF
--- a/controllers/admin/AdminMollieAjaxController.php
+++ b/controllers/admin/AdminMollieAjaxController.php
@@ -195,13 +195,13 @@ class AdminMollieAjaxController extends ModuleAdminController
             return;
         }
 
-        /** @var TaxCalculatorProvider $taxProvider */
-        $taxProvider = $this->module->getService(TaxCalculatorProvider::class);
+        /** @var TaxCalculatorProvider $taxCalculatorProvider */
+        $taxCalculatorProvider = $this->module->getService(TaxCalculatorProvider::class);
 
         /** @var Context $context */
         $context = $this->module->getService(Context::class);
 
-        $taxCalculator = $taxProvider->getTaxCalculator(
+        $taxCalculator = $taxCalculatorProvider->getTaxCalculator(
             $taxRulesGroupId,
             $context->getCountryId(),
             0 // NOTE: there is no default state for back office so setting no state

--- a/controllers/front/ajax.php
+++ b/controllers/front/ajax.php
@@ -88,7 +88,7 @@ class MollieAjaxModuleFrontController extends AbstractMollieController
         $configuration = $this->module->getService(ConfigurationAdapter::class);
 
         try {
-            $paymentFeeData = $paymentFeeProvider->getPaymentFee($molPaymentMethod, (float)$cart->getOrderTotal());
+            $paymentFeeData = $paymentFeeProvider->getPaymentFee($molPaymentMethod, (float) $cart->getOrderTotal());
         } catch (FailedToProvidePaymentFeeException $exception) {
             $errorData = [
                 'error' => true,
@@ -98,14 +98,11 @@ class MollieAjaxModuleFrontController extends AbstractMollieController
             $this->returnDefaultOrderSummaryBlock($cart, $errorData);
         }
 
-        $orderTotalWithFee = NumberUtility::plus($paymentFeeData->getPaymentFeeTaxIncl(), $cart->getOrderTotal());
+        $orderTotalWithTax = NumberUtility::plus($paymentFeeData->getPaymentFeeTaxIncl(), $cart->getOrderTotal());
 
-        $orderTotalNoTaxWithFee = NumberUtility::plus($paymentFeeData->getPaymentFeeTaxExcl(), $cart->getOrderTotal(false));
+        $orderTotalWithoutTax = NumberUtility::plus($paymentFeeData->getPaymentFeeTaxExcl(), $cart->getOrderTotal(false));
 
-        $orderTotalWithTax = $orderTotalWithFee;
-        $orderTotalWithoutTax = $orderTotalNoTaxWithFee;
-
-        $orderTotalTax = NumberUtility::minus($orderTotalWithFee, $orderTotalNoTaxWithFee);
+        $orderTotalTax = NumberUtility::minus($orderTotalWithTax, $orderTotalWithoutTax);
 
         $taxConfiguration = new TaxConfiguration();
         $presentedCart = $this->cart_presenter->present($cart);
@@ -155,7 +152,7 @@ class MollieAjaxModuleFrontController extends AbstractMollieController
                     $orderTotalTax,
                     $cartCurrency->iso_code
                 ),
-            ]
+            ],
         ];
 
         $this->returnDefaultOrderSummaryBlock($cart, [], $presentedCart);

--- a/controllers/front/ajax.php
+++ b/controllers/front/ajax.php
@@ -96,6 +96,8 @@ class MollieAjaxModuleFrontController extends AbstractMollieController
             ];
 
             $this->returnDefaultOrderSummaryBlock($cart, $errorData);
+
+            exit;
         }
 
         $orderTotalWithTax = NumberUtility::plus($paymentFeeData->getPaymentFeeTaxIncl(), $cart->getOrderTotal());

--- a/src/Controller/AbstractMollieController.php
+++ b/src/Controller/AbstractMollieController.php
@@ -16,7 +16,7 @@ use Mollie\Errors\Http\HttpStatusCode;
 
 class AbstractMollieController extends \ModuleFrontControllerCore
 {
-    protected function respond($status, $statusCode = HttpStatusCode::HTTP_OK, $message = '')
+    protected function respond($status, $statusCode = HttpStatusCode::HTTP_OK, $message = ''): void
     {
         http_response_code($statusCode);
 
@@ -26,6 +26,13 @@ class AbstractMollieController extends \ModuleFrontControllerCore
             $response['error'] = new Error($statusCode, $message);
         }
 
-        $this->ajaxDie(json_encode($response));
+        $this->ajaxRender(json_encode($response));
+    }
+
+    protected function ajaxRender($value = null, $controller = null, $method = null): void
+    {
+        parent::ajaxRender($value, $controller, $method);
+
+        exit;
     }
 }

--- a/src/Provider/PaymentOption/BancontactPaymentOptionProvider.php
+++ b/src/Provider/PaymentOption/BancontactPaymentOptionProvider.php
@@ -100,6 +100,7 @@ class BancontactPaymentOptionProvider implements PaymentOptionProviderInterface
     public function getPaymentOption(MolPaymentMethod $paymentMethod): PaymentOption
     {
         $paymentOption = new PaymentOption();
+
         $paymentOption->setCallToActionText(
             $paymentMethod->title ?:
                 $this->languageService->lang($paymentMethod->method_name)
@@ -112,6 +113,7 @@ class BancontactPaymentOptionProvider implements PaymentOptionProviderInterface
             true
         ));
         $paymentOption->setLogo($this->creditCardLogoProvider->getMethodOptionLogo($paymentMethod));
+
         $paymentFeeData = $this->paymentFeeProvider->getPaymentFee($paymentMethod, $this->orderTotalProvider->getOrderTotal());
 
         $this->context->getSmarty()->assign([
@@ -152,6 +154,11 @@ class BancontactPaymentOptionProvider implements PaymentOptionProviderInterface
                         'type' => 'hidden',
                         'name' => 'mollie-method-id',
                         'value' => PaymentMethod::BANCONTACT,
+                    ],
+                    [
+                        'type' => 'hidden',
+                        'name' => 'payment-method-id',
+                        'value' => $paymentMethod->id,
                     ],
                 ]
             );

--- a/src/Provider/PaymentOption/BasePaymentOptionProvider.php
+++ b/src/Provider/PaymentOption/BasePaymentOptionProvider.php
@@ -99,6 +99,7 @@ class BasePaymentOptionProvider implements PaymentOptionProviderInterface
     public function getPaymentOption(MolPaymentMethod $paymentMethod): PaymentOption
     {
         $paymentOption = new PaymentOption();
+
         $paymentOption->setCallToActionText(
             $paymentMethod->title ?:
                 $this->languageService->lang($paymentMethod->method_name)
@@ -111,6 +112,7 @@ class BasePaymentOptionProvider implements PaymentOptionProviderInterface
             true
         ));
         $paymentOption->setLogo($this->creditCardLogoProvider->getMethodOptionLogo($paymentMethod));
+
         $paymentFeeData = $this->paymentFeeProvider->getPaymentFee($paymentMethod, $this->orderTotalProvider->getOrderTotal());
 
         if ($paymentFeeData->isActive()) {
@@ -128,6 +130,11 @@ class BasePaymentOptionProvider implements PaymentOptionProviderInterface
                             $this->module->l('Payment Fee: %1s', self::FILE_NAME),
                             Tools::displayPrice($paymentFeeData->getPaymentFeeTaxIncl())
                         ),
+                    ],
+                    [
+                        'type' => 'hidden',
+                        'name' => 'payment-method-id',
+                        'value' => $paymentMethod->id,
                     ],
                 ]
             );

--- a/src/Provider/PaymentOption/CreditCardPaymentOptionProvider.php
+++ b/src/Provider/PaymentOption/CreditCardPaymentOptionProvider.php
@@ -203,6 +203,11 @@ class CreditCardPaymentOptionProvider implements PaymentOptionProviderInterface
                             Tools::displayPrice($paymentFeeData->getPaymentFeeTaxIncl())
                         ),
                     ],
+                    [
+                        'type' => 'hidden',
+                        'name' => 'payment-method-id',
+                        'value' => $paymentMethod->id,
+                    ],
                 ])
             );
         }

--- a/src/Provider/PaymentOption/CreditCardSingleClickPaymentOptionProvider.php
+++ b/src/Provider/PaymentOption/CreditCardSingleClickPaymentOptionProvider.php
@@ -121,6 +121,7 @@ class CreditCardSingleClickPaymentOptionProvider implements PaymentOptionProvide
     public function getPaymentOption(MolPaymentMethod $paymentMethod): PaymentOption
     {
         $paymentOption = new PaymentOption();
+
         $paymentOption->setCallToActionText(
             $paymentMethod->title ?:
                 $this->languageService->lang($paymentMethod->method_name)
@@ -198,6 +199,11 @@ class CreditCardSingleClickPaymentOptionProvider implements PaymentOptionProvide
                             $this->module->l('Payment Fee: %1s', self::FILE_NAME),
                             Tools::displayPrice($paymentFeeData->getPaymentFeeTaxIncl())
                         ),
+                    ],
+                    [
+                        'type' => 'hidden',
+                        'name' => 'payment-method-id',
+                        'value' => $paymentMethod->id,
                     ],
                 ])
             );

--- a/src/Provider/PaymentOption/IdealPaymentOptionProvider.php
+++ b/src/Provider/PaymentOption/IdealPaymentOptionProvider.php
@@ -115,6 +115,7 @@ class IdealPaymentOptionProvider implements PaymentOptionProviderInterface
     public function getPaymentOption(MolPaymentMethod $paymentMethod): PaymentOption
     {
         $paymentOption = new PaymentOption();
+
         $paymentOption->setCallToActionText(
             $paymentMethod->title ?:
             $this->languageService->lang($paymentMethod->method_name)
@@ -163,6 +164,11 @@ class IdealPaymentOptionProvider implements PaymentOptionProviderInterface
                             $this->module->l('Payment Fee: %1s', self::FILE_NAME),
                             Tools::displayPrice($paymentFeeData->getPaymentFeeTaxIncl())
                         ),
+                    ],
+                    [
+                        'type' => 'hidden',
+                        'name' => 'payment-method-id',
+                        'value' => $paymentMethod->id,
                     ],
                 ]
             );

--- a/src/ServiceProvider/BaseServiceProvider.php
+++ b/src/ServiceProvider/BaseServiceProvider.php
@@ -43,6 +43,8 @@ use Mollie\Repository\AddressRepository;
 use Mollie\Repository\AddressRepositoryInterface;
 use Mollie\Repository\CartRuleRepository;
 use Mollie\Repository\CartRuleRepositoryInterface;
+use Mollie\Repository\CurrencyRepository;
+use Mollie\Repository\CurrencyRepositoryInterface;
 use Mollie\Repository\GenderRepository;
 use Mollie\Repository\GenderRepositoryInterface;
 use Mollie\Repository\MolCustomerRepository;
@@ -161,6 +163,7 @@ final class BaseServiceProvider
         $this->addService($container, PendingOrderCartRuleRepositoryInterface::class, $container->get(PendingOrderCartRuleRepository::class));
         $this->addService($container, CartRuleRepositoryInterface::class, $container->get(CartRuleRepository::class));
         $this->addService($container, OrderRepositoryInterface::class, $container->get(OrderRepository::class));
+        $this->addService($container, CurrencyRepositoryInterface::class, $container->get(CurrencyRepository::class));
         $this->addService($container, CartRuleQuantityChangeHandlerInterface::class, $container->get(CartRuleQuantityChangeHandler::class));
 
         $this->addService($container, RecurringOrderRepositoryInterface::class, RecurringOrderRepository::class)

--- a/views/js/front/payment_fee.js
+++ b/views/js/front/payment_fee.js
@@ -33,24 +33,38 @@ $(document).ready(function () {
     }
 
     $('input[name="payment-option"]').on('change', function () {
-        var $nextDiv = $(this).closest('.payment-option').parent().next();
-        var paymentFee;
+        const $nextDiv = $(this).closest('.payment-option').parent().next();
+
+        let paymentMethodId = 0;
+        let $paymentMethodId;
+
         if ($nextDiv.hasClass('js-payment-option-form')) {
-            paymentFee = $nextDiv.find('input[name="payment-fee-price"]').val();
+          $paymentMethodId = $nextDiv.find('input[name="payment-method-id"]');
         } else {
-            paymentFee = $nextDiv.next().find('input[name="payment-fee-price"]').val();
+          $paymentMethodId = $nextDiv.next().find('input[name="payment-method-id"]');
+        }
+
+        if ($paymentMethodId.length > 0) {
+          paymentMethodId = $paymentMethodId.val();
         }
 
         $.ajax({
             url: ajaxUrl,
             method: 'GET',
             data: {
-                'paymentFee': paymentFee,
+                paymentMethodId: paymentMethodId,
                 ajax: 1,
                 action: 'getTotalCartPrice'
             },
             success: function (response) {
                 response = jQuery.parseJSON(response);
+
+                if (response.error) {
+                  console.error(response.message);
+
+                  return;
+                }
+
                 $('.card-block.cart-summary-totals').replaceWith(response.cart_summary_totals);
             }
         })


### PR DESCRIPTION
Improved ajax call to provide order summary block with updated tax price as well. Previously, only total price was updated.
Also improved overall functionality. Instead of relying on given payment fee from front-end, trying to fetch it fresh from the database.

Payment fee prices are shown with tax incl. Tax is 21%. So 12.10 is 10 without tax.

![image](https://github.com/mollie/PrestaShop/assets/61560082/6a12a2dd-3648-496b-9db1-764fb921250f)
![image](https://github.com/mollie/PrestaShop/assets/61560082/650bd680-a1c4-4179-aef7-422c970eb495)
