### PR TITLE
PIPRES-208: Payment fee append to subscription recurred order

### DIFF
--- a/controllers/front/subscriptionWebhook.php
+++ b/controllers/front/subscriptionWebhook.php
@@ -12,6 +12,7 @@
 
 use Mollie\Controller\AbstractMollieController;
 use Mollie\Errors\Http\HttpStatusCode;
+use Mollie\Handler\ErrorHandler\ErrorHandler;
 use Mollie\Subscription\Handler\RecurringOrderHandler;
 
 if (!defined('_PS_VERSION_')) {
@@ -57,8 +58,18 @@ class MollieSubscriptionWebhookModuleFrontController extends AbstractMollieContr
 
         /** @var RecurringOrderHandler $recurringOrderHandler */
         $recurringOrderHandler = $this->module->getService(RecurringOrderHandler::class);
-        $recurringOrderHandler->handle($transactionId);
 
-        return 'OK';
+        /** @var ErrorHandler $errorHandler */
+        $errorHandler = $this->module->getService(ErrorHandler::class);
+
+        try {
+            $recurringOrderHandler->handle($transactionId);
+        } catch (Throwable $exception) {
+            $errorHandler->handle($exception, null, false);
+
+            $this->respond('failed', HttpStatusCode::HTTP_BAD_REQUEST);
+        }
+
+        $this->respond('OK');
     }
 }

--- a/controllers/front/subscriptionWebhook.php
+++ b/controllers/front/subscriptionWebhook.php
@@ -64,7 +64,7 @@ class MollieSubscriptionWebhookModuleFrontController extends AbstractMollieContr
 
         try {
             $recurringOrderHandler->handle($transactionId);
-        } catch (Throwable $exception) {
+        } catch (Exception $exception) {
             $errorHandler->handle($exception, null, false);
 
             $this->respond('failed', HttpStatusCode::HTTP_BAD_REQUEST);

--- a/src/Exception/Code/ExceptionCode.php
+++ b/src/Exception/Code/ExceptionCode.php
@@ -7,6 +7,7 @@ class ExceptionCode
     // Infrastructure error codes starts from 1000
 
     public const INFRASTRUCTURE_FAILED_TO_INSTALL_ORDER_STATE = 1001;
+    public const INFRASTRUCTURE_UNKNOWN_ERROR = 1002;
 
     public const FAILED_TO_FIND_CUSTOMER_ADDRESS = 2001;
 
@@ -14,4 +15,8 @@ class ExceptionCode
 
     public const ORDER_FAILED_TO_UPDATE_ORDER_TOTALS = 3001;
     public const ORDER_FAILED_TO_INSERT_ORDER_PAYMENT_FEE = 3002;
+    public const ORDER_FAILED_TO_RETRIEVE_PAYMENT_METHOD = 3003;
+    public const ORDER_FAILED_TO_RETRIEVE_PAYMENT_FEE = 3004;
+    public const ORDER_FAILED_TO_CREATE_ORDER_PAYMENT_FEE = 3005;
+    public const ORDER_FAILED_TO_UPDATE_ORDER_TOTAL_WITH_PAYMENT_FEE = 3006;
 }

--- a/src/Exception/MollieException.php
+++ b/src/Exception/MollieException.php
@@ -22,7 +22,7 @@ class MollieException extends \Exception
 
     const API_CONNECTION_EXCEPTION = 2;
 
-    final public function __construct($message = "", $code = 0, Throwable $previous = null)
+    final public function __construct($message = '', $code = 0, Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/src/Exception/MollieException.php
+++ b/src/Exception/MollieException.php
@@ -12,7 +12,6 @@
 
 namespace Mollie\Exception;
 
-use Exception;
 use Mollie\Exception\Code\ExceptionCode;
 use Throwable;
 
@@ -27,7 +26,7 @@ class MollieException extends \Exception
         parent::__construct($message, $code, $previous);
     }
 
