### PR TITLE
PIPRES-303: Locale retrieve fix for email template

### DIFF
--- a/mollie.php
+++ b/mollie.php
@@ -723,17 +723,16 @@ class Mollie extends PaymentModule
                 'id_order' => (int) $order->id,
             ]);
 
-            $locale = $this->context->getCurrentLocale();
+            /**
+             * NOTE: Locale is set at init() method but in this case init() doesn't always get executed first.
+             */
+            /** @var Repository $localeRepo */
+            $localeRepo = $this->get('prestashop.core.localization.locale.repository');
 
-            if (!$locale) {
-                /** @var Repository $localeRepo */
-                $localeRepo = $this->get('prestashop.core.localization.locale.repository');
-
-                /**
-                 * NOTE: context language is set based on customer/employee context
-                 */
-                $locale = $localeRepo->getLocale($this->context->language->getLocale());
-            }
+            /**
+             * NOTE: context language is set based on customer/employee context
+             */
+            $locale = $localeRepo->getLocale($this->context->language->getLocale());
 
             if (!$molOrderPaymentFee) {
                 $orderFee = $locale->formatPrice(

--- a/mollie.php
+++ b/mollie.php
@@ -40,6 +40,7 @@ use Mollie\Subscription\Validator\CanProductBeAddedToCartValidator;
 use Mollie\Subscription\Verification\HasSubscriptionProductInCart;
 use Mollie\Utility\PsVersionUtility;
 use Mollie\Verification\IsPaymentInformationAvailable;
+use PrestaShop\PrestaShop\Core\Localization\Locale\Repository;
 use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -722,13 +723,25 @@ class Mollie extends PaymentModule
                 'id_order' => (int) $order->id,
             ]);
 
+            $locale = $this->context->getCurrentLocale();
+
+            if (!$locale) {
+                /** @var Repository $localeRepo */
+                $localeRepo = $this->get('prestashop.core.localization.locale.repository');
+
+                /**
+                 * NOTE: context language is set based on customer/employee context
+                 */
+                $locale = $localeRepo->getLocale($this->context->language->getLocale());
+            }
+
             if (!$molOrderPaymentFee) {
-                $orderFee = $this->context->getCurrentLocale()->formatPrice(
+                $orderFee = $locale->formatPrice(
                     0,
                     $orderCurrency->iso_code
                 );
             } else {
-                $orderFee = $this->context->getCurrentLocale()->formatPrice(
+                $orderFee = $locale->formatPrice(
                     $molOrderPaymentFee->fee_tax_incl,
                     $orderCurrency->iso_code
                 );

--- a/mollie.php
+++ b/mollie.php
@@ -724,7 +724,7 @@ class Mollie extends PaymentModule
             ]);
 
             /**
-             * NOTE: Locale is set at init() method but in this case init() doesn't always get executed first.
+             * NOTE: Locale in context is set at init() method but in this case init() doesn't always get executed first.
              */
             /** @var Repository $localeRepo */
             $localeRepo = $this->get('prestashop.core.localization.locale.repository');


### PR DESCRIPTION
Context doesn't always provide us with current locale so we need to retrieve it via Symfony's DI service. It would be a waste to create our locale repository to do this as quite some dependencies are needed there in repository.