### PR TITLE
PIPRES-266: payment fee order tax append

### DIFF
--- a/controllers/front/payment.php
+++ b/controllers/front/payment.php
@@ -81,19 +81,17 @@ class MolliePaymentModuleFrontController extends ModuleFrontController
             Tools::redirectLink('index.php');
         }
 
-        /** @var PaymentMethodRepositoryInterface $paymentMethodRepo */
-        $paymentMethodRepo = $this->module->getService(PaymentMethodRepositoryInterface::class);
+        /** @var PaymentMethodRepositoryInterface $paymentMethodRepository */
+        $paymentMethodRepository = $this->module->getService(PaymentMethodRepositoryInterface::class);
         /** @var PaymentMethodService $transactionService */
         $transactionService = $this->module->getService(PaymentMethodService::class);
         /** @var MollieOrderCreationService $mollieOrderCreationService */
         $mollieOrderCreationService = $this->module->getService(MollieOrderCreationService::class);
-        /** @var PaymentMethodRepositoryInterface $paymentMethodRepository */
-        $paymentMethodRepository = $this->module->getService(PaymentMethodRepositoryInterface::class);
         /** @var SubscriptionOrderValidator $subscriptionOrderValidator */
         $subscriptionOrderValidator = $this->module->getService(SubscriptionOrderValidator::class);
 
         $environment = (int) Configuration::get(Mollie\Config\Config::MOLLIE_ENVIRONMENT);
-        $paymentMethodId = $paymentMethodRepo->getPaymentMethodIdByMethodId($method, $environment);
+        $paymentMethodId = $paymentMethodRepository->getPaymentMethodIdByMethodId($method, $environment);
         $paymentMethodObj = new MolPaymentMethod((int) $paymentMethodId);
 
         /* if its subscription order only payment API is allowed */
