### PR TITLE
PIPRES-113: Billie payment method validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "ext-json": "*",
         "ext-simplexml": "*",
         "prestashop/decimal": "^1.3",
-        "mollie/mollie-api-php": "v2.42.1",
+        "mollie/mollie-api-php": "v2.61.0",
         "segmentio/analytics-php": "^1.5",
         "sentry/sentry": "3.17.0",
         "league/container": "2.5.0",

--- a/src/Repository/CustomerRepository.php
+++ b/src/Repository/CustomerRepository.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Mollie\Repository;
+
+class CustomerRepository extends AbstractRepository implements CustomerRepositoryInterface
+{
+    public function __construct()
+    {
+        parent::__construct(\Customer::class);
+    }
+}

--- a/src/Repository/CustomerRepositoryInterface.php
+++ b/src/Repository/CustomerRepositoryInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Mollie\Repository;
+
+interface CustomerRepositoryInterface extends ReadOnlyRepositoryInterface
+{
+}

--- a/src/Service/PaymentMethod/PaymentMethodRestrictionValidation/ApplePayPaymentMethodRestrictionValidator.php
+++ b/src/Service/PaymentMethod/PaymentMethodRestrictionValidation/ApplePayPaymentMethodRestrictionValidator.php
@@ -37,7 +37,7 @@
 namespace Mollie\Service\PaymentMethod\PaymentMethodRestrictionValidation;
 
 use Mollie\Adapter\ConfigurationAdapter;
-use Mollie\Config\Config;
+use Mollie\Api\Types\PaymentMethod;
 use MolPaymentMethod;
 
 class ApplePayPaymentMethodRestrictionValidator implements PaymentMethodRestrictionValidatorInterface
@@ -73,7 +73,7 @@ class ApplePayPaymentMethodRestrictionValidator implements PaymentMethodRestrict
      */
     public function supports(MolPaymentMethod $paymentMethod): bool
     {
-        return $paymentMethod->getPaymentMethodName() === Config::MOLLIE_METHOD_ID_APPLE_PAY;
+        return $paymentMethod->getPaymentMethodName() === PaymentMethod::APPLEPAY;
     }
 
     /**

--- a/src/Service/PaymentMethod/PaymentMethodRestrictionValidation/B2bPaymentMethodRestrictionValidator.php
+++ b/src/Service/PaymentMethod/PaymentMethodRestrictionValidation/B2bPaymentMethodRestrictionValidator.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Mollie\Service\PaymentMethod\PaymentMethodRestrictionValidation;
+
+use Mollie\Adapter\ConfigurationAdapter;
+use Mollie\Adapter\Context;
+use Mollie\Api\Types\PaymentMethod;
+use Mollie\Repository\AddressRepositoryInterface;
+use Mollie\Repository\CustomerRepositoryInterface;
+use MolPaymentMethod;
+
+class B2bPaymentMethodRestrictionValidator implements PaymentMethodRestrictionValidatorInterface
+{
+    /** @var Context */
+    private $context;
+    /** @var AddressRepositoryInterface */
+    private $addressRepository;
+    /** @var CustomerRepositoryInterface */
+    private $customerRepository;
+    /** @var ConfigurationAdapter */
+    private $configuration;
+
+    public function __construct(
+        Context $context,
+        AddressRepositoryInterface $addressRepository,
+        CustomerRepositoryInterface $customerRepository,
+        ConfigurationAdapter $configuration
+    ) {
+        $this->context = $context;
+        $this->addressRepository = $addressRepository;
+        $this->customerRepository = $customerRepository;
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isValid(MolPaymentMethod $paymentMethod): bool
+    {
+        if (!$this->isB2bEnabled()) {
+            return false;
+        }
+
+        if (!$this->isIdentificationNumberValid()) {
+            return false;
+        }
+
+        if (!$this->isVatNumberValid()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function supports(MolPaymentMethod $paymentMethod): bool
+    {
+        return $paymentMethod->getPaymentMethodName() === PaymentMethod::BILLIE;
+    }
+
+    private function isIdentificationNumberValid(): bool
+    {
+        $customerId = $this->context->getCustomerId();
+
+        /** @var \Customer $customer */
+        $customer = $this->customerRepository->findOneBy([
+            'id_customer' => $customerId,
+        ]);
+
+        return !empty($customer->siret);
+    }
+
+    private function isVatNumberValid(): bool
+    {
+        $billingAddressId = $this->context->getInvoiceAddressId();
+
+        /** @var \Address $billingAddress */
+        $billingAddress = $this->addressRepository->findOneBy([
+            'id_address' => (int) $billingAddressId,
+        ]);
+
+        return !empty($billingAddress->vat_number);
+    }
+
+    private function isB2bEnabled(): bool
+    {
+        return (bool) (int) $this->configuration->get('PS_B2B_ENABLE');
+    }
+}

--- a/src/Service/PaymentMethod/PaymentMethodRestrictionValidation/B2bPaymentMethodRestrictionValidator.php
+++ b/src/Service/PaymentMethod/PaymentMethodRestrictionValidation/B2bPaymentMethodRestrictionValidator.php
@@ -74,7 +74,7 @@ class B2bPaymentMethodRestrictionValidator implements PaymentMethodRestrictionVa
 
     private function isVatNumberValid(): bool
     {
-        $billingAddressId = $this->context->getInvoiceAddressId();
+        $billingAddressId = $this->context->getAddressInvoiceId();
 
         /** @var \Address $billingAddress */
         $billingAddress = $this->addressRepository->findOneBy([

--- a/src/ServiceProvider/BaseServiceProvider.php
+++ b/src/ServiceProvider/BaseServiceProvider.php
@@ -49,6 +49,8 @@ use Mollie\Repository\CartRuleRepository;
 use Mollie\Repository\CartRuleRepositoryInterface;
 use Mollie\Repository\CurrencyRepository;
 use Mollie\Repository\CurrencyRepositoryInterface;
+use Mollie\Repository\CustomerRepository;
+use Mollie\Repository\CustomerRepositoryInterface;
 use Mollie\Repository\GenderRepository;
 use Mollie\Repository\GenderRepositoryInterface;
 use Mollie\Repository\MolCustomerRepository;
@@ -72,6 +74,7 @@ use Mollie\Service\Content\TemplateParserInterface;
 use Mollie\Service\PaymentMethod\PaymentMethodRestrictionValidation;
 use Mollie\Service\PaymentMethod\PaymentMethodRestrictionValidation\AmountPaymentMethodRestrictionValidator;
 use Mollie\Service\PaymentMethod\PaymentMethodRestrictionValidation\ApplePayPaymentMethodRestrictionValidator;
+use Mollie\Service\PaymentMethod\PaymentMethodRestrictionValidation\B2bPaymentMethodRestrictionValidator;
 use Mollie\Service\PaymentMethod\PaymentMethodRestrictionValidation\BasePaymentMethodRestrictionValidator;
 use Mollie\Service\PaymentMethod\PaymentMethodRestrictionValidation\EnvironmentVersionSpecificPaymentMethodRestrictionValidator;
 use Mollie\Service\PaymentMethod\PaymentMethodRestrictionValidation\VoucherPaymentMethodRestrictionValidator;
@@ -171,6 +174,7 @@ final class BaseServiceProvider
         $this->addService($container, CartRuleRepositoryInterface::class, $container->get(CartRuleRepository::class));
         $this->addService($container, OrderRepositoryInterface::class, $container->get(OrderRepository::class));
         $this->addService($container, CurrencyRepositoryInterface::class, $container->get(CurrencyRepository::class));
+        $this->addService($container, CustomerRepositoryInterface::class, $container->get(CustomerRepository::class));
         $this->addService($container, MolOrderPaymentFeeRepositoryInterface::class, $container->get(MolOrderPaymentFeeRepository::class));
         $this->addService($container, CartRuleQuantityChangeHandlerInterface::class, $container->get(CartRuleQuantityChangeHandler::class));
 
@@ -192,6 +196,7 @@ final class BaseServiceProvider
                 $container->get(EnvironmentVersionSpecificPaymentMethodRestrictionValidator::class),
                 $container->get(ApplePayPaymentMethodRestrictionValidator::class),
                 $container->get(AmountPaymentMethodRestrictionValidator::class),
+                $container->get(B2bPaymentMethodRestrictionValidator::class),
             ]);
 
         $this->addService($container, CustomLogoProviderInterface::class, $container->get(CreditCardLogoProvider::class));

--- a/tests/Integration/Factory/AddressFactory.php
+++ b/tests/Integration/Factory/AddressFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Mollie\Tests\Integration\Factory;
+
+class AddressFactory implements FactoryInterface
+{
+    public static function create(array $data = []): \Address
+    {
+        $address = new \Address(null, (int) \Configuration::get('PS_LANG_DEFAULT'));
+
+        $address->firstname = $data['first_name'] ?? 'test-first-name';
+        $address->lastname = $data['last_name'] ?? 'test-last-name';
+        $address->country = $data['country'] ?? 'test-country';
+        $address->id_country = $data['id_country'] ?? \Configuration::get('PS_COUNTRY_DEFAULT');
+        $address->city = $data['city'] ?? 'test-city';
+        $address->postcode = $data['postcode'] ?? '97222'; //max 12 chars
+        $address->address1 = $data['address1'] ?? 'test-address1';
+        $address->address2 = $data['address2'] ?? 'test-address2';
+        $address->phone_mobile = $data['phone_mobile'] ?? '5555555'; //letters or symbols cause errors
+        $address->alias = $data['alias'] ?? 'test-alias';
+        $address->vat_number = $data['vat_number'] ?? 'test-vat';
+        $address->company = $data['company'] ?? 'test-company';
+
+        $address->save();
+
+        return $address;
+    }
+}

--- a/tests/Integration/Factory/CarrierFactory.php
+++ b/tests/Integration/Factory/CarrierFactory.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Mollie\Tests\Integration\Factory;
+
+class CarrierFactory implements FactoryInterface
+{
+    public static function create(array $data = [])
+    {
+        $carrier = new \Carrier(null, (int) \Configuration::get('PS_LANG_DEFAULT'));
+
+        $carrier->name = $data['name'] ?? 'test-name';
+        $carrier->active = $data['active'] ?? true;
+        $carrier->delay = $data['delay'] ?? '28 days later';
+
+        //NOTE to if true would add PS_SHIPPING_HANDLING from configuration to shipping price.
+        $carrier->shipping_handling = $data['shipping_handling'] ?? false;
+
+        //NOTE need to do it like this because otherwise it would not show up as option.
+        if (isset($data['price']) && !empty((int) $data['price'])) {
+            $carrier->shipping_method = \Carrier::SHIPPING_METHOD_PRICE;
+        } else {
+            $carrier->shipping_method = \Carrier::SHIPPING_METHOD_FREE;
+        }
+
+        $carrier->shipping_method = $data['shipping_method'] ?? $carrier->shipping_method;
+
+        $carrier->save();
+
+        $rangePrice = new \RangePrice();
+        $rangePrice->id_carrier = $carrier->id;
+        $rangePrice->delimiter1 = 0;
+        $rangePrice->delimiter2 = 1;
+
+        $rangePrice->save();
+
+        $zones = \Zone::getZones();
+        $prices = [];
+
+        foreach ($zones as $zone) {
+            $carrier->addZone($zone['id_zone']);
+
+            $prices[] = [
+                'id_range_price' => $rangePrice->id,
+                'id_range_weight' => null,
+                'id_carrier' => (int) $carrier->id,
+                'id_zone' => (int) $zone['id_zone'],
+                'price' => $data['price'] ?? 0,
+            ];
+        }
+        // enable all zones
+        $carrier->addDeliveryPrice($prices);
+
+        return $carrier;
+    }
+}

--- a/tests/Integration/Factory/CartFactory.php
+++ b/tests/Integration/Factory/CartFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Mollie\Tests\Integration\Factory;
+
+class CartFactory implements FactoryInterface
+{
+    public static function create(array $data = []): \Cart
+    {
+        $cart = new \Cart();
+
+        $cart->id_lang = $data['id_lang'] ?? \Configuration::get('PS_LANG_DEFAULT');
+        $cart->id_currency = $data['id_currency'] ?? \Configuration::get('PS_CURRENCY_DEFAULT');
+        $cart->id_carrier = $data['id_carrier'] ?? CarrierFactory::create()->id;
+        $cart->id_address_delivery = $data['id_address_delivery'] ?? AddressFactory::create()->id;
+        $cart->id_address_invoice = $data['id_address_invoice'] ?? AddressFactory::create()->id;
+        $cart->id_customer = $data['id_customer'] ?? CustomerFactory::create()->id;
+
+        $cart->save();
+
+        \Context::getContext()->cart = $cart;
+
+        return $cart;
+    }
+}

--- a/tests/Integration/Factory/CustomerFactory.php
+++ b/tests/Integration/Factory/CustomerFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Mollie\Tests\Integration\Factory;
+
+class CustomerFactory implements FactoryInterface
+{
+    public static function create(array $data = []): \Customer
+    {
+        $customer = new \Customer();
+
+        $customer->firstname = $data['first_name'] ?? 'test-first-name';
+        $customer->lastname = $data['last_name'] ?? 'test-last-name';
+        $customer->email = $data['email'] ?? 'test-email@email.com';
+        $customer->passwd = $data['passwd'] ?? 'test-passwd';
+        $customer->is_guest = $data['is_guest'] ?? false;
+        $customer->siret = $data['siret'] ?? 'test-siret';
+
+        $customer->save();
+
+        \Context::getContext()->customer = $customer;
+
+        return $customer;
+    }
+}

--- a/tests/Integration/Factory/FactoryInterface.php
+++ b/tests/Integration/Factory/FactoryInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Mollie\Tests\Integration\Factory;
+
+interface FactoryInterface
+{
+    public static function create(array $data = []);
+}

--- a/tests/Integration/Service/PaymentMethod/PaymentMethodRestrictionValidation/B2bPaymentMethodRestrictionValidatorTest.php
+++ b/tests/Integration/Service/PaymentMethod/PaymentMethodRestrictionValidation/B2bPaymentMethodRestrictionValidatorTest.php
@@ -1,0 +1,223 @@
+<?php
+
+namespace Mollie\Tests\Integration\Service\PaymentMethod\PaymentMethodRestrictionValidation;
+
+use Configuration;
+use Mollie\Api\Types\PaymentMethod;
+use Mollie\Service\PaymentMethod\PaymentMethodRestrictionValidation\B2bPaymentMethodRestrictionValidator;
+use Mollie\Tests\Integration\BaseTestCase;
+use Mollie\Tests\Integration\Factory\AddressFactory;
+use Mollie\Tests\Integration\Factory\CartFactory;
+use Mollie\Tests\Integration\Factory\CustomerFactory;
+
+class B2bPaymentMethodRestrictionValidatorTest extends BaseTestCase
+{
+    /** @var int */
+    private $originalB2bValue;
+
+    public function setUp(): void
+    {
+        $this->originalB2bValue = (int) Configuration::get('PS_B2B_ENABLE');
+
+        parent::setUp();
+    }
+
+    public function tearDown(): void
+    {
+        Configuration::set('PS_B2B_ENABLE', $this->originalB2bValue);
+
+        parent::tearDown();
+    }
+
+    public function testItSuccessfullyValidatedIsValid(): void
+    {
+        Configuration::set('PS_B2B_ENABLE', 1);
+
+        $molPaymentMethod = new \MolPaymentMethod();
+        $molPaymentMethod->id_method = PaymentMethod::BILLIE;
+
+        $customer = CustomerFactory::create([
+            'siret' => 'test-siret-number',
+        ]);
+
+        $billingAddress = AddressFactory::create([
+            'vat_number' => 'vat-number',
+        ]);
+
+        $this->contextBuilder->setCart(CartFactory::create());
+        $this->contextBuilder->getContext()->cart->id_address_invoice = $billingAddress->id;
+        $this->contextBuilder->getContext()->cart->id_customer = $customer->id;
+
+        /** @var B2bPaymentMethodRestrictionValidator $b2bPaymentMethodRestrictionValidator */
+        $b2bPaymentMethodRestrictionValidator = $this->getService(B2bPaymentMethodRestrictionValidator::class);
+
+        $supports = $b2bPaymentMethodRestrictionValidator->supports($molPaymentMethod);
+
+        $valid = $b2bPaymentMethodRestrictionValidator->isValid($molPaymentMethod);
+
+        $this->assertEquals(true, $supports);
+        $this->assertEquals(true, $valid);
+    }
+
+    public function testItUnsuccessfullyValidatedIsValidMethodNotSupported(): void
+    {
+        Configuration::set('PS_B2B_ENABLE', 1);
+
+        $molPaymentMethod = new \MolPaymentMethod();
+        $molPaymentMethod->id_method = 'not-supported-method';
+
+        $customer = CustomerFactory::create([
+            'siret' => 'test-siret-number',
+        ]);
+
+        $billingAddress = AddressFactory::create([
+            'vat_number' => 'vat-number',
+        ]);
+
+        $this->contextBuilder->setCart(CartFactory::create());
+        $this->contextBuilder->getContext()->cart->id_address_invoice = $billingAddress->id;
+        $this->contextBuilder->getContext()->cart->id_customer = $customer->id;
+
+        /** @var B2bPaymentMethodRestrictionValidator $b2bPaymentMethodRestrictionValidator */
+        $b2bPaymentMethodRestrictionValidator = $this->getService(B2bPaymentMethodRestrictionValidator::class);
+
+        $supports = $b2bPaymentMethodRestrictionValidator->supports($molPaymentMethod);
+
+        $valid = $b2bPaymentMethodRestrictionValidator->isValid($molPaymentMethod);
+
+        $this->assertEquals(false, $supports);
+        $this->assertEquals(true, $valid);
+    }
+
+    public function testItUnsuccessfullyValidatedIsValidMissingSiretNumber(): void
+    {
+        Configuration::set('PS_B2B_ENABLE', 1);
+
+        $molPaymentMethod = new \MolPaymentMethod();
+        $molPaymentMethod->id_method = PaymentMethod::BILLIE;
+
+        $customer = CustomerFactory::create([
+            'siret' => '',
+        ]);
+
+        $billingAddress = AddressFactory::create([
+            'vat_number' => 'vat-number',
+        ]);
+
+        $this->contextBuilder->setCart(CartFactory::create([
+            'id_customer' => $customer->id,
+            'id_address_delivery' => $billingAddress->id,
+            'id_address_invoice' => $billingAddress->id,
+        ]));
+
+        /** @var B2bPaymentMethodRestrictionValidator $b2bPaymentMethodRestrictionValidator */
+        $b2bPaymentMethodRestrictionValidator = $this->getService(B2bPaymentMethodRestrictionValidator::class);
+
+        $supports = $b2bPaymentMethodRestrictionValidator->supports($molPaymentMethod);
+
+        $valid = $b2bPaymentMethodRestrictionValidator->isValid($molPaymentMethod);
+
+        $this->assertEquals(true, $supports);
+        $this->assertEquals(false, $valid);
+    }
+
+    public function testItUnsuccessfullyValidatedIsValidB2bNotEnabled(): void
+    {
+        Configuration::set('PS_B2B_ENABLE', 0);
+
+        $molPaymentMethod = new \MolPaymentMethod();
+        $molPaymentMethod->id_method = PaymentMethod::BILLIE;
+
+        $customer = CustomerFactory::create([
+            'siret' => 'test-siret',
+        ]);
+
+        $billingAddress = AddressFactory::create([
+            'vat_number' => 'vat-number',
+        ]);
+
+        $this->contextBuilder->setCart(CartFactory::create([
+            'id_customer' => $customer->id,
+            'id_address_delivery' => $billingAddress->id,
+            'id_address_invoice' => $billingAddress->id,
+        ]));
+
+        /** @var B2bPaymentMethodRestrictionValidator $b2bPaymentMethodRestrictionValidator */
+        $b2bPaymentMethodRestrictionValidator = $this->getService(B2bPaymentMethodRestrictionValidator::class);
+
+        $supports = $b2bPaymentMethodRestrictionValidator->supports($molPaymentMethod);
+
+        $valid = $b2bPaymentMethodRestrictionValidator->isValid($molPaymentMethod);
+
+        $this->assertEquals(true, $supports);
+        $this->assertEquals(false, $valid);
+    }
+
+    public function testItUnsuccessfullyValidatedIsValidMissingVatNumberInBothAddresses(): void
+    {
+        Configuration::set('PS_B2B_ENABLE', 1);
+
+        $molPaymentMethod = new \MolPaymentMethod();
+        $molPaymentMethod->id_method = PaymentMethod::BILLIE;
+
+        $customer = CustomerFactory::create([
+            'siret' => 'test-siret',
+        ]);
+
+        $billingAddress = AddressFactory::create([
+            'vat_number' => '',
+        ]);
+
+        $this->contextBuilder->setCart(CartFactory::create([
+            'id_customer' => $customer->id,
+            'id_address_delivery' => $billingAddress->id,
+            'id_address_invoice' => $billingAddress->id,
+        ]));
+
+        /** @var B2bPaymentMethodRestrictionValidator $b2bPaymentMethodRestrictionValidator */
+        $b2bPaymentMethodRestrictionValidator = $this->getService(B2bPaymentMethodRestrictionValidator::class);
+
+        $supports = $b2bPaymentMethodRestrictionValidator->supports($molPaymentMethod);
+
+        $valid = $b2bPaymentMethodRestrictionValidator->isValid($molPaymentMethod);
+
+        $this->assertEquals(true, $supports);
+        $this->assertEquals(false, $valid);
+    }
+
+    public function testItUnsuccessfullyValidatedIsValidMissingVatNumberInBillingAddress(): void
+    {
+        Configuration::set('PS_B2B_ENABLE', 1);
+
+        $molPaymentMethod = new \MolPaymentMethod();
+        $molPaymentMethod->id_method = PaymentMethod::BILLIE;
+
+        $customer = CustomerFactory::create([
+            'siret' => 'test-siret',
+        ]);
+
+        $billingAddress = AddressFactory::create([
+            'vat_number' => '',
+        ]);
+
+        $shippingAddress = AddressFactory::create([
+            'vat_number' => 'test-vat-number',
+        ]);
+
+        $this->contextBuilder->setCart(CartFactory::create([
+            'id_customer' => $customer->id,
+            'id_address_delivery' => $shippingAddress->id,
+            'id_address_invoice' => $billingAddress->id,
+        ]));
+
+        /** @var B2bPaymentMethodRestrictionValidator $b2bPaymentMethodRestrictionValidator */
+        $b2bPaymentMethodRestrictionValidator = $this->getService(B2bPaymentMethodRestrictionValidator::class);
+
+        $supports = $b2bPaymentMethodRestrictionValidator->supports($molPaymentMethod);
+
+        $valid = $b2bPaymentMethodRestrictionValidator->isValid($molPaymentMethod);
+
+        $this->assertEquals(true, $supports);
+        $this->assertEquals(false, $valid);
+    }
+}


### PR DESCRIPTION
Added validation for Billie payment method. Payment method requirements:
- B2B enabled
- Vat number entered
- Identification number entered

Additionally bumped Mollie vendor package version as Billie was introduced later as we will use constant from the package for saving it in our configs. 