### PR TITLE
PIPRES-311: Subscription orders table data fix

### DIFF
--- a/src/Adapter/ToolsAdapter.php
+++ b/src/Adapter/ToolsAdapter.php
@@ -33,6 +33,7 @@ class ToolsAdapter
 
     public function displayPrice($price, $currency): string
     {
+        // TODO replace all displayPrice calls with Locale::formatPrice()
         return Tools::displayPrice($price, $currency);
     }
 

--- a/subscription/Grid/SubscriptionGridDefinitionFactory.php
+++ b/subscription/Grid/SubscriptionGridDefinitionFactory.php
@@ -16,6 +16,7 @@ use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShopBundle\Form\Admin\Type\DateRangeType;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
+use Symfony\Component\Form\Extension\Core\Type\MoneyType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 class SubscriptionGridDefinitionFactory extends AbstractGridDefinitionFactory
@@ -219,7 +220,7 @@ class SubscriptionGridDefinitionFactory extends AbstractGridDefinitionFactory
                 ])
                 ->setAssociatedColumn('status')
             )
-            ->add((new Filter('unit_price', TextType::class))
+            ->add((new Filter('unit_price', MoneyType::class))
                 ->setTypeOptions([
                     'required' => false,
                     'attr' => [

--- a/subscription/Grid/SubscriptionGridQueryBuilder.php
+++ b/subscription/Grid/SubscriptionGridQueryBuilder.php
@@ -47,7 +47,7 @@ class SubscriptionGridQueryBuilder extends AbstractDoctrineQueryBuilder
         $qb = $this->getQueryBuilder($searchCriteria->getFilters())
             ->select('recurring_order.*')
             ->addSelect($this->getNameField() . ' as fullname')
-            ->addSelect('recurring_orders_product.quantity, recurring_orders_product.unit_price')
+            ->addSelect('ROUND(orders.total_paid, 2) as unit_price')
             ->addSelect('currency.iso_code')
         ;
 
@@ -106,7 +106,7 @@ class SubscriptionGridQueryBuilder extends AbstractDoctrineQueryBuilder
             'fullname' => $this->getNameField(),
             'description' => 'recurring_order.description',
             'status' => 'recurring_order.status',
-            'unit_price' => 'recurring_orders_product.unit_price',
+            'unit_price' => 'orders.total_paid',
             'iso_code' => 'currency.iso_code',
         ];
 

--- a/subscription/Presenter/RecurringOrdersPresenter.php
+++ b/subscription/Presenter/RecurringOrdersPresenter.php
@@ -5,13 +5,16 @@ declare(strict_types=1);
 namespace Mollie\Subscription\Logger;
 
 use Currency;
+use Mollie\Adapter\Context;
 use Mollie\Adapter\Language;
 use Mollie\Adapter\Link;
 use Mollie\Adapter\ToolsAdapter;
+use Mollie\Repository\OrderRepositoryInterface;
 use Mollie\Subscription\Repository\RecurringOrderRepositoryInterface;
 use Mollie\Subscription\Repository\RecurringOrdersProductRepositoryInterface;
+use Mollie\Utility\NumberUtility;
 use MolRecurringOrder;
-use PrestaShop\Decimal\Number;
+use Order;
 use Product;
 
 class RecurringOrdersPresenter
@@ -26,19 +29,27 @@ class RecurringOrdersPresenter
     private $language;
     /** @var ToolsAdapter */
     private $tools;
+    /** @var OrderRepositoryInterface */
+    private $orderRepository;
+    /** @var Context */
+    private $context;
 
     public function __construct(
         RecurringOrderRepositoryInterface $recurringOrderRepository,
         RecurringOrdersProductRepositoryInterface $recurringOrdersProductRepository,
         Link $link,
         Language $language,
-        ToolsAdapter $tools
+        ToolsAdapter $tools,
+        OrderRepositoryInterface $orderRepository,
+        Context $context
     ) {
         $this->recurringOrderRepository = $recurringOrderRepository;
         $this->link = $link;
         $this->recurringOrdersProductRepository = $recurringOrdersProductRepository;
         $this->language = $language;
         $this->tools = $tools;
+        $this->orderRepository = $orderRepository;
+        $this->context = $context;
     }
 
     public function present(string $molCustomerId): array
@@ -53,15 +64,22 @@ class RecurringOrdersPresenter
         $recurringOrdersPresentData = [];
         /** @var MolRecurringOrder $recurringOrder */
         foreach ($recurringOrders as $recurringOrder) {
-            $recurringProduct = $this->recurringOrdersProductRepository->findOneBy(['id_mol_recurring_orders_product' => $recurringOrder->id]);
+            /** @var Order $order */
+            $order = $this->orderRepository->findOneBy([
+                'id_order' => $recurringOrder->id_order,
+            ]);
+
+            $recurringProduct = $this->recurringOrdersProductRepository->findOneBy([
+                'id_mol_recurring_orders_product' => $recurringOrder->id,
+            ]);
+
             $product = new Product($recurringProduct->id_product, false, $this->language->getDefaultLanguageId());
-            $totalPrice = (new Number((string) $recurringProduct->unit_price))->times(new Number((string) $recurringProduct->quantity));
 
             $recurringOrderData = [];
             $recurringOrderData['recurring_order'] = $recurringOrder;
             $recurringOrderData['details_url'] = $this->link->getModuleLink('mollie', 'recurringOrderDetail', ['id_mol_recurring_order' => $recurringOrder->id]);
-            $recurringOrderData['product'] = $product;
-            $recurringOrderData['total_price'] = $this->tools->displayPrice($totalPrice->toPrecision(2), new Currency($recurringOrder->id_currency));
+            $recurringOrderData['product_name'] = is_array($product->name) ? $product->name[$this->context->getLanguageId()] : $product->name;
+            $recurringOrderData['total_price'] = $this->tools->displayPrice(NumberUtility::toPrecision((float) $order->total_paid, 2), new Currency($recurringOrder->id_currency));
             $recurringOrderData['currency'] = new \Currency($recurringOrder->id_currency);
             $recurringOrdersPresentData[] = $recurringOrderData;
         }

--- a/tests/phpstan/phpstan_base.neon
+++ b/tests/phpstan/phpstan_base.neon
@@ -41,5 +41,6 @@ parameters:
     - '#Call to method [a-zA-Z0-9_]+\(\) on an unknown class AttributeCore.#'
     - '#Parameter \#1 \$value of method ControllerCore\:\:ajaxRender\(\) expects null, string\|false given.#'
     - '#Call to function is_subclass_of\(\) with.*will always evaluate to false.#'
+    - '#Call to function is_array\(\) with.*will always evaluate to false.#'
 
   level: 5

--- a/views/templates/front/subscription/customerSubscriptionsData.tpl
+++ b/views/templates/front/subscription/customerSubscriptionsData.tpl
@@ -45,7 +45,7 @@
                     <th scope="row">{$recurringOrder.recurring_order->id}</th>
                     <td>{$recurringOrder.recurring_order->status}</td>
                     <td>{$recurringOrder.recurring_order->payment_method}</td>
-                    <td>{$recurringOrder.product->name}</td>
+                    <td>{$recurringOrder.product_name}</td>
                     <td>{$recurringOrder.total_price}</td>
                     <td>{$recurringOrder.recurring_order->date_add}</td>
                     <td class="text-sm-center order-actions">


### PR DESCRIPTION
Fixed price display issue. Prices were fetched by calculating product base price instead of full order price.

![image](https://github.com/mollie/PrestaShop/assets/61560082/99c6d13c-7ff3-49aa-8ffd-81d1e351c533)
![image](https://github.com/mollie/PrestaShop/assets/61560082/f00a05b0-a7a8-4bb0-8103-b4619066dc4b)

![image](https://github.com/mollie/PrestaShop/assets/61560082/25522da3-a665-41be-a43a-5bc8aea2d89e)
![image](https://github.com/mollie/PrestaShop/assets/61560082/39b5062b-74ad-4da7-aa1d-f9deb1260603)