@@ -155,7 +153,7 @@ class MolliePaymentModuleFrontController extends ModuleFrontController
             if ($method === PaymentMethod::BANKTRANSFER) {
                 $orderId = Order::getOrderByCartId($cart->id);
                 $order = new Order($orderId);
-                $paymentMethodRepo->addOpenStatusPayment(
+                $paymentMethodRepository->addOpenStatusPayment(
                     $cart->id,
                     $apiPayment->method,
                     $apiPayment->id,

--- a/src/DTO/PaymentFeeData.php
+++ b/src/DTO/PaymentFeeData.php
@@ -8,16 +8,20 @@ class PaymentFeeData
     private $paymentFeeTaxIncl;
     /** @var float */
     private $paymentFeeTaxExcl;
+    /** @var float */
+    private $taxRate;
     /** @var bool */
     private $active;
 
     public function __construct(
         float $paymentFeeTaxIncl,
         float $paymentFeeTaxExcl,
+        float $taxRate,
         bool $active
     ) {
         $this->paymentFeeTaxIncl = $paymentFeeTaxIncl;
         $this->paymentFeeTaxExcl = $paymentFeeTaxExcl;
+        $this->taxRate = $taxRate;
         $this->active = $active;
     }
 
@@ -35,6 +39,14 @@ class PaymentFeeData
     public function getPaymentFeeTaxExcl(): float
     {
         return $this->paymentFeeTaxExcl;
+    }
+
+    /**
+     * @return float
+     */
+    public function getTaxRate(): float
+    {
+        return $this->taxRate;
     }
 
     /**

--- a/src/Handler/Order/OrderFeeHandler.php
+++ b/src/Handler/Order/OrderFeeHandler.php
@@ -38,8 +38,6 @@ namespace Mollie\Handler\Order;
 
 use Cart;
 use Configuration;
-use Mollie\Api\Resources\OrderLine;
-use Mollie\Config\Config;
 use Mollie\Provider\PaymentFeeProviderInterface;
 use Mollie\Service\OrderFeeService;
 use Mollie\Service\PaymentMethodService;

--- a/src/Provider/PaymentFeeProvider.php
+++ b/src/Provider/PaymentFeeProvider.php
@@ -141,7 +141,7 @@ class PaymentFeeProvider implements PaymentFeeProviderInterface
                 );
         }
 
-        return new PaymentFeeData(0.00, 0.00, false);
+        return new PaymentFeeData(0.00, 0.00, 0.00, false);
     }
 
     private function handleSurchargeMaxValue(

--- a/src/Service/CartLinesService.php
+++ b/src/Service/CartLinesService.php
@@ -74,6 +74,8 @@ class CartLinesService
         $psGiftWrapping,
         $selectedVoucherCategory
     ) {
+        // TODO refactor whole service, split order line append into separate services and test them individually at least!!!
+
         $apiRoundingPrecision = Config::API_ROUNDING_PRECISION;
         $vatRatePrecision = Config::VAT_RATE_ROUNDING_PRECISION;
 

--- a/src/Service/CartLinesService.php
+++ b/src/Service/CartLinesService.php
@@ -18,6 +18,7 @@ use Mollie\Adapter\ToolsAdapter;
 use Mollie\Config\Config;
 use Mollie\DTO\Line;
 use Mollie\DTO\Object\Amount;
+use Mollie\DTO\PaymentFeeData;
 use Mollie\Utility\CalculationUtility;
 use Mollie\Utility\CartPriceUtility;
 use Mollie\Utility\NumberUtility;
@@ -51,7 +52,7 @@ class CartLinesService
 
     /**
      * @param float $amount
-     * @param float $paymentFee
+     * @param PaymentFeeData $paymentFeeData
      * @param string $currencyIsoCode
      * @param array $cartSummary
      * @param float $shippingCost
@@ -65,7 +66,7 @@ class CartLinesService
      */
     public function getCartLines(
         $amount,
-        $paymentFee,
+        $paymentFeeData,
         $currencyIsoCode,
         $cartSummary,
         $shippingCost,
@@ -111,7 +112,7 @@ class CartLinesService
         $orderLines = $this->addWrappingLine($wrappingPrice, $cartSummary, $vatRatePrecision, $apiRoundingPrecision, $orderLines);
 
         // Add fee
-        $orderLines = $this->addPaymentFeeLine($paymentFee, $apiRoundingPrecision, $orderLines);
+        $orderLines = $this->addPaymentFeeLine($paymentFeeData, $apiRoundingPrecision, $orderLines);
 
         // Ungroup all the cart lines, just one level
         $newItems = $this->ungroupLines($orderLines);
@@ -419,27 +420,29 @@ class CartLinesService
     }
 
     /**
-     * @param float $paymentFee
+     * @param PaymentFeeData $paymentFeeData
      * @param int $apiRoundingPrecision
      * @param array $orderLines
      *
      * @return array
      */
-    private function addPaymentFeeLine($paymentFee, $apiRoundingPrecision, array $orderLines)
+    private function addPaymentFeeLine($paymentFeeData, $apiRoundingPrecision, array $orderLines)
     {
-        if ($paymentFee) {
-            $orderLines['surcharge'] = [
-                [
-                    'name' => $this->languageService->lang('Payment fee'),
-                    'sku' => Config::PAYMENT_FEE_SKU,
-                    'quantity' => 1,
-                    'unitPrice' => round($paymentFee, $apiRoundingPrecision),
-                    'totalAmount' => round($paymentFee, $apiRoundingPrecision),
-                    'vatAmount' => 0,
-                    'vatRate' => 0,
-                ],
-            ];
+        if (!$paymentFeeData->isActive()) {
+            return $orderLines;
         }
+
+        $orderLines['surcharge'] = [
+            [
+                'name' => $this->languageService->lang('Payment fee'),
+                'sku' => Config::PAYMENT_FEE_SKU,
+                'quantity' => 1,
+                'unitPrice' => round($paymentFeeData->getPaymentFeeTaxIncl(), $apiRoundingPrecision),
+                'totalAmount' => round($paymentFeeData->getPaymentFeeTaxIncl(), $apiRoundingPrecision),
+                'vatAmount' => NumberUtility::minus($paymentFeeData->getPaymentFeeTaxIncl(), $paymentFeeData->getPaymentFeeTaxExcl()),
+                'vatRate' => $paymentFeeData->getTaxRate(),
+            ],
+        ];
 
         return $orderLines;
     }

--- a/src/Service/OrderFeeService.php
+++ b/src/Service/OrderFeeService.php
@@ -47,6 +47,8 @@ class OrderFeeService
 
     public function createOrderFee($cartId, $orderFee): void
     {
+        // TODO do we really need this? Haven't see where this is used
+
         $orderFeeObj = new MolOrderFee();
 
         $orderFeeObj->id_cart = (int) $cartId;

--- a/src/Service/PaymentMethodService.php
+++ b/src/Service/PaymentMethodService.php
@@ -281,9 +281,9 @@ class PaymentMethodService
 
         $paymentFeeData = $this->paymentFeeProvider->getPaymentFee($molPaymentMethod, $totalAmount);
 
-        $paymentFee = $paymentFeeData->getPaymentFeeTaxIncl();
-
-        $totalAmount += $paymentFee;
+        if ($paymentFeeData->isActive()) {
+            $totalAmount += $paymentFeeData->getPaymentFeeTaxIncl();
+        }
 
         $currency = (string) ($currency ? Tools::strtoupper($currency) : 'EUR');
         $value = (float) TextFormatUtility::formatNumber($totalAmount, 2);
@@ -417,7 +417,7 @@ class PaymentMethodService
             $orderData->setLines(
                 $this->cartLinesService->getCartLines(
                     $amount,
-                    $paymentFee,
+                    $paymentFeeData,
                     $currency->iso_code,
                     $cart->getSummaryDetails(),
                     $cart->getTotalShippingCost(null, true),

--- a/tests/Unit/Provider/PaymentFeeProviderTest.php
+++ b/tests/Unit/Provider/PaymentFeeProviderTest.php
@@ -60,6 +60,7 @@ class PaymentFeeProviderTest extends TestCase
 
         $taxCalculator->method('addTaxes')->willReturn($taxCalculatorResults['addTaxResult']);
         $taxCalculator->method('removeTaxes')->willReturn($taxCalculatorResults['removeTaxResult']);
+        $taxCalculator->method('getTotalRate')->willReturn($taxCalculatorResults['taxRate']);
 
         $this->taxProvider->method('getTaxCalculator')->willReturn($taxCalculator);
 
@@ -76,6 +77,7 @@ class PaymentFeeProviderTest extends TestCase
 
         $this->assertEquals($result->getPaymentFeeTaxIncl(), $expectedResult['paymentFeeTaxIncl']);
         $this->assertEquals($result->getPaymentFeeTaxExcl(), $expectedResult['paymentFeeTaxExcl']);
+        $this->assertEquals($result->getTaxRate(), $expectedResult['taxRate']);
         $this->assertEquals($result->isActive(), $expectedResult['active']);
     }
 
@@ -91,11 +93,13 @@ class PaymentFeeProviderTest extends TestCase
                     'tax_rules_group_id' => 1,
                 ],
                 'taxCalculatorResults' => [
+                    'taxRate' => 10.00,
                     'addTaxResult' => 11.00,
                     'removeTaxResult' => 0.00,
                 ],
                 'totalCartPrice' => 10,
                 'expectedResult' => [
+                    'taxRate' => 10.00,
                     'paymentFeeTaxIncl' => 11.00,
                     'paymentFeeTaxExcl' => 10.00,
                     'active' => true,
@@ -110,11 +114,13 @@ class PaymentFeeProviderTest extends TestCase
                     'tax_rules_group_id' => 1,
                 ],
                 'taxCalculatorResults' => [
+                    'taxRate' => 10.00,
                     'addTaxResult' => 1.1,
                     'removeTaxResult' => 0.00,
                 ],
                 'totalCartPrice' => 10,
                 'expectedResult' => [
+                    'taxRate' => 10.00,
                     'paymentFeeTaxIncl' => 1.1,
                     'paymentFeeTaxExcl' => 1.0,
                     'active' => true,
@@ -129,11 +135,13 @@ class PaymentFeeProviderTest extends TestCase
                     'tax_rules_group_id' => 1,
                 ],
                 'taxCalculatorResults' => [
+                    'taxRate' => 10.00,
                     'addTaxResult' => 22.00,
                     'removeTaxResult' => 10.00,
                 ],
                 'totalCartPrice' => 200,
                 'expectedResult' => [
+                    'taxRate' => 10.00,
                     'paymentFeeTaxIncl' => 11.00,
                     'paymentFeeTaxExcl' => 10.00,
                     'active' => true,
@@ -148,11 +156,13 @@ class PaymentFeeProviderTest extends TestCase
                     'tax_rules_group_id' => 1,
                 ],
                 'taxCalculatorResults' => [
+                    'taxRate' => 10.00,
                     'addTaxResult' => 22.00,
                     'removeTaxResult' => 0.00,
                 ],
                 'totalCartPrice' => 100,
                 'expectedResult' => [
+                    'taxRate' => 10.00,
                     'paymentFeeTaxIncl' => 22.00,
                     'paymentFeeTaxExcl' => 20.00,
                     'active' => true,

--- a/tests/Unit/Provider/PaymentFeeProviderTest.php
+++ b/tests/Unit/Provider/PaymentFeeProviderTest.php
@@ -84,6 +84,27 @@ class PaymentFeeProviderTest extends TestCase
     public function paymentFeeDataProvider(): array
     {
         return [
+            'success with no surcharge found' => [
+                'paymentMethod' => [
+                    'surcharge' => 'not-found',
+                    'surcharge_percentage' => '0',
+                    'surcharge_limit' => '0',
+                    'surcharge_fixed_amount_tax_excl' => 0,
+                    'tax_rules_group_id' => 0,
+                ],
+                'taxCalculatorResults' => [
+                    'taxRate' => 0.00,
+                    'addTaxResult' => 0.00,
+                    'removeTaxResult' => 0.00,
+                ],
+                'totalCartPrice' => 0,
+                'expectedResult' => [
+                    'taxRate' => 0.00,
+                    'paymentFeeTaxIncl' => 0.00,
+                    'paymentFeeTaxExcl' => 0.00,
+                    'active' => false,
+                ],
+            ],
             'success with fixed price' => [
                 'paymentMethod' => [
                     'surcharge' => Config::FEE_FIXED_FEE,

--- a/tests/Unit/Service/CartLinesServiceTest.php
+++ b/tests/Unit/Service/CartLinesServiceTest.php
@@ -13,9 +13,11 @@
 namespace Service;
 
 use Mollie\Adapter\ConfigurationAdapter;
+use Mollie\Adapter\Context;
 use Mollie\Adapter\ToolsAdapter;
 use Mollie\DTO\Line;
 use Mollie\DTO\Object\Amount;
+use Mollie\DTO\PaymentFeeData;
 use Mollie\Service\CartLinesService;
 use Mollie\Service\LanguageService;
 use Mollie\Service\VoucherService;
@@ -54,27 +56,29 @@ class CartLinesServiceTest extends TestCase
         $mocks,
         $result
     ) {
-        /** @var MockObject $configurationAdapter */
         $configurationAdapter = $this->getMockBuilder(ConfigurationAdapter::class)->getMock();
+
         foreach ($mocks as $mock) {
             $configurationAdapter->expects(self::at($mock['at']))->method($mock['function'])->with($mock['expects'])->willReturn($mock['return']);
         }
 
-        /** @var MockObject $languageService */
         $languageService = $this->getMockBuilder(LanguageService::class)->disableOriginalConstructor()->getMock();
+
         foreach ($translationMocks as $mock) {
             $languageService->expects(self::at($mock['at']))->method($mock['function'])->with($mock['expects'])->willReturn($mock['return']);
         }
 
-        /** @var ToolsAdapter $toolsAdapter */
         $toolsAdapter = $this->getMockBuilder(ToolsAdapter::class)->getMock();
+
         foreach ($toolsMocks as $mock) {
             $toolsAdapter->method($mock['function'])->with($mock['expects'])->willReturn($mock['return']);
         }
 
-        $voucherService = new VoucherService($configurationAdapter);
+        $voucherService = $this->getMockBuilder(VoucherService::class)->disableOriginalConstructor()->getMock();
+        $context = $this->getMockBuilder(Context::class)->getMock();
 
-        $cartLineService = new CartLinesService($languageService, $voucherService, $toolsAdapter);
+        $cartLineService = new CartLinesService($languageService, $voucherService, $toolsAdapter, $context);
+
         $cartLines = $cartLineService->getCartLines(
             $amount,
             $paymentFee,
@@ -101,7 +105,7 @@ class CartLinesServiceTest extends TestCase
         return [
             'two products with a gift which is the same as one product' => [
                 'amount' => 204.84,
-                'paymentFee' => false,
+                'paymentFee' => new PaymentFeeData(0.00, 0.00, 0.00, false),
                 'currencyIsoCode' => $currencyIsoCode,
                 'cartSummary' => [
                     'gift_products' => [
@@ -134,6 +138,8 @@ class CartLinesServiceTest extends TestCase
                             'id_product_attribute' => '9',
                             'id_customization' => null,
                             'features' => [],
+                            'link_rewrite' => 'test-link',
+                            'id_image' => 'test-image-id',
                         ],
                     1 => [
                             'total_wt' => 100,
@@ -145,6 +151,8 @@ class CartLinesServiceTest extends TestCase
                             'id_product_attribute' => '9',
                             'id_customization' => null,
                             'features' => [],
+                            'link_rewrite' => 'test-link',
+                            'id_image' => 'test-image-id',
                         ],
                 ],
                 'psGiftWrapping' => '1',
@@ -211,7 +219,7 @@ class CartLinesServiceTest extends TestCase
             ],
             'one products with a gift' => [
                 'amount' => 104.84,
-                'paymentFee' => false,
+                'paymentFee' => new PaymentFeeData(0.00, 0.00, 0.00, false),
                 'currencyIsoCode' => $currencyIsoCode,
                 'cartSummary' => [
                     'gift_products' => [
@@ -244,6 +252,8 @@ class CartLinesServiceTest extends TestCase
                             'id_product_attribute' => '9',
                             'id_customization' => null,
                             'features' => [],
+                            'link_rewrite' => 'test-link',
+                            'id_image' => 'test-image-id',
                         ],
                     1 => [
                             'total_wt' => 100,
@@ -255,6 +265,8 @@ class CartLinesServiceTest extends TestCase
                             'id_product_attribute' => '9',
                             'id_customization' => null,
                             'features' => [],
+                            'link_rewrite' => 'test-link',
+                            'id_image' => 'test-image-id',
                         ],
                 ],
                 'psGiftWrapping' => '1',
@@ -311,7 +323,7 @@ class CartLinesServiceTest extends TestCase
             ],
             'product without name' => [
                 'amount' => 104.84,
-                'paymentFee' => false,
+                'paymentFee' => new PaymentFeeData(0.00, 0.00, 0.00, false),
                 'currencyIsoCode' => $currencyIsoCode,
                 'cartSummary' => [
                     'gift_products' => [
@@ -344,6 +356,8 @@ class CartLinesServiceTest extends TestCase
                             'id_product_attribute' => '9',
                             'id_customization' => null,
                             'features' => [],
+                            'link_rewrite' => 'test-link',
+                            'id_image' => 'test-image-id',
                         ],
                 ],
                 'psGiftWrapping' => '1',
@@ -390,7 +404,7 @@ class CartLinesServiceTest extends TestCase
             ],
             'Cart with discount' => [
                 'amount' => 98.79,
-                'paymentFee' => false,
+                'paymentFee' => new PaymentFeeData(0.00, 0.00, 0.00, false),
                 'currencyIsoCode' => $currencyIsoCode,
                 'cartSummary' => [
                     'gift_products' => [
@@ -419,6 +433,8 @@ class CartLinesServiceTest extends TestCase
                             'id_product_attribute' => '9',
                             'id_customization' => null,
                             'features' => [],
+                            'link_rewrite' => 'test-link',
+                            'id_image' => 'test-image-id',
                         ],
                 ],
                 'psGiftWrapping' => '1',

--- a/tests/Unit/Service/CartLinesServiceTest.php
+++ b/tests/Unit/Service/CartLinesServiceTest.php
@@ -21,7 +21,6 @@ use Mollie\DTO\PaymentFeeData;
 use Mollie\Service\CartLinesService;
 use Mollie\Service\LanguageService;
 use Mollie\Service\VoucherService;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class CartLinesServiceTest extends TestCase


### PR DESCRIPTION
Previously payment fee tax incl was appended to  order_total_tax_incl and order_total_tax_excl. Now added tax excl price separately.

Prices and taxes with no payment fee:
![image](https://github.com/mollie/PrestaShop/assets/61560082/62c4bfa4-888e-4a20-aeb4-dd56ed4da99a)

Prices with payment fee:
![image](https://github.com/mollie/PrestaShop/assets/61560082/29a452a4-d84e-4d84-a3e1-d4fe1d5e748d)

Order summary with tax appended:
![image](https://github.com/mollie/PrestaShop/assets/61560082/717b54be-c8a9-4a1b-b776-b3cf45f332d8)

Invoice with payment fee (product without tax and with tax sum is 35.61):
FYI: noticed in invoice that there is additional "payment fee" field, which is empty. I'll try to fix it in another PR as more investigation is needed.
![image](https://github.com/mollie/PrestaShop/assets/61560082/fc8a6f15-2922-4050-8ad0-15ae8db4f6cc)



