### PR TITLE
PIPRES-221: Bank transfer order state change for payment API fix

### DIFF
--- a/src/Service/TransactionService.php
+++ b/src/Service/TransactionService.php
@@ -201,9 +201,10 @@ class TransactionService
                         $this->updatePaymentDescription($apiPayment, $orderId);
                     } elseif (strpos($apiPayment->description, OrderNumberUtility::ORDER_NUMBER_PREFIX) === 0) {
                         $this->handlePaymentDescription($apiPayment);
-                    } elseif ($apiPayment->amountRefunded->value > 0) {
+                    } elseif ($orderId) {
                         $this->orderStatusService->setOrderStatus($orderId, $apiPayment->status);
                     }
+
                     $orderId = Order::getOrderByCartId((int) $apiPayment->metadata->cart_id);
                 }
                 break;


### PR DESCRIPTION
Main issue is that for bank transfer order state is not changed when Payment API is used. 

Firstly, other payment options are handled in different way than bank transfer. Bank transfer's order is created before redirecting to Mollie while other methods force order creation only after webhook call, where order state is actually changed. After bank transfer actions webhook is called as well, but it doesn't use the same flow as other method (due to already created order).

Secondly, bank transfer with Order API works fine because there is no additional if statement to check something. After many nested if, elseif, else statements order state change is executed if order is not modified, is not Klarna order. 

After these results investigated previous commits where I found out that for some reason there is a check for refunded amount while order does not even have any refunds (there is if statement for this earlier in the code). By removing this check for refunded amount and adding check if orderId exists order state started to change. Didn't add check isPaymentFinished as order state could be "cancelled", "expired" or else.

Order API doesn't need any changes ATM as order is created before any actions are done.