-    public static function unknownError(Exception $exception): self
+    public static function unknownError(Throwable $exception): self
     {
         return new static(
             'An unknown error error occurred. Please check system logs or contact Klarna payment support.',

--- a/src/Exception/MollieException.php
+++ b/src/Exception/MollieException.php
@@ -14,12 +14,18 @@ namespace Mollie\Exception;
 
 use Exception;
 use Mollie\Exception\Code\ExceptionCode;
+use Throwable;
 
 class MollieException extends \Exception
 {
     const CUSTOMER_EXCEPTION = 1;
 
     const API_CONNECTION_EXCEPTION = 2;
+
+    final public function __construct($message = "", $code = 0, Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
 
     public static function unknownError(Exception $exception): self
     {

--- a/src/Exception/MollieException.php
+++ b/src/Exception/MollieException.php
@@ -12,9 +12,21 @@
 
 namespace Mollie\Exception;
 
+use Exception;
+use Mollie\Exception\Code\ExceptionCode;
+
 class MollieException extends \Exception
 {
     const CUSTOMER_EXCEPTION = 1;
 
     const API_CONNECTION_EXCEPTION = 2;
+
+    public static function unknownError(Exception $exception): self
+    {
+        return new static(
+            'An unknown error error occurred. Please check system logs or contact Klarna payment support.',
+            ExceptionCode::INFRASTRUCTURE_UNKNOWN_ERROR,
+            $exception
+        );
+    }
 }

--- a/src/Handler/Exception/CouldNotHandleOrderPaymentFee.php
+++ b/src/Handler/Exception/CouldNotHandleOrderPaymentFee.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Mollie\Handler\Exception;
+
+use Exception;
+use Mollie\Exception\Code\ExceptionCode;
+use Mollie\Exception\MollieException;
+
+class CouldNotHandleOrderPaymentFee extends MollieException
+{
+    public static function failedToRetrievePaymentMethod(Exception $exception): CouldNotHandleOrderPaymentFee
+    {
+        return new self(
+            'Failed to retrieve payment method',
+            ExceptionCode::ORDER_FAILED_TO_RETRIEVE_PAYMENT_METHOD,
+            $exception
+        );
+    }
+
+    public static function failedToRetrievePaymentFee(Exception $exception): CouldNotHandleOrderPaymentFee
+    {
+        return new self(
+            'Failed to retrieve payment fee',
+            ExceptionCode::ORDER_FAILED_TO_RETRIEVE_PAYMENT_FEE,
+            $exception
+        );
+    }
+
+    public static function failedToCreateOrderPaymentFee(Exception $exception): CouldNotHandleOrderPaymentFee
+    {
+        return new self(
+            'Failed to create order payment fee',
+            ExceptionCode::ORDER_FAILED_TO_CREATE_ORDER_PAYMENT_FEE,
+            $exception
+        );
+    }
+
+    public static function failedToUpdateOrderTotalWithPaymentFee(Exception $exception): CouldNotHandleOrderPaymentFee
+    {
+        return new self(
+            'Failed to update order total with payment fee.',
+            ExceptionCode::ORDER_FAILED_TO_UPDATE_ORDER_TOTAL_WITH_PAYMENT_FEE,
+            $exception
+        );
+    }
+}

--- a/src/Handler/Exception/CouldNotHandleOrderPaymentFee.php
+++ b/src/Handler/Exception/CouldNotHandleOrderPaymentFee.php
@@ -2,13 +2,13 @@
 
 namespace Mollie\Handler\Exception;
 
-use Exception;
 use Mollie\Exception\Code\ExceptionCode;
 use Mollie\Exception\MollieException;
+use Throwable;
 
 class CouldNotHandleOrderPaymentFee extends MollieException
 {
-    public static function failedToRetrievePaymentMethod(Exception $exception): CouldNotHandleOrderPaymentFee
+    public static function failedToRetrievePaymentMethod(Throwable $exception): CouldNotHandleOrderPaymentFee
     {
         return new self(
             'Failed to retrieve payment method',
@@ -17,7 +17,7 @@ class CouldNotHandleOrderPaymentFee extends MollieException
         );
     }
 
-    public static function failedToRetrievePaymentFee(Exception $exception): CouldNotHandleOrderPaymentFee
+    public static function failedToRetrievePaymentFee(Throwable $exception): CouldNotHandleOrderPaymentFee
     {
         return new self(
             'Failed to retrieve payment fee',
@@ -26,7 +26,7 @@ class CouldNotHandleOrderPaymentFee extends MollieException
         );
     }
 
-    public static function failedToCreateOrderPaymentFee(Exception $exception): CouldNotHandleOrderPaymentFee
+    public static function failedToCreateOrderPaymentFee(Throwable $exception): CouldNotHandleOrderPaymentFee
     {
         return new self(
             'Failed to create order payment fee',
@@ -35,7 +35,7 @@ class CouldNotHandleOrderPaymentFee extends MollieException
         );
     }
 
-    public static function failedToUpdateOrderTotalWithPaymentFee(Exception $exception): CouldNotHandleOrderPaymentFee
+    public static function failedToUpdateOrderTotalWithPaymentFee(Throwable $exception): CouldNotHandleOrderPaymentFee
     {
         return new self(
             'Failed to update order total with payment fee.',

--- a/src/Handler/Order/OrderPaymentFeeHandler.php
+++ b/src/Handler/Order/OrderPaymentFeeHandler.php
@@ -37,83 +37,121 @@
 namespace Mollie\Handler\Order;
 
 use Cart;
-use Configuration;
+use Exception;
+use Mollie\Action\CreateOrderPaymentFeeAction;
+use Mollie\Action\UpdateOrderTotalsAction;
+use Mollie\Api\Resources\Order as MollieOrderAlias;
+use Mollie\Api\Resources\Payment as MolliePaymentAlias;
+use Mollie\DTO\CreateOrderPaymentFeeActionData;
+use Mollie\DTO\UpdateOrderTotalsData;
+use Mollie\Exception\CouldNotCreateOrderPaymentFee;
+use Mollie\Exception\CouldNotUpdateOrderTotals;
+use Mollie\Exception\FailedToProvidePaymentFeeException;
+use Mollie\Exception\OrderCreationException;
+use Mollie\Handler\Exception\CouldNotHandleOrderPaymentFee;
 use Mollie\Provider\PaymentFeeProviderInterface;
-use Mollie\Service\OrderPaymentFeeService;
+use Mollie\Repository\CartRepositoryInterface;
+use Mollie\Repository\OrderRepositoryInterface;
 use Mollie\Service\PaymentMethodService;
 use Order;
-use OrderDetail;
-use PrestaShop\Decimal\Number;
 
 class OrderPaymentFeeHandler
 {
-    /** @var OrderPaymentFeeService */
-    private $orderPaymentFeeService;
     /** @var PaymentMethodService */
     private $paymentMethodService;
     /** @var PaymentFeeProviderInterface */
     private $paymentFeeProvider;
+    /** @var CreateOrderPaymentFeeAction */
+    private $createOrderPaymentFeeAction;
+    /** @var UpdateOrderTotalsAction */
+    private $updateOrderTotalsAction;
+    /** @var OrderRepositoryInterface */
+    private $orderRepository;
+    /** @var CartRepositoryInterface */
+    private $cartRepository;
 
     public function __construct(
-        OrderPaymentFeeService $orderPaymentFeeService,
         PaymentMethodService $paymentMethodService,
-        PaymentFeeProviderInterface $paymentFeeProvider
+        PaymentFeeProviderInterface $paymentFeeProvider,
+        CreateOrderPaymentFeeAction $createOrderPaymentFeeAction,
+        UpdateOrderTotalsAction $updateOrderTotalsAction,
+        OrderRepositoryInterface $orderRepository,
+        CartRepositoryInterface $cartRepository
     ) {
-        $this->orderPaymentFeeService = $orderPaymentFeeService;
         $this->paymentMethodService = $paymentMethodService;
         $this->paymentFeeProvider = $paymentFeeProvider;
+        $this->createOrderPaymentFeeAction = $createOrderPaymentFeeAction;
+        $this->updateOrderTotalsAction = $updateOrderTotalsAction;
+        $this->orderRepository = $orderRepository;
+        $this->cartRepository = $cartRepository;
     }
 
-    public function addOrderPaymentFee(int $orderId, $apiPayment): int
+    /**
+     * @param MollieOrderAlias|MolliePaymentAlias $apiPayment
+     *
+     * @throws CouldNotHandleOrderPaymentFee
+     */
+    public function addOrderPaymentFee(int $orderId, $apiPayment): void
     {
-        // TODO use created payment fee services for DB actions, add exception throw
+        /** @var Order $order */
+        $order = $this->orderRepository->findOneBy([
+            'id_order' => $orderId,
+        ]);
 
-        $order = new Order($orderId);
-        $cart = new Cart($order->id_cart);
+        /** @var Cart $cart */
+        $cart = $this->cartRepository->findOneBy([
+            'id_cart' => $order->id_cart,
+        ]);
 
-        $originalAmountWithTax = $cart->getOrderTotal(
-            true,
-            Cart::BOTH
-        );
+        try {
+            $originalAmountWithTax = (float) $cart->getOrderTotal(
+                true,
+                Cart::BOTH
+            );
 
-        $originalAmountWithoutTax = $cart->getOrderTotal(
-            false,
-            Cart::BOTH
-        );
-
-        $paymentMethod = $this->paymentMethodService->getPaymentMethod($apiPayment);
-
-        $paymentFeeData = $this->paymentFeeProvider->getPaymentFee($paymentMethod, (float) $originalAmountWithTax);
-
-        $this->orderPaymentFeeService->createOrderPaymentFee($orderId, (int) $order->id_cart, $paymentFeeData);
-
-        $order = new Order($orderId);
-
-        $order->total_paid_tax_excl = (float) (new Number((string) $originalAmountWithoutTax))->plus((new Number((string) $paymentFeeData->getPaymentFeeTaxExcl())))->toPrecision(2);
-        $order->total_paid_tax_incl = (float) (new Number((string) $originalAmountWithTax))->plus((new Number((string) $paymentFeeData->getPaymentFeeTaxIncl())))->toPrecision(2);
-        $order->total_paid = (float) $apiPayment->amount->value;
-        $order->total_paid_real = (float) $apiPayment->amount->value;
-
-        $order->update();
-
-        return $orderId;
-    }
-
-    private function isOrderBackOrder($orderId)
-    {
-        $order = new Order($orderId);
-        $orderDetails = $order->getOrderDetailList();
-        /** @var OrderDetail $detail */
-        foreach ($orderDetails as $detail) {
-            $orderDetail = new OrderDetail($detail['id_order_detail']);
-            if (
-                Configuration::get('PS_STOCK_MANAGEMENT') &&
-                ($orderDetail->getStockState() || $orderDetail->product_quantity_in_stock < 0)
-            ) {
-                return true;
-            }
+            $originalAmountWithoutTax = (float) $cart->getOrderTotal(
+                false,
+                Cart::BOTH
+            );
+        } catch (Exception $exception) {
+            throw CouldNotHandleOrderPaymentFee::unknownError($exception);
         }
 
-        return false;
+        try {
+            $paymentMethod = $this->paymentMethodService->getPaymentMethod($apiPayment);
+        } catch (OrderCreationException $exception) {
+            throw CouldNotHandleOrderPaymentFee::failedToRetrievePaymentMethod($exception);
+        }
+
+        try {
+            $paymentFeeData = $this->paymentFeeProvider->getPaymentFee($paymentMethod, (float) $originalAmountWithTax);
+        } catch (FailedToProvidePaymentFeeException $exception) {
+            throw CouldNotHandleOrderPaymentFee::failedToRetrievePaymentFee($exception);
+        }
+
+        try {
+            $this->createOrderPaymentFeeAction->run(CreateOrderPaymentFeeActionData::create(
+                $orderId,
+                (int) $order->id_cart,
+                $paymentFeeData->getPaymentFeeTaxIncl(),
+                $paymentFeeData->getPaymentFeeTaxExcl()
+            ));
+        } catch (CouldNotCreateOrderPaymentFee $exception) {
+            throw CouldNotHandleOrderPaymentFee::failedToCreateOrderPaymentFee($exception);
+        }
+
+        try {
+            $this->updateOrderTotalsAction->run(UpdateOrderTotalsData::create(
+                $orderId,
+                $paymentFeeData->getPaymentFeeTaxIncl(),
+                $paymentFeeData->getPaymentFeeTaxExcl(),
+                // TODO abstraction for apiPayment
+                (float) $apiPayment->amount->value,
+                $originalAmountWithTax,
+                $originalAmountWithoutTax
+            ));
+        } catch (CouldNotUpdateOrderTotals $exception) {
+            throw CouldNotHandleOrderPaymentFee::failedToUpdateOrderTotalWithPaymentFee($exception);
+        }
     }
 }

--- a/src/Repository/CartRepository.php
+++ b/src/Repository/CartRepository.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Mollie\Repository;
+
+use Cart;
+
+class CartRepository extends AbstractRepository implements CartRepositoryInterface
+{
+    public function __construct()
+    {
+        parent::__construct(Cart::class);
+    }
+}

--- a/src/Repository/CartRepositoryInterface.php
+++ b/src/Repository/CartRepositoryInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Mollie\Repository;
+
+interface CartRepositoryInterface extends ReadOnlyRepositoryInterface
+{
+}

--- a/src/Service/OrderPaymentFeeService.php
+++ b/src/Service/OrderPaymentFeeService.php
@@ -17,9 +17,7 @@ use Mollie\Config\Config;
 use Mollie\DTO\PaymentFeeData;
 use Mollie\Provider\PaymentFeeProviderInterface;
 use Mollie\Repository\PaymentMethodRepositoryInterface;
-use MolOrderPaymentFee;
 use MolPaymentMethod;
-use PrestaShopException;
 use Shop;
 
 class OrderPaymentFeeService
@@ -43,28 +41,6 @@ class OrderPaymentFeeService
         $this->paymentMethodRepository = $paymentMethodRepository;
         $this->shop = $shop;
         $this->paymentFeeProvider = $paymentFeeProvider;
-    }
-
-    public function createOrderPaymentFee(int $orderId, int $cartId, PaymentFeeData $paymentFeeData): void
-    {
-        // TODO remove this method when separate actions for DB will be in use
-
-        $molOrderPaymentFee = new MolOrderPaymentFee();
-
-        $molOrderPaymentFee->id_cart = $cartId;
-        $molOrderPaymentFee->id_order = $orderId;
-        $molOrderPaymentFee->fee_tax_incl = $paymentFeeData->getPaymentFeeTaxIncl();
-        $molOrderPaymentFee->fee_tax_excl = $paymentFeeData->getPaymentFeeTaxExcl();
-
-        try {
-            $molOrderPaymentFee->add();
-        } catch (\Exception $e) {
-            $errorHandler = \Mollie\Handler\ErrorHandler\ErrorHandler::getInstance();
-            $errorHandler->handle($e, $e->getCode(), false);
-
-            // TODO use custom exceptions
-            throw new PrestaShopException('Can\'t save Order fee');
-        }
     }
 
     public function getPaymentFee(float $totalAmount, string $method): PaymentFeeData

--- a/src/ServiceProvider/BaseServiceProvider.php
+++ b/src/ServiceProvider/BaseServiceProvider.php
@@ -43,6 +43,8 @@ use Mollie\Provider\UpdateMessageProvider;
 use Mollie\Provider\UpdateMessageProviderInterface;
 use Mollie\Repository\AddressRepository;
 use Mollie\Repository\AddressRepositoryInterface;
+use Mollie\Repository\CartRepository;
+use Mollie\Repository\CartRepositoryInterface;
 use Mollie\Repository\CartRuleRepository;
 use Mollie\Repository\CartRuleRepositoryInterface;
 use Mollie\Repository\CurrencyRepository;
@@ -155,6 +157,7 @@ final class BaseServiceProvider
         $this->addService($container, TaxRulesGroupRepositoryInterface::class, $container->get(TaxRulesGroupRepository::class));
         $this->addService($container, TaxRuleRepositoryInterface::class, $container->get(TaxRuleRepository::class));
         $this->addService($container, TaxRepositoryInterface::class, $container->get(TaxRepository::class));
+        $this->addService($container, CartRepositoryInterface::class, $container->get(CartRepository::class));
 
         $this->addService($container, OrderTotalProviderInterface::class, $container->get(OrderTotalProvider::class));
         $this->addService($container, PaymentFeeProviderInterface::class, $container->get(PaymentFeeProvider::class));

--- a/subscription/Exception/CouldNotHandleRecurringOrder.php
+++ b/subscription/Exception/CouldNotHandleRecurringOrder.php
@@ -2,11 +2,11 @@
 
 namespace Mollie\Subscription\Exception;
 
-use Exception;
+use Throwable;
 
 class CouldNotHandleRecurringOrder extends MollieSubscriptionException
 {
-    public static function failedToCreateOrderPaymentFee(Exception $exception): CouldNotHandleRecurringOrder
+    public static function failedToCreateOrderPaymentFee(Throwable $exception): CouldNotHandleRecurringOrder
     {
         return new self(
             'Failed to create order payment fee',
@@ -15,7 +15,7 @@ class CouldNotHandleRecurringOrder extends MollieSubscriptionException
         );
     }
 
-    public static function failedToUpdateOrderTotalWithPaymentFee(Exception $exception): CouldNotHandleRecurringOrder
+    public static function failedToUpdateOrderTotalWithPaymentFee(Throwable $exception): CouldNotHandleRecurringOrder
     {
         return new self(
             'Failed to update order total with payment fee.',

--- a/subscription/Exception/CouldNotHandleRecurringOrder.php
+++ b/subscription/Exception/CouldNotHandleRecurringOrder.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Mollie\Subscription\Exception;
+
+use Exception;
+
+class CouldNotHandleRecurringOrder extends MollieSubscriptionException
+{
+    public static function failedToCreateOrderPaymentFee(Exception $exception): CouldNotHandleRecurringOrder
+    {
+        return new self(
+            'Failed to create order payment fee',
+            ExceptionCode::ORDER_FAILED_TO_CREATE_ORDER_PAYMENT_FEE,
+            $exception
+        );
+    }
+
+    public static function failedToUpdateOrderTotalWithPaymentFee(Exception $exception): CouldNotHandleRecurringOrder
+    {
+        return new self(
+            'Failed to update order total with payment fee.',
+            ExceptionCode::ORDER_FAILED_TO_UPDATE_ORDER_TOTAL_WITH_PAYMENT_FEE,
+            $exception
+        );
+    }
+}

--- a/subscription/Exception/ExceptionCode.php
+++ b/subscription/Exception/ExceptionCode.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Mollie\Subscription\Exception;
+
+class ExceptionCode
+{
+    //Order error codes starts from 1000
+
+    public const ORDER_FAILED_TO_CREATE_ORDER_PAYMENT_FEE = 1001;
+    public const ORDER_FAILED_TO_UPDATE_ORDER_TOTAL_WITH_PAYMENT_FEE = 1002;
+}

--- a/subscription/Handler/RecurringOrderHandler.php
+++ b/subscription/Handler/RecurringOrderHandler.php
@@ -149,7 +149,7 @@ class RecurringOrderHandler
     {
         $cart = new Cart($recurringOrder->id_cart);
 
-        /** @var $newCart array{success: bool, cart: Cart}|bool $newCart */
+        /** @var array{success: bool, cart: Cart}|bool $newCart */
         $newCart = $cart->duplicate();
 
         if (!$newCart || !$newCart['success']) {

--- a/subscription/Handler/RecurringOrderHandler.php
+++ b/subscription/Handler/RecurringOrderHandler.php
@@ -6,25 +6,34 @@ namespace Mollie\Subscription\Handler;
 
 use Cart;
 use Mollie;
+use Mollie\Action\CreateOrderPaymentFeeAction;
+use Mollie\Action\UpdateOrderTotalsAction;
 use Mollie\Adapter\Shop;
 use Mollie\Api\Resources\Payment;
 use Mollie\Api\Resources\Subscription as MollieSubscription;
 use Mollie\Api\Types\PaymentStatus;
 use Mollie\Api\Types\SubscriptionStatus;
 use Mollie\Config\Config;
+use Mollie\DTO\CreateOrderPaymentFeeActionData;
+use Mollie\DTO\UpdateOrderTotalsData;
 use Mollie\Errors\Http\HttpStatusCode;
+use Mollie\Exception\CouldNotCreateOrderPaymentFee;
+use Mollie\Exception\CouldNotUpdateOrderTotals;
+use Mollie\Exception\OrderCreationException;
 use Mollie\Exception\TransactionException;
+use Mollie\Repository\MolOrderPaymentFeeRepositoryInterface;
 use Mollie\Repository\PaymentMethodRepositoryInterface;
 use Mollie\Service\MailService;
 use Mollie\Service\MollieOrderCreationService;
 use Mollie\Service\OrderStatusService;
 use Mollie\Service\PaymentMethodService;
-use Mollie\Service\TransactionService;
 use Mollie\Subscription\Api\SubscriptionApi;
+use Mollie\Subscription\Exception\CouldNotHandleRecurringOrder;
 use Mollie\Subscription\Factory\GetSubscriptionDataFactory;
 use Mollie\Subscription\Repository\RecurringOrderRepositoryInterface;
 use Mollie\Subscription\Utility\ClockInterface;
 use Mollie\Utility\SecureKeyUtility;
+use MolOrderPaymentFee;
 use MolRecurringOrder;
 use MolRecurringOrdersProduct;
 use Order;
@@ -54,8 +63,12 @@ class RecurringOrderHandler
     private $shop;
     /** @var MailService */
     private $mailService;
-    /** @var TransactionService */
-    private $transactionService;
+    /** @var MolOrderPaymentFeeRepositoryInterface */
+    private $molOrderPaymentFeeRepository;
+    /** @var UpdateOrderTotalsAction */
+    private $updateOrderTotalsAction;
+    /** @var CreateOrderPaymentFeeAction */
+    private $createOrderPaymentFeeAction;
 
     public function __construct(
         SubscriptionApi $subscriptionApi,
@@ -68,7 +81,10 @@ class RecurringOrderHandler
         PaymentMethodService $paymentMethodService,
         ClockInterface $clock,
         Shop $shop,
-        MailService $mailService
+        MailService $mailService,
+        MolOrderPaymentFeeRepositoryInterface $molOrderPaymentFeeRepository,
+        UpdateOrderTotalsAction $updateOrderTotalsAction,
+        CreateOrderPaymentFeeAction $createOrderPaymentFeeAction
     ) {
         $this->subscriptionApi = $subscriptionApi;
         $this->subscriptionDataFactory = $subscriptionDataFactory;
@@ -81,6 +97,9 @@ class RecurringOrderHandler
         $this->clock = $clock;
         $this->shop = $shop;
         $this->mailService = $mailService;
+        $this->molOrderPaymentFeeRepository = $molOrderPaymentFeeRepository;
+        $this->updateOrderTotalsAction = $updateOrderTotalsAction;
+        $this->createOrderPaymentFeeAction = $createOrderPaymentFeeAction;
     }
 
     public function handle(string $transactionId): string
@@ -102,6 +121,7 @@ class RecurringOrderHandler
 
         $existingTransaction = $this->paymentMethodRepository->getPaymentBy('transaction_id', $transaction->id);
 
+        // TODO separate these actions into separate service. Test them as well.
         switch (true) {
             case $existingTransaction:
                 $this->updateOrderStatus($transaction, (int) $existingTransaction['order_id']);
@@ -119,13 +139,20 @@ class RecurringOrderHandler
         return 'OK';
     }
 
-    private function createSubscription(Payment $transaction, MolRecurringOrder $recurringOrder, MollieSubscription $subscription)
+    /**
+     * @throws CouldNotHandleRecurringOrder
+     * @throws OrderCreationException
+     * @throws \PrestaShopDatabaseException
+     * @throws \PrestaShopException
+     */
+    private function createSubscription(Payment $transaction, MolRecurringOrder $recurringOrder, MollieSubscription $subscription): void
     {
         $cart = new Cart($recurringOrder->id_cart);
 
+        /** @var $newCart array{success: bool, cart: Cart}|bool $newCart */
         $newCart = $cart->duplicate();
 
-        if (!$newCart['success']) {
+        if (!$newCart || !$newCart['success']) {
             return;
         }
 
@@ -161,17 +188,46 @@ class RecurringOrderHandler
             $newCart->secure_key
         );
 
-        $orderId = Order::getIdByCartId((int) $newCart->id);
+        $orderId = (int) Order::getIdByCartId((int) $newCart->id);
         $order = new Order($orderId);
 
         $specificPrice->delete();
 
-        // TODO add order fee append to order and new instance insert into database
-
         $this->mollieOrderCreationService->createMolliePayment($transaction, (int) $newCart->id, $order->reference, (int) $orderId, PaymentStatus::STATUS_PAID);
+
+        /** @var MolOrderPaymentFee|null $molOrderPaymentFee */
+        $molOrderPaymentFee = $this->molOrderPaymentFeeRepository->findOneBy([
+            'id_order' => $recurringOrder->id_order,
+        ]);
+
+        if ($molOrderPaymentFee) {
+            try {
+                $this->createOrderPaymentFeeAction->run(CreateOrderPaymentFeeActionData::create(
+                    $orderId,
+                    (int) $newCart->id,
+                    (float) $molOrderPaymentFee->fee_tax_incl,
+                    (float) $molOrderPaymentFee->fee_tax_excl
+                ));
+            } catch (CouldNotCreateOrderPaymentFee $exception) {
+                throw CouldNotHandleRecurringOrder::failedToCreateOrderPaymentFee($exception);
+            }
+
+            try {
+                $this->updateOrderTotalsAction->run(UpdateOrderTotalsData::create(
+                    $orderId,
+                    (float) $molOrderPaymentFee->fee_tax_incl,
+                    (float) $molOrderPaymentFee->fee_tax_excl,
+                    (float) $transaction->amount->value,
+                    (float) $cart->getOrderTotal(true, Cart::BOTH),
+                    (float) $cart->getOrderTotal(false, Cart::BOTH)
+                ));
+            } catch (CouldNotUpdateOrderTotals $exception) {
+                throw CouldNotHandleRecurringOrder::failedToUpdateOrderTotalWithPaymentFee($exception);
+            }
+        }
     }
 
-    private function updateOrderStatus(Payment $transaction, int $orderId)
+    private function updateOrderStatus(Payment $transaction, int $orderId): void
     {
         $this->orderStatusService->setOrderStatus($orderId, $transaction->status);
         $this->paymentMethodRepository->savePaymentStatus($transaction->id, $transaction->status, $orderId, $transaction->method);

--- a/tests/Unit/Handler/Order/OrderPaymentFeeHandlerTest.php
+++ b/tests/Unit/Handler/Order/OrderPaymentFeeHandlerTest.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Mollie\Tests\Unit\Handler\Order;
+
+use Cart;
+use Exception;
+use Mollie\Action\CreateOrderPaymentFeeAction;
+use Mollie\Action\UpdateOrderTotalsAction;
+use Mollie\Api\Resources\Payment;
+use Mollie\DTO\PaymentFeeData;
+use Mollie\Exception\Code\ExceptionCode;
+use Mollie\Exception\CouldNotCreateOrderPaymentFee;
+use Mollie\Exception\CouldNotUpdateOrderTotals;
+use Mollie\Exception\FailedToProvidePaymentFeeException;
+use Mollie\Exception\OrderCreationException;
+use Mollie\Handler\Exception\CouldNotHandleOrderPaymentFee;
+use Mollie\Handler\Order\OrderPaymentFeeHandler;
+use Mollie\Provider\PaymentFeeProviderInterface;
+use Mollie\Repository\CartRepositoryInterface;
+use Mollie\Repository\OrderRepositoryInterface;
+use Mollie\Service\PaymentMethodService;
+use MolPaymentMethod;
+use Order;
+use PHPUnit\Framework\TestCase;
+
+class OrderPaymentFeeHandlerTest extends TestCase
+{
+    /** @var PaymentMethodService */
+    private $paymentMethodService;
+    /** @var PaymentFeeProviderInterface */
+    private $paymentFeeProvider;
+    /** @var CreateOrderPaymentFeeAction */
+    private $createOrderPaymentFeeAction;
+    /** @var UpdateOrderTotalsAction */
+    private $updateOrderTotalsAction;
+    /** @var OrderRepositoryInterface */
+    private $orderRepository;
+    /** @var CartRepositoryInterface */
+    private $cartRepository;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->paymentMethodService = $this->createMock(PaymentMethodService::class);
+        $this->paymentFeeProvider = $this->createMock(PaymentFeeProviderInterface::class);
+        $this->createOrderPaymentFeeAction = $this->createMock(CreateOrderPaymentFeeAction::class);
+        $this->updateOrderTotalsAction = $this->createMock(UpdateOrderTotalsAction::class);
+        $this->orderRepository = $this->createMock(OrderRepositoryInterface::class);
+        $this->cartRepository = $this->createMock(CartRepositoryInterface::class);
+    }
+
+    public function testItSuccessfullyHandlesOrderPaymentFee(): void
+    {
+        $order = $this->createMock(Order::class);
+        $order->id_cart = 1;
+
+        $this->orderRepository->expects($this->once())->method('findOneBy')->willReturn($order);
+
+        $cart = $this->createMock(Cart::class);
+        $cart->expects($this->exactly(2))->method('getOrderTotal')->willReturn(12.1);
+
+        $this->cartRepository->expects($this->once())->method('findOneBy')->willReturn($cart);
+
+        $molPaymentMethod = $this->createMock(MolPaymentMethod::class);
+
+        $this->paymentMethodService->expects($this->once())->method('getPaymentMethod')->willReturn($molPaymentMethod);
+
+        $paymentFeeData = $this->createMock(PaymentFeeData::class);
+        $paymentFeeData->expects($this->exactly(2))->method('getPaymentFeeTaxIncl')->willReturn(12.1);
+        $paymentFeeData->expects($this->exactly(2))->method('getPaymentFeeTaxExcl')->willReturn(10);
+
+        $this->paymentFeeProvider->expects($this->once())->method('getPaymentFee')->willReturn($paymentFeeData);
+
+        $this->createOrderPaymentFeeAction->expects($this->once())->method('run');
+
+        $this->updateOrderTotalsAction->expects($this->once())->method('run');
+
+        $orderPaymentFeeHandler = new OrderPaymentFeeHandler(
+            $this->paymentMethodService,
+            $this->paymentFeeProvider,
+            $this->createOrderPaymentFeeAction,
+            $this->updateOrderTotalsAction,
+            $this->orderRepository,
+            $this->cartRepository
+        );
+
+        /** @var Payment $apiPayment */
+        $apiPayment = $this->createMock(Payment::class);
+
+        $apiPayment->amount = (object) [
+            'value' => 12.1,
+        ];
+
+        $orderPaymentFeeHandler->addOrderPaymentFee(1, $apiPayment);
+    }
+
+    public function testItUnsuccessfullyHandlesOrderPaymentFeeUnknownError(): void
+    {
+        $order = $this->createMock(Order::class);
+        $order->id_cart = 1;
+
+        $this->orderRepository->expects($this->once())->method('findOneBy')->willReturn($order);
+
+        $cart = $this->createMock(Cart::class);
+        $cart->expects($this->exactly(1))->method('getOrderTotal')->willThrowException(new Exception());
+
+        $this->cartRepository->expects($this->once())->method('findOneBy')->willReturn($cart);
+
+        $orderPaymentFeeHandler = new OrderPaymentFeeHandler(
+            $this->paymentMethodService,
+            $this->paymentFeeProvider,
+            $this->createOrderPaymentFeeAction,
+            $this->updateOrderTotalsAction,
+            $this->orderRepository,
+            $this->cartRepository
+        );
+
+        /** @var Payment $apiPayment */
+        $apiPayment = $this->createMock(Payment::class);
+
+        $this->expectException(CouldNotHandleOrderPaymentFee::class);
+        $this->expectExceptionCode(ExceptionCode::INFRASTRUCTURE_UNKNOWN_ERROR);
+
+        $orderPaymentFeeHandler->addOrderPaymentFee(1, $apiPayment);
+    }
+
+    public function testItUnsuccessfullyHandlesOrderPaymentFeeFailedToRetrievePaymentMethod(): void
+    {
+        $order = $this->createMock(Order::class);
+        $order->id_cart = 1;
+
+        $this->orderRepository->expects($this->once())->method('findOneBy')->willReturn($order);
+
+        $cart = $this->createMock(Cart::class);
+        $cart->expects($this->exactly(2))->method('getOrderTotal')->willReturn(12.1);
+
+        $this->cartRepository->expects($this->once())->method('findOneBy')->willReturn($cart);
+
+        $this->paymentMethodService->expects($this->once())->method('getPaymentMethod')->willThrowException(new OrderCreationException());
+
+        $orderPaymentFeeHandler = new OrderPaymentFeeHandler(
+            $this->paymentMethodService,
+            $this->paymentFeeProvider,
+            $this->createOrderPaymentFeeAction,
+            $this->updateOrderTotalsAction,
+            $this->orderRepository,
+            $this->cartRepository
+        );
+
+        /** @var Payment $apiPayment */
+        $apiPayment = $this->createMock(Payment::class);
+
+        $this->expectException(CouldNotHandleOrderPaymentFee::class);
+        $this->expectExceptionCode(ExceptionCode::ORDER_FAILED_TO_RETRIEVE_PAYMENT_METHOD);
+
+        $orderPaymentFeeHandler->addOrderPaymentFee(1, $apiPayment);
+    }
+
+    public function testItUnsuccessfullyHandlesOrderPaymentFeeFailedToRetrievePaymentFee(): void
+    {
+        $order = $this->createMock(Order::class);
+        $order->id_cart = 1;
+
+        $this->orderRepository->expects($this->once())->method('findOneBy')->willReturn($order);
+
+        $cart = $this->createMock(Cart::class);
+        $cart->expects($this->exactly(2))->method('getOrderTotal')->willReturn(12.1);
+
+        $this->cartRepository->expects($this->once())->method('findOneBy')->willReturn($cart);
+
+        $molPaymentMethod = $this->createMock(MolPaymentMethod::class);
+
+        $this->paymentMethodService->expects($this->once())->method('getPaymentMethod')->willReturn($molPaymentMethod);
+
+        $this->paymentFeeProvider->expects($this->once())->method('getPaymentFee')->willThrowException(new FailedToProvidePaymentFeeException());
+
+        $orderPaymentFeeHandler = new OrderPaymentFeeHandler(
+            $this->paymentMethodService,
+            $this->paymentFeeProvider,
+            $this->createOrderPaymentFeeAction,
+            $this->updateOrderTotalsAction,
+            $this->orderRepository,
+            $this->cartRepository
+        );
+
+        /** @var Payment $apiPayment */
+        $apiPayment = $this->createMock(Payment::class);
+
+        $this->expectException(CouldNotHandleOrderPaymentFee::class);
+        $this->expectExceptionCode(ExceptionCode::ORDER_FAILED_TO_RETRIEVE_PAYMENT_FEE);
+
+        $orderPaymentFeeHandler->addOrderPaymentFee(1, $apiPayment);
+    }
+
+    public function testItUnsuccessfullyHandlesOrderPaymentFeeFailedToCreateOrderPaymentFee(): void
+    {
+        $order = $this->createMock(Order::class);
+        $order->id_cart = 1;
+
+        $this->orderRepository->expects($this->once())->method('findOneBy')->willReturn($order);
+
+        $cart = $this->createMock(Cart::class);
+        $cart->expects($this->exactly(2))->method('getOrderTotal')->willReturn(12.1);
+
+        $this->cartRepository->expects($this->once())->method('findOneBy')->willReturn($cart);
+
+        $molPaymentMethod = $this->createMock(MolPaymentMethod::class);
+
+        $this->paymentMethodService->expects($this->once())->method('getPaymentMethod')->willReturn($molPaymentMethod);
+
+        $paymentFeeData = $this->createMock(PaymentFeeData::class);
+        $paymentFeeData->expects($this->exactly(1))->method('getPaymentFeeTaxIncl')->willReturn(12.1);
+        $paymentFeeData->expects($this->exactly(1))->method('getPaymentFeeTaxExcl')->willReturn(10);
+
+        $this->paymentFeeProvider->expects($this->once())->method('getPaymentFee')->willReturn($paymentFeeData);
+
+        $this->createOrderPaymentFeeAction->expects($this->once())->method('run')->willThrowException(new CouldNotCreateOrderPaymentFee());
+
+        $orderPaymentFeeHandler = new OrderPaymentFeeHandler(
+            $this->paymentMethodService,
+            $this->paymentFeeProvider,
+            $this->createOrderPaymentFeeAction,
+            $this->updateOrderTotalsAction,
+            $this->orderRepository,
+            $this->cartRepository
+        );
+
+        /** @var Payment $apiPayment */
+        $apiPayment = $this->createMock(Payment::class);
+
+        $this->expectException(CouldNotHandleOrderPaymentFee::class);
+        $this->expectExceptionCode(ExceptionCode::ORDER_FAILED_TO_CREATE_ORDER_PAYMENT_FEE);
+
+        $orderPaymentFeeHandler->addOrderPaymentFee(1, $apiPayment);
+    }
+
+    public function testItUnsuccessfullyHandlesOrderPaymentFeeFailedToUpdateOrderTotalWithPaymentFee(): void
+    {
+        $order = $this->createMock(Order::class);
+        $order->id_cart = 1;
+
+        $this->orderRepository->expects($this->once())->method('findOneBy')->willReturn($order);
+
+        $cart = $this->createMock(Cart::class);
+        $cart->expects($this->exactly(2))->method('getOrderTotal')->willReturn(12.1);
+
+        $this->cartRepository->expects($this->once())->method('findOneBy')->willReturn($cart);
+
+        $molPaymentMethod = $this->createMock(MolPaymentMethod::class);
+
+        $this->paymentMethodService->expects($this->once())->method('getPaymentMethod')->willReturn($molPaymentMethod);
+
+        $paymentFeeData = $this->createMock(PaymentFeeData::class);
+        $paymentFeeData->expects($this->exactly(2))->method('getPaymentFeeTaxIncl')->willReturn(12.1);
+        $paymentFeeData->expects($this->exactly(2))->method('getPaymentFeeTaxExcl')->willReturn(10);
+
+        $this->paymentFeeProvider->expects($this->once())->method('getPaymentFee')->willReturn($paymentFeeData);
+
+        $this->createOrderPaymentFeeAction->expects($this->once())->method('run');
+
+        $this->updateOrderTotalsAction->expects($this->once())->method('run')->willThrowException(new CouldNotUpdateOrderTotals());
+
+        $orderPaymentFeeHandler = new OrderPaymentFeeHandler(
+            $this->paymentMethodService,
+            $this->paymentFeeProvider,
+            $this->createOrderPaymentFeeAction,
+            $this->updateOrderTotalsAction,
+            $this->orderRepository,
+            $this->cartRepository
+        );
+
+        /** @var Payment $apiPayment */
+        $apiPayment = $this->createMock(Payment::class);
+
+        $apiPayment->amount = (object) [
+            'value' => 12.1,
+        ];
+
+        $this->expectException(CouldNotHandleOrderPaymentFee::class);
+        $this->expectExceptionCode(ExceptionCode::ORDER_FAILED_TO_UPDATE_ORDER_TOTAL_WITH_PAYMENT_FEE);
+
+        $orderPaymentFeeHandler->addOrderPaymentFee(1, $apiPayment);
+    }
+}


### PR DESCRIPTION
Fixed issue where payment fee was not appended to recurring orders at all. Logic: fetching payment fee from original order, appending payment fee to duplicated order totals, inserting new payment fee record for the new order.