### PR TITLE
PIPRES-191: Misleading exception throw on shipment verification

### DIFF
--- a/controllers/front/payment.php
+++ b/controllers/front/payment.php
@@ -133,7 +133,7 @@ class MolliePaymentModuleFrontController extends ModuleFrontController
             } else {
                 /** @var ExceptionService $exceptionService */
                 $exceptionService = $this->module->getService(ExceptionService::class);
-                $message = $exceptionService->getErrorMessageForException($e, $exceptionService->getErrorMessages());
+                $message = $exceptionService->getErrorMessageForException($e);
             }
             $this->errors[] = $message;
 

--- a/src/Exception/ShipmentCannotBeSentException.php
+++ b/src/Exception/ShipmentCannotBeSentException.php
@@ -16,13 +16,9 @@ use Exception;
 
 class ShipmentCannotBeSentException extends Exception
 {
-    const NO_SHIPPING_INFORMATION = 1;
-
-    const AUTOMATIC_SHIPMENT_SENDER_IS_NOT_AVAILABLE = 2;
-
-    const ORDER_HAS_NO_PAYMENT_INFORMATION = 3;
-
-    const PAYMENT_IS_NOT_ORDER = 4;
+    public const NO_SHIPPING_INFORMATION = 1;
+    public const ORDER_HAS_NO_PAYMENT_INFORMATION = 2;
+    public const PAYMENT_IS_NOT_ORDER = 3;
 
     /**
      * @var string

--- a/src/Handler/Shipment/ShipmentSenderHandler.php
+++ b/src/Handler/Shipment/ShipmentSenderHandler.php
@@ -46,7 +46,6 @@ class ShipmentSenderHandler implements ShipmentSenderHandlerInterface
      */
     public function handleShipmentSender(?MollieApiClient $apiClient, Order $order, OrderState $orderState): void
     {
-        // TODO testing doesn't make sense as we can't even see if bool has changed anything
         if (!$this->canSendShipment->verify($order, $orderState)) {
             return;
         }

--- a/src/Handler/Shipment/ShipmentSenderHandlerInterface.php
+++ b/src/Handler/Shipment/ShipmentSenderHandlerInterface.php
@@ -12,16 +12,17 @@
 
 namespace Mollie\Handler\Shipment;
 
+use Mollie\Api\Exceptions\ApiException;
 use Mollie\Api\MollieApiClient;
+use Mollie\Exception\ShipmentCannotBeSentException;
 use Order;
 use OrderState;
 
 interface ShipmentSenderHandlerInterface
 {
     /**
-     * @param MollieApiClient $apiClient
-     * @param Order $order
-     * @param OrderState $orderState
+     * @throws ShipmentCannotBeSentException
+     * @throws ApiException
      */
-    public function handleShipmentSender(MollieApiClient $apiClient, Order $order, OrderState $orderState);
+    public function handleShipmentSender(?MollieApiClient $apiClient, Order $order, OrderState $orderState);
 }

--- a/src/Logger/PrestaLogger.php
+++ b/src/Logger/PrestaLogger.php
@@ -13,9 +13,8 @@
 namespace Mollie\Logger;
 
 use Mollie\Exception\NotImplementedException;
-use Psr\Log\LoggerInterface;
 
-class PrestaLogger implements LoggerInterface
+class PrestaLogger implements PrestaLoggerInterface
 {
     public function emergency($message, array $context = [])
     {

--- a/src/Logger/PrestaLoggerInterface.php
+++ b/src/Logger/PrestaLoggerInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Mollie\Logger;
+
+use Psr\Log\LoggerInterface;
+
+interface PrestaLoggerInterface extends LoggerInterface
+{
+}

--- a/src/Service/ExceptionService.php
+++ b/src/Service/ExceptionService.php
@@ -30,7 +30,7 @@ class ExceptionService
         $this->module = $module;
     }
 
-    public function getErrorMessages()
+    public function getErrorMessages(): array
     {
         return [
             OrderCreationException::class => [
@@ -42,15 +42,18 @@ class ExceptionService
             ],
             ShipmentCannotBeSentException::class => [
                 ShipmentCannotBeSentException::NO_SHIPPING_INFORMATION => $this->module->l('Shipment information cannot be sent. Order reference (%s) has no shipping information.', self::FILE_NAME),
-                ShipmentCannotBeSentException::AUTOMATIC_SHIPMENT_SENDER_IS_NOT_AVAILABLE => $this->module->l('Shipment information cannot be sent. Order reference (%s) does not have automatic shipment sender available.', self::FILE_NAME),
                 ShipmentCannotBeSentException::ORDER_HAS_NO_PAYMENT_INFORMATION => $this->module->l('Shipment information cannot be sent. Order reference (%s) has no payment information.', self::FILE_NAME),
                 ShipmentCannotBeSentException::PAYMENT_IS_NOT_ORDER => $this->module->l('Shipment information cannot be sent. Order reference (%s) is a regular payment.', self::FILE_NAME),
             ],
         ];
     }
 
-    public function getErrorMessageForException(Exception $exception, array $messages, array $params = [])
+    public function getErrorMessageForException(Exception $exception, array $messages = [], array $params = [])
     {
+        if (empty($messages)) {
+            $messages = $this->getErrorMessages();
+        }
+
         $exceptionType = get_class($exception);
         $exceptionCode = $exception->getCode();
 

--- a/src/Service/Shipment/ShipmentInformationSender.php
+++ b/src/Service/Shipment/ShipmentInformationSender.php
@@ -12,6 +12,7 @@
 
 namespace Mollie\Service\Shipment;
 
+use Mollie\Api\MollieApiClient;
 use Mollie\Api\Resources\Order as ApiOrder;
 use Mollie\Repository\PaymentMethodRepositoryInterface;
 use Mollie\Service\ShipmentServiceInterface;
@@ -40,12 +41,14 @@ class ShipmentInformationSender implements ShipmentInformationSenderInterface
     /**
      * {@inheritDoc}
      */
-    public function sendShipmentInformation($apiGateway, Order $order)
+    public function sendShipmentInformation(?MollieApiClient $apiGateway, Order $order): void
     {
         if (empty($apiGateway)) {
             return;
         }
+
         $payment = $this->paymentMethodRepository->getPaymentBy('order_id', (int) $order->id);
+
         $apiOrder = $apiGateway->orders->get($payment['transaction_id']);
 
         if (empty($apiOrder)) {
@@ -64,7 +67,7 @@ class ShipmentInformationSender implements ShipmentInformationSenderInterface
      *
      * @return bool
      */
-    private function hasShippableItems(ApiOrder $apiOrder)
+    private function hasShippableItems(ApiOrder $apiOrder): bool
     {
         $shippableItems = 0;
 

--- a/src/Service/Shipment/ShipmentInformationSenderInterface.php
+++ b/src/Service/Shipment/ShipmentInformationSenderInterface.php
@@ -12,14 +12,15 @@
 
 namespace Mollie\Service\Shipment;
 
+use Mollie\Api\Exceptions\ApiException;
 use Mollie\Api\MollieApiClient;
 use Order;
 
 interface ShipmentInformationSenderInterface
 {
     /**
-     * @param MollieApiClient|null $apiGateway
-     * @param Order $order
+     * @throws ApiException
+     * @throws \Exception
      */
-    public function sendShipmentInformation($apiGateway, Order $order);
+    public function sendShipmentInformation(?MollieApiClient $apiGateway, Order $order): void;
 }

--- a/src/Service/TransactionService.php
+++ b/src/Service/TransactionService.php
@@ -25,10 +25,12 @@ use Mollie\Api\Types\OrderStatus;
 use Mollie\Api\Types\RefundStatus;
 use Mollie\Config\Config;
 use Mollie\Errors\Http\HttpStatusCode;
+use Mollie\Exception\ShipmentCannotBeSentException;
 use Mollie\Exception\TransactionException;
 use Mollie\Handler\Order\OrderCreationHandler;
 use Mollie\Handler\Order\OrderFeeHandler;
 use Mollie\Handler\Shipment\ShipmentSenderHandlerInterface;
+use Mollie\Logger\PrestaLoggerInterface;
 use Mollie\Repository\PaymentMethodRepositoryInterface;
 use Mollie\Utility\MollieStatusUtility;
 use Mollie\Utility\NumberUtility;
@@ -73,6 +75,10 @@ class TransactionService
     private $orderFeeHandler;
     /** @var ShipmentSenderHandlerInterface */
     private $shipmentSenderHandler;
+    /** @var PrestaLoggerInterface */
+    private $logger;
+    /** @var ExceptionService */
+    private $exceptionService;
 
     public function __construct(
         Mollie $module,
@@ -82,7 +88,9 @@ class TransactionService
         PaymentMethodService $paymentMethodService,
         MollieOrderCreationService $mollieOrderCreationService,
         OrderFeeHandler $orderFeeHandler,
-        ShipmentSenderHandlerInterface $shipmentSenderHandler
+        ShipmentSenderHandlerInterface $shipmentSenderHandler,
+        PrestaLoggerInterface $logger,
+        ExceptionService $exceptionService
     ) {
         $this->module = $module;
         $this->orderStatusService = $orderStatusService;
@@ -92,6 +100,8 @@ class TransactionService
         $this->mollieOrderCreationService = $mollieOrderCreationService;
         $this->orderFeeHandler = $orderFeeHandler;
         $this->shipmentSenderHandler = $shipmentSenderHandler;
+        $this->logger = $logger;
+        $this->exceptionService = $exceptionService;
     }
 
     /**
@@ -211,13 +221,28 @@ class TransactionService
 
                 if (!$orderId && $isPaymentFinished) {
                     $orderId = $this->orderCreationHandler->createOrder($apiPayment, $cart->id, $isKlarnaOrder);
+
                     if (!$orderId) {
                         throw new TransactionException('Order is already created', HttpStatusCode::HTTP_METHOD_NOT_ALLOWED);
                     }
+
                     $apiPayment = $this->updateOrderDescription($apiPayment, $orderId);
+
                     $this->savePaymentStatus($apiPayment->id, $apiPayment->status, $orderId);
+
                     $order = new Order($orderId);
-                    $this->shipmentSenderHandler->handleShipmentSender($this->module->getApiClient(), $order, new \OrderState($order->current_state));
+
+                    try {
+                        $this->shipmentSenderHandler->handleShipmentSender($this->module->getApiClient(), $order, new \OrderState($order->current_state));
+                    }  catch (ShipmentCannotBeSentException $exception) {
+                        $this->logger->error($this->exceptionService->getErrorMessageForException(
+                            $exception,
+                            [],
+                            ['orderReference' => $order->reference]
+                        ));
+                    } catch (ApiException $exception) {
+                        $this->logger->error($exception->getMessage());
+                    }
                 } elseif ($apiPayment->amountRefunded) {
                     if (strpos($apiPayment->orderNumber, OrderNumberUtility::ORDER_NUMBER_PREFIX) === 0) {
                         if (!MollieStatusUtility::isPaymentFinished($apiPayment->status)) {

--- a/src/Service/TransactionService.php
+++ b/src/Service/TransactionService.php
@@ -234,7 +234,7 @@ class TransactionService
 
                     try {
                         $this->shipmentSenderHandler->handleShipmentSender($this->module->getApiClient(), $order, new \OrderState($order->current_state));
-                    }  catch (ShipmentCannotBeSentException $exception) {
+                    } catch (ShipmentCannotBeSentException $exception) {
                         $this->logger->error($this->exceptionService->getErrorMessageForException(
                             $exception,
                             [],

--- a/src/ServiceProvider/BaseServiceProvider.php
+++ b/src/ServiceProvider/BaseServiceProvider.php
@@ -21,6 +21,8 @@ use Mollie\Handler\Settings\PaymentMethodPositionHandlerInterface;
 use Mollie\Handler\Shipment\ShipmentSenderHandler;
 use Mollie\Handler\Shipment\ShipmentSenderHandlerInterface;
 use Mollie\Install\UninstallerInterface;
+use Mollie\Logger\PrestaLogger;
+use Mollie\Logger\PrestaLoggerInterface;
 use Mollie\Provider\CreditCardLogoProvider;
 use Mollie\Provider\CustomLogoProviderInterface;
 use Mollie\Provider\EnvironmentVersionProvider;
@@ -111,6 +113,8 @@ final class BaseServiceProvider
     {
         /* Logger */
         $this->addService($container, LoggerInterface::class, $container->get(Logger::class));
+        $this->addService($container, PrestaLoggerInterface::class, $container->get(PrestaLogger::class));
+
         /* Utility */
         $this->addService($container, ClockInterface::class, $container->get(Clock::class));
 
@@ -143,8 +147,6 @@ final class BaseServiceProvider
                 [
                     $container->get(ShipmentVerificationInterface::class),
                     $container->get(ShipmentInformationSenderInterface::class),
-                    $container->get(ExceptionService::class),
-                    $container->get(Logger::class),
                 ]
             );
 

--- a/src/ServiceProvider/BaseServiceProvider.php
+++ b/src/ServiceProvider/BaseServiceProvider.php
@@ -65,7 +65,6 @@ use Mollie\Repository\TaxRulesGroupRepositoryInterface;
 use Mollie\Service\ApiKeyService;
 use Mollie\Service\Content\SmartyTemplateParser;
 use Mollie\Service\Content\TemplateParserInterface;
-use Mollie\Service\ExceptionService;
 use Mollie\Service\PaymentMethod\PaymentMethodRestrictionValidation;
 use Mollie\Service\PaymentMethod\PaymentMethodRestrictionValidation\ApplePayPaymentMethodRestrictionValidator;
 use Mollie\Service\PaymentMethod\PaymentMethodRestrictionValidation\BasePaymentMethodRestrictionValidator;

--- a/src/Verification/IsPaymentInformationAvailable.php
+++ b/src/Verification/IsPaymentInformationAvailable.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Mollie\Verification;
+
+use Mollie\Repository\PaymentMethodRepositoryInterface;
+
+class IsPaymentInformationAvailable
+{
+    /** @var PaymentMethodRepositoryInterface */
+    private $paymentMethodRepository;
+
+    public function __construct(PaymentMethodRepositoryInterface $paymentMethodRepository)
+    {
+        $this->paymentMethodRepository = $paymentMethodRepository;
+    }
+
+    public function verify(int $orderId): bool
+    {
+        return $this->hasPaymentInformation($orderId);
+    }
+
+    private function hasPaymentInformation(int $orderId): bool
+    {
+        $payment = $this->paymentMethodRepository->getPaymentBy('order_id', (int) $orderId);
+
+        if (empty($payment)) {
+            return false;
+        }
+
+        if (empty($payment['transaction_id'])) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Verification/IsPaymentInformationAvailable.php
+++ b/src/Verification/IsPaymentInformationAvailable.php
@@ -23,14 +23,6 @@ class IsPaymentInformationAvailable
     {
         $payment = $this->paymentMethodRepository->getPaymentBy('order_id', (int) $orderId);
 
-        if (empty($payment)) {
-            return false;
-        }
-
-        if (empty($payment['transaction_id'])) {
-            return false;
-        }
-
-        return true;
+        return !(empty($payment) || empty($payment['transaction_id']));
     }
 }

--- a/src/Verification/Shipment/CanSendShipment.php
+++ b/src/Verification/Shipment/CanSendShipment.php
@@ -86,19 +86,11 @@ class CanSendShipment implements ShipmentVerificationInterface
         }
 
         if (!$this->isPaymentInformationAvailable->verify((int) $order->id)) {
-            throw new ShipmentCannotBeSentException(
-                'Shipment information cannot be sent. Missing payment information',
-                ShipmentCannotBeSentException::ORDER_HAS_NO_PAYMENT_INFORMATION,
-                $order->reference
-            );
+            throw new ShipmentCannotBeSentException('Shipment information cannot be sent. Missing payment information', ShipmentCannotBeSentException::ORDER_HAS_NO_PAYMENT_INFORMATION, $order->reference);
         }
 
         if (!$this->isRegularPayment((int) $order->id)) {
-            throw new ShipmentCannotBeSentException(
-                'Shipment information cannot be sent. Is regular payment',
-                ShipmentCannotBeSentException::PAYMENT_IS_NOT_ORDER,
-                $order->reference
-            );
+            throw new ShipmentCannotBeSentException('Shipment information cannot be sent. Is regular payment', ShipmentCannotBeSentException::PAYMENT_IS_NOT_ORDER, $order->reference);
         }
 
         return true;

--- a/src/Verification/Shipment/ShipmentVerificationInterface.php
+++ b/src/Verification/Shipment/ShipmentVerificationInterface.php
@@ -22,7 +22,7 @@ interface ShipmentVerificationInterface
      * @param Order $order
      * @param OrderState $orderState
      *
-     * @throws ShipmentCannotBeSentException
+     * @returns bool
      */
     public function verify(Order $order, OrderState $orderState);
 }

--- a/src/Verification/Shipment/ShipmentVerificationInterface.php
+++ b/src/Verification/Shipment/ShipmentVerificationInterface.php
@@ -23,6 +23,8 @@ interface ShipmentVerificationInterface
      * @param OrderState $orderState
      *
      * @returns bool
+     *
+     * @throws ShipmentCannotBeSentException
      */
     public function verify(Order $order, OrderState $orderState);
 }

--- a/tests/Unit/Handler/Shipment/ShipmentSenderHandlerTest.php
+++ b/tests/Unit/Handler/Shipment/ShipmentSenderHandlerTest.php
@@ -113,12 +113,15 @@ class ShipmentSenderHandlerTest extends TestCase
 
     public function testItSuccessfullyFailsToSendShipmentVerificationReturnedFalse(): void
     {
-        $this->order->reference = 'test';
-
         $this->canSendShipment
             ->expects($this->once())
             ->method('verify')
             ->willReturn(false)
+        ;
+
+        $this->shipmentInformationSender
+            ->expects($this->never())
+            ->method('sendShipmentInformation')
         ;
 
         $shipmentSenderHandler = new ShipmentSenderHandler(

--- a/tests/Unit/Handler/Shipment/ShipmentSenderHandlerTest.php
+++ b/tests/Unit/Handler/Shipment/ShipmentSenderHandlerTest.php
@@ -78,6 +78,11 @@ class ShipmentSenderHandlerTest extends TestCase
             ->willReturn(true)
         ;
 
+        $this->shipmentInformationSender
+            ->expects($this->once())
+            ->method('sendShipmentInformation')
+        ;
+
         $shipmentSenderHandler = new ShipmentSenderHandler(
             $this->canSendShipment,
             $this->shipmentInformationSender

--- a/tests/Unit/Handler/Shipment/ShipmentSenderHandlerTest.php
+++ b/tests/Unit/Handler/Shipment/ShipmentSenderHandlerTest.php
@@ -3,8 +3,6 @@
 use Mollie\Api\MollieApiClient;
 use Mollie\Exception\ShipmentCannotBeSentException;
 use Mollie\Handler\Shipment\ShipmentSenderHandler;
-use Mollie\Logger\PrestaLogger;
-use Mollie\Service\ExceptionService;
 use Mollie\Service\Shipment\ShipmentInformationSender;
 use Mollie\Verification\Shipment\CanSendShipment;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -36,16 +34,6 @@ class ShipmentSenderHandlerTest extends TestCase
      * @var ShipmentInformationSender|MockObject
      */
     private $shipmentInformationSender;
-
-    /**
-     * @var ExceptionService|MockObject
-     */
-    private $exceptionService;
-
-    /**
-     * @var PrestaLogger|MockObject
-     */
-    private $moduleLogger;
 
     protected function setUp()
     {
@@ -80,21 +68,9 @@ class ShipmentSenderHandlerTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock()
         ;
-
-        $this->exceptionService = $this
-            ->getMockBuilder(ExceptionService::class)
-            ->disableOriginalConstructor()
-            ->getMock()
-        ;
-
-        $this->moduleLogger = $this
-            ->getMockBuilder(PrestaLogger::class)
-            ->disableOriginalConstructor()
-            ->getMock()
-        ;
     }
 
-    public function testCanSendShipment()
+    public function testCanSendShipment(): void
     {
         $this->canSendShipment
             ->expects($this->once())
@@ -102,34 +78,15 @@ class ShipmentSenderHandlerTest extends TestCase
             ->willReturn(true)
         ;
 
-        $this->exceptionService
-            ->expects($this->never())
-            ->method('getErrorMessages')
-            ->willReturn([])
-        ;
-
-        $this->exceptionService
-            ->expects($this->never())
-            ->method('getErrorMessageForException')
-        ;
-
-        $this->moduleLogger
-            ->expects($this->never())
-            ->method('error')
-        ;
-
         $shipmentSenderHandler = new ShipmentSenderHandler(
             $this->canSendShipment,
-            $this->shipmentInformationSender,
-            $this->exceptionService,
-            $this->moduleLogger
+            $this->shipmentInformationSender
         );
-        $result = $shipmentSenderHandler->handleShipmentSender($this->apiClient, $this->order, $this->orderState);
 
-        $this->assertEquals(true, $result);
+        $shipmentSenderHandler->handleShipmentSender($this->apiClient, $this->order, $this->orderState);
     }
 
-    public function testOnVerificationExceptionLogExceptionAndNotSendInformation()
+    public function testItSuccessfullyFailsToSendShipmentExceptionThrown(): void
     {
         $this->order->reference = 'test';
 
@@ -137,36 +94,38 @@ class ShipmentSenderHandlerTest extends TestCase
             ->expects($this->once())
             ->method('verify')
             ->willThrowException(new ShipmentCannotBeSentException(
-                'Shipment information cannot be sent. No shipment information found by order reference',
-                ShipmentCannotBeSentException::NO_SHIPPING_INFORMATION,
+                '',
+                ShipmentCannotBeSentException::ORDER_HAS_NO_PAYMENT_INFORMATION,
                 $this->order->reference
             ))
         ;
 
-        $this->exceptionService
-            ->expects($this->once())
-            ->method('getErrorMessages')
-            ->willReturn([])
-        ;
+        $shipmentSenderHandler = new ShipmentSenderHandler(
+            $this->canSendShipment,
+            $this->shipmentInformationSender
+        );
 
-        $this->exceptionService
-            ->expects($this->once())
-            ->method('getErrorMessageForException')
-        ;
+        $this->expectException(ShipmentCannotBeSentException::class);
+        $this->expectExceptionCode(ShipmentCannotBeSentException::ORDER_HAS_NO_PAYMENT_INFORMATION);
 
-        $this->moduleLogger
+        $shipmentSenderHandler->handleShipmentSender($this->apiClient, $this->order, $this->orderState);
+    }
+
+    public function testItSuccessfullyFailsToSendShipmentVerificationReturnedFalse(): void
+    {
+        $this->order->reference = 'test';
+
+        $this->canSendShipment
             ->expects($this->once())
-            ->method('error')
+            ->method('verify')
+            ->willReturn(false)
         ;
 
         $shipmentSenderHandler = new ShipmentSenderHandler(
             $this->canSendShipment,
-            $this->shipmentInformationSender,
-            $this->exceptionService,
-            $this->moduleLogger
+            $this->shipmentInformationSender
         );
-        $result = $shipmentSenderHandler->handleShipmentSender($this->apiClient, $this->order, $this->orderState);
 
-        $this->assertEquals(false, $result);
+        $shipmentSenderHandler->handleShipmentSender($this->apiClient, $this->order, $this->orderState);
     }
 }


### PR DESCRIPTION
Use case:

When order is created and initial order state is given for order, updateOrderStatus hook is called. On this hook we try to send shipment. CanSendShipment checks if all requirements are met. But on initial order status update requirements won't be met as orderId is still not returned from validateOrder method, so it is not inserted inside database with mollie transaction. Merchants were annoyed with logged warnings and errors every time order was made from this exact verification. 

That's why we created additional verify service, which is used outside canSendShipment. We use this service to verify if payment information is available by trying to find it by order id.  