### PR TITLE
PIPRES-113: Billie payment method setup

### DIFF
--- a/mollie.php
+++ b/mollie.php
@@ -82,7 +82,7 @@ class Mollie extends PaymentModule
     {
         $this->name = 'mollie';
         $this->tab = 'payments_gateways';
-        $this->version = '6.0.2';
+        $this->version = '6.0.3';
         $this->author = 'Mollie B.V.';
         $this->need_instance = 1;
         $this->bootstrap = true;

--- a/src/Builder/FormBuilder.php
+++ b/src/Builder/FormBuilder.php
@@ -430,8 +430,6 @@ class FormBuilder
             'customLogoUrl' => $this->creditCardLogoProvider->getLogoPathUri() . "?{$dateStamp}",
             'customLogoExist' => $this->creditCardLogoProvider->logoExists(),
             'voucherCategory' => $this->configuration->get(Config::MOLLIE_VOUCHER_CATEGORY),
-            'klarnaPayments' => Config::KLARNA_PAYMENTS,
-            'klarnaStatuses' => [Config::MOLLIE_STATUS_KLARNA_AUTHORIZED, Config::MOLLIE_STATUS_KLARNA_SHIPPED],
             'applePayDirectProduct' => (int) $this->configuration->get(Config::MOLLIE_APPLE_PAY_DIRECT_PRODUCT),
             'applePayDirectCart' => (int) $this->configuration->get(Config::MOLLIE_APPLE_PAY_DIRECT_CART),
             'applePayDirectStyle' => (int) $this->configuration->get(Config::MOLLIE_APPLE_PAY_DIRECT_STYLE),
@@ -505,22 +503,22 @@ class FormBuilder
 
         $input[] = [
             'type' => 'select',
-            'label' => $this->module->l('Select when to create the Klarna invoice', self::FILE_NAME),
+            'label' => $this->module->l('Select when to create the Order invoice', self::FILE_NAME),
             'desc' => $this->module->display($this->module->getPathUri(), 'views/templates/admin/invoice_description.tpl'),
             'tab' => $advancedSettings,
-            'name' => Config::MOLLIE_KLARNA_INVOICE_ON,
+            'name' => Config::MOLLIE_AUTHORIZABLE_PAYMENT_INVOICE_ON_STATUS,
             'options' => [
                 'query' => [
                     [
-                        'id' => Config::MOLLIE_STATUS_DEFAULT,
+                        'id' => Config::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_DEFAULT,
                         'name' => $this->module->l('Default', self::FILE_NAME),
                     ],
                     [
-                        'id' => Config::MOLLIE_STATUS_KLARNA_AUTHORIZED,
+                        'id' => Config::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_AUTHORIZED,
                         'name' => $this->module->l('Authorised', self::FILE_NAME),
                     ],
                     [
-                        'id' => Config::MOLLIE_STATUS_KLARNA_SHIPPED,
+                        'id' => Config::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_SHIPPED,
                         'name' => $this->module->l('Shipped', self::FILE_NAME),
                     ],
                 ],

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -143,11 +143,11 @@ class Config
     const PARTIAL_REFUND_CODE = 'partial_refund';
     const MOLLIE_STATUS_PARTIALLY_SHIPPED = 'MOLLIE_PARTIALLY_SHIPPED';
     const MOLLIE_STATUS_ORDER_COMPLETED = 'MOLLIE_STATUS_ORDER_COMPLETED';
-    const MOLLIE_STATUS_DEFAULT = 'MOLLIE_STATUS_DEFAULT';
-    const MOLLIE_STATUS_KLARNA_AUTHORIZED = 'MOLLIE_STATUS_KLARNA_AUTHORIZED';
-    const MOLLIE_STATUS_KLARNA_SHIPPED = 'MOLLIE_STATUS_KLARNA_SHIPPED';
+    const MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_DEFAULT = 'MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_DEFAULT';
+    const MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_AUTHORIZED = 'MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_AUTHORIZED';
+    const MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_SHIPPED = 'MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_SHIPPED';
     const MOLLIE_STATUS_CHARGEBACK = 'MOLLIE_STATUS_CHARGEBACK';
-    const MOLLIE_KLARNA_INVOICE_ON = 'MOLLIE_KLARNA_INVOICE_ON';
+    const MOLLIE_AUTHORIZABLE_PAYMENT_INVOICE_ON_STATUS = 'MOLLIE_AUTHORIZABLE_PAYMENT_INVOICE_ON_STATUS';
     const MOLLIE_APPLE_PAY_DIRECT_PRODUCT = 'MOLLIE_APPLE_PAY_DIRECT_PRODUCT';
     const MOLLIE_APPLE_PAY_DIRECT_CART = 'MOLLIE_APPLE_PAY_DIRECT_CART';
 
@@ -256,16 +256,18 @@ class Config
     const RESTORE_CART_BACKTRACE_MEMORIZATION_SERVICE = 'memo';
     const RESTORE_CART_BACKTRACE_RETURN_CONTROLLER = 'return';
 
-    const KLARNA_PAYMENTS = [
+    const AUTHORIZABLE_PAYMENTS = [
         PaymentMethod::KLARNA_PAY_LATER,
         PaymentMethod::KLARNA_SLICE_IT,
         PaymentMethod::KLARNA_PAY_NOW,
+        PaymentMethod::BILLIE,
     ];
 
     const ORDER_API_ONLY_METHODS = [
         PaymentMethod::KLARNA_PAY_LATER,
         PaymentMethod::KLARNA_SLICE_IT,
         PaymentMethod::KLARNA_PAY_NOW,
+        PaymentMethod::BILLIE,
         self::MOLLIE_VOUCHER_METHOD_ID,
         self::MOLLIE_in3_METHOD_ID,
     ];
@@ -303,20 +305,22 @@ class Config
         'voucher' => 'Voucher',
         'klarnapaynow' => 'Klarna Pay now.',
         'in3' => 'in3',
+        'billie' => 'Billie',
     ];
 
     const MOLLIE_BUTTON_ORDER_TOTAL_REFRESH = 'MOLLIE_BUTTON_ORDER_TOTAL_REFRESH';
 
+    // TODO migrate functions below to separate service
     public static function getStatuses()
     {
-        $isKlarnaDefault = Configuration::get(Config::MOLLIE_KLARNA_INVOICE_ON) === Config::MOLLIE_STATUS_DEFAULT;
+        $isAuthorizablePaymentInvoiceOnStatusDefault = Configuration::get(Config::MOLLIE_AUTHORIZABLE_PAYMENT_INVOICE_ON_STATUS) === Config::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_DEFAULT;
 
         return [
             self::MOLLIE_AWAITING_PAYMENT => Configuration::get(self::MOLLIE_STATUS_AWAITING),
             PaymentStatus::STATUS_PAID => Configuration::get(self::MOLLIE_STATUS_PAID),
             OrderStatus::STATUS_COMPLETED => Configuration::get(self::MOLLIE_STATUS_COMPLETED),
-            PaymentStatus::STATUS_AUTHORIZED => $isKlarnaDefault ?
-                Configuration::get(self::MOLLIE_STATUS_PAID) : Configuration::get(self::MOLLIE_STATUS_KLARNA_AUTHORIZED),
+            PaymentStatus::STATUS_AUTHORIZED => $isAuthorizablePaymentInvoiceOnStatusDefault ?
+                Configuration::get(self::MOLLIE_STATUS_PAID) : Configuration::get(self::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_AUTHORIZED),
             PaymentStatus::STATUS_CANCELED => Configuration::get(self::MOLLIE_STATUS_CANCELED),
             PaymentStatus::STATUS_EXPIRED => Configuration::get(self::MOLLIE_STATUS_EXPIRED),
             RefundStatus::STATUS_REFUNDED => Configuration::get(self::MOLLIE_STATUS_REFUNDED),
@@ -329,7 +333,7 @@ class Config
             self::STATUS_PAID_ON_BACKORDER => Configuration::get('PS_OS_OUTOFSTOCK_PAID'),
             self::STATUS_PENDING_ON_BACKORDER => Configuration::get('PS_OS_OUTOFSTOCK_UNPAID'),
             self::STATUS_ON_BACKORDER => Configuration::get('PS_OS_OUTOFSTOCK'),
-            self::MOLLIE_STATUS_KLARNA_SHIPPED => Configuration::get(self::MOLLIE_STATUS_KLARNA_SHIPPED),
+            self::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_SHIPPED => Configuration::get(self::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_SHIPPED),
             self::MOLLIE_CHARGEBACK => Configuration::get(self::MOLLIE_STATUS_CHARGEBACK),
         ];
     }
@@ -351,8 +355,8 @@ class Config
             self::MOLLIE_STATUS_PARTIAL_REFUND,
             self::MOLLIE_STATUS_AWAITING,
             self::MOLLIE_STATUS_ORDER_COMPLETED,
-            self::MOLLIE_STATUS_KLARNA_AUTHORIZED,
-            self::MOLLIE_STATUS_KLARNA_SHIPPED,
+            self::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_AUTHORIZED,
+            self::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_SHIPPED,
             self::MOLLIE_STATUS_CHARGEBACK,
         ];
     }

--- a/src/Handler/Order/OrderCreationHandler.php
+++ b/src/Handler/Order/OrderCreationHandler.php
@@ -109,7 +109,7 @@ class OrderCreationHandler
     /**
      * @param MollieOrderAlias|MolliePaymentAlias $apiPayment
      * @param int $cartId
-     * @param bool $isKlarnaOrder
+     * @param bool $isAuthorizablePayment
      *
      * @return int
      *
@@ -119,9 +119,9 @@ class OrderCreationHandler
      * @throws \PrestaShopDatabaseException
      * @throws \PrestaShopException
      */
-    public function createOrder($apiPayment, int $cartId, $isKlarnaOrder = false): int
+    public function createOrder($apiPayment, int $cartId, bool $isAuthorizablePayment = false): int
     {
-        $orderStatus = $isKlarnaOrder ?
+        $orderStatus = $isAuthorizablePayment ?
             (int) Config::getStatuses()[PaymentStatus::STATUS_AUTHORIZED] :
             (int) Config::getStatuses()[PaymentStatus::STATUS_PAID];
 

--- a/src/Install/OrderStateInstaller.php
+++ b/src/Install/OrderStateInstaller.php
@@ -33,7 +33,7 @@ class OrderStateInstaller implements InstallerInterface
     /**
      * @throws CouldNotInstallModule
      */
-    public function install()
+    public function install(): bool
     {
         $this->installOrderState(
             Config::MOLLIE_STATUS_PARTIAL_REFUND,
@@ -69,9 +69,9 @@ class OrderStateInstaller implements InstallerInterface
         );
 
         $this->installOrderState(
-            Config::MOLLIE_STATUS_KLARNA_AUTHORIZED,
+            Config::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_AUTHORIZED,
             new OrderStateData(
-                'Klarna payment authorized',
+                'Order payment authorized',
                 '#8A2BE2',
                 true,
                 true,
@@ -85,9 +85,9 @@ class OrderStateInstaller implements InstallerInterface
         );
 
         $this->installOrderState(
-            Config::MOLLIE_STATUS_KLARNA_SHIPPED,
+            Config::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_SHIPPED,
             new OrderStateData(
-                'Klarna payment shipped',
+                'Order payment shipped',
                 '#8A2BE2',
                 true,
                 true,
@@ -114,7 +114,7 @@ class OrderStateInstaller implements InstallerInterface
     /**
      * @throws CouldNotInstallModule
      */
-    private function installOrderState(string $orderStatus, OrderStateData $orderStateInstallerData)
+    private function installOrderState(string $orderStatus, OrderStateData $orderStateInstallerData): void
     {
         if ($this->validateIfStatusExists($orderStatus)) {
             $this->enableState($orderStatus);
@@ -136,7 +136,7 @@ class OrderStateInstaller implements InstallerInterface
         return \Validate::isLoadedObject($orderState);
     }
 
-    private function enableState(string $key)
+    private function enableState(string $key): void
     {
         $existingStateId = (int) $this->configurationAdapter->get($key);
         $orderState = new OrderState($existingStateId);
@@ -186,7 +186,7 @@ class OrderStateInstaller implements InstallerInterface
         return $orderState;
     }
 
-    private function updateStateConfiguration(string $key, OrderState $orderState)
+    private function updateStateConfiguration(string $key, OrderState $orderState): void
     {
         $this->configurationAdapter->updateValue($key, (int) $orderState->id);
     }

--- a/src/Service/ConfigFieldService.php
+++ b/src/Service/ConfigFieldService.php
@@ -12,10 +12,11 @@
 
 namespace Mollie\Service;
 
-use Configuration;
 use Mollie;
+use Mollie\Adapter\ConfigurationAdapter;
 use Mollie\Config\Config;
 use Mollie\Repository\CountryRepository;
+use Mollie\Utility\EnvironmentUtility;
 
 class ConfigFieldService
 {
@@ -31,14 +32,14 @@ class ConfigFieldService
      * @var CountryRepository
      */
     private $countryRepository;
-    /** @var Mollie\Adapter\ConfigurationAdapter */
+    /** @var ConfigurationAdapter */
     private $configurationAdapter;
 
     public function __construct(
         Mollie $module,
         ApiService $apiService,
         CountryRepository $countryRepository,
-        Mollie\Adapter\ConfigurationAdapter $configurationAdapter
+        ConfigurationAdapter $configurationAdapter
     ) {
         $this->module = $module;
         $this->apiService = $apiService;
@@ -52,67 +53,72 @@ class ConfigFieldService
     public function getConfigFieldsValues()
     {
         $configFields = [
-            Config::MOLLIE_ENVIRONMENT => Configuration::get(Config::MOLLIE_ENVIRONMENT),
-            Config::MOLLIE_API_KEY => Configuration::get(Config::MOLLIE_API_KEY),
-            Config::MOLLIE_API_KEY_TEST => Configuration::get(Config::MOLLIE_API_KEY_TEST),
-            Config::MOLLIE_PAYMENTSCREEN_LOCALE => Configuration::get(Config::MOLLIE_PAYMENTSCREEN_LOCALE),
-            Config::MOLLIE_SEND_ORDER_CONFIRMATION => Configuration::get(Config::MOLLIE_SEND_ORDER_CONFIRMATION),
+            Config::MOLLIE_ENVIRONMENT => $this->configurationAdapter->get(Config::MOLLIE_ENVIRONMENT),
+            Config::MOLLIE_API_KEY => $this->configurationAdapter->get(Config::MOLLIE_API_KEY),
+            Config::MOLLIE_API_KEY_TEST => $this->configurationAdapter->get(Config::MOLLIE_API_KEY_TEST),
+            Config::MOLLIE_PAYMENTSCREEN_LOCALE => $this->configurationAdapter->get(Config::MOLLIE_PAYMENTSCREEN_LOCALE),
+            Config::MOLLIE_SEND_ORDER_CONFIRMATION => $this->configurationAdapter->get(Config::MOLLIE_SEND_ORDER_CONFIRMATION),
             Config::MOLLIE_IFRAME[(int) $this->configurationAdapter->get(Config::MOLLIE_ENVIRONMENT) ? 'production' : 'sandbox'] => $this->configurationAdapter->get(Config::MOLLIE_IFRAME),
             Config::MOLLIE_SINGLE_CLICK_PAYMENT[(int) $this->configurationAdapter->get(Config::MOLLIE_ENVIRONMENT) ? 'production' : 'sandbox'] => $this->configurationAdapter->get(Config::MOLLIE_SINGLE_CLICK_PAYMENT),
 
-            Config::MOLLIE_CSS => Configuration::get(Config::MOLLIE_CSS),
-            Config::MOLLIE_IMAGES => Configuration::get(Config::MOLLIE_IMAGES),
-            Config::MOLLIE_SHOW_RESEND_PAYMENT_LINK => Configuration::get(Config::MOLLIE_SHOW_RESEND_PAYMENT_LINK),
+            Config::MOLLIE_CSS => $this->configurationAdapter->get(Config::MOLLIE_CSS),
+            Config::MOLLIE_IMAGES => $this->configurationAdapter->get(Config::MOLLIE_IMAGES),
+            Config::MOLLIE_SHOW_RESEND_PAYMENT_LINK => $this->configurationAdapter->get(Config::MOLLIE_SHOW_RESEND_PAYMENT_LINK),
             Config::MOLLIE_ISSUERS[(int) $this->configurationAdapter->get(Config::MOLLIE_ENVIRONMENT) ? 'production' : 'sandbox'] => $this->configurationAdapter->get(Config::MOLLIE_ISSUERS),
 
-            Config::MOLLIE_METHOD_COUNTRIES => Configuration::get(Config::MOLLIE_METHOD_COUNTRIES),
-            Config::MOLLIE_METHOD_COUNTRIES_DISPLAY => Configuration::get(Config::MOLLIE_METHOD_COUNTRIES_DISPLAY),
+            Config::MOLLIE_METHOD_COUNTRIES => $this->configurationAdapter->get(Config::MOLLIE_METHOD_COUNTRIES),
+            Config::MOLLIE_METHOD_COUNTRIES_DISPLAY => $this->configurationAdapter->get(Config::MOLLIE_METHOD_COUNTRIES_DISPLAY),
 
-            Config::MOLLIE_STATUS_OPEN => Configuration::get(Config::MOLLIE_STATUS_OPEN),
-            Config::MOLLIE_STATUS_AWAITING => Configuration::get(Config::MOLLIE_STATUS_AWAITING),
-            Config::MOLLIE_STATUS_PAID => Configuration::get(Config::MOLLIE_STATUS_PAID),
-            Config::MOLLIE_STATUS_COMPLETED => Configuration::get(Config::MOLLIE_STATUS_COMPLETED),
-            Config::MOLLIE_STATUS_CANCELED => Configuration::get(Config::MOLLIE_STATUS_CANCELED),
-            Config::MOLLIE_STATUS_EXPIRED => Configuration::get(Config::MOLLIE_STATUS_EXPIRED),
-            Config::MOLLIE_STATUS_PARTIAL_REFUND => Configuration::get(Config::MOLLIE_STATUS_PARTIAL_REFUND),
-            Config::MOLLIE_STATUS_REFUNDED => Configuration::get(Config::MOLLIE_STATUS_REFUNDED),
-            Config::MOLLIE_STATUS_CHARGEBACK => Configuration::get(Config::MOLLIE_STATUS_CHARGEBACK),
-            Config::MOLLIE_MAIL_WHEN_OPEN => Configuration::get(Config::MOLLIE_MAIL_WHEN_OPEN),
-            Config::MOLLIE_MAIL_WHEN_AWAITING => Configuration::get(Config::MOLLIE_MAIL_WHEN_AWAITING),
-            Config::MOLLIE_MAIL_WHEN_PAID => Configuration::get(Config::MOLLIE_MAIL_WHEN_PAID),
-            Config::MOLLIE_MAIL_WHEN_COMPLETED => Configuration::get(Config::MOLLIE_MAIL_WHEN_COMPLETED),
-            Config::MOLLIE_MAIL_WHEN_CANCELED => Configuration::get(Config::MOLLIE_MAIL_WHEN_CANCELED),
-            Config::MOLLIE_MAIL_WHEN_EXPIRED => Configuration::get(Config::MOLLIE_MAIL_WHEN_EXPIRED),
-            Config::MOLLIE_MAIL_WHEN_REFUNDED => Configuration::get(Config::MOLLIE_MAIL_WHEN_REFUNDED),
-            Config::MOLLIE_MAIL_WHEN_CHARGEBACK => Configuration::get(Config::MOLLIE_MAIL_WHEN_CHARGEBACK),
-            Config::MOLLIE_ACCOUNT_SWITCH => Configuration::get(Config::MOLLIE_ACCOUNT_SWITCH),
+            Config::MOLLIE_STATUS_OPEN => $this->configurationAdapter->get(Config::MOLLIE_STATUS_OPEN),
+            Config::MOLLIE_STATUS_AWAITING => $this->configurationAdapter->get(Config::MOLLIE_STATUS_AWAITING),
+            Config::MOLLIE_STATUS_PAID => $this->configurationAdapter->get(Config::MOLLIE_STATUS_PAID),
+            Config::MOLLIE_STATUS_COMPLETED => $this->configurationAdapter->get(Config::MOLLIE_STATUS_COMPLETED),
+            Config::MOLLIE_STATUS_CANCELED => $this->configurationAdapter->get(Config::MOLLIE_STATUS_CANCELED),
+            Config::MOLLIE_STATUS_EXPIRED => $this->configurationAdapter->get(Config::MOLLIE_STATUS_EXPIRED),
+            Config::MOLLIE_STATUS_PARTIAL_REFUND => $this->configurationAdapter->get(Config::MOLLIE_STATUS_PARTIAL_REFUND),
+            Config::MOLLIE_STATUS_REFUNDED => $this->configurationAdapter->get(Config::MOLLIE_STATUS_REFUNDED),
+            Config::MOLLIE_STATUS_CHARGEBACK => $this->configurationAdapter->get(Config::MOLLIE_STATUS_CHARGEBACK),
+            Config::MOLLIE_MAIL_WHEN_OPEN => $this->configurationAdapter->get(Config::MOLLIE_MAIL_WHEN_OPEN),
+            Config::MOLLIE_MAIL_WHEN_AWAITING => $this->configurationAdapter->get(Config::MOLLIE_MAIL_WHEN_AWAITING),
+            Config::MOLLIE_MAIL_WHEN_PAID => $this->configurationAdapter->get(Config::MOLLIE_MAIL_WHEN_PAID),
+            Config::MOLLIE_MAIL_WHEN_COMPLETED => $this->configurationAdapter->get(Config::MOLLIE_MAIL_WHEN_COMPLETED),
+            Config::MOLLIE_MAIL_WHEN_CANCELED => $this->configurationAdapter->get(Config::MOLLIE_MAIL_WHEN_CANCELED),
+            Config::MOLLIE_MAIL_WHEN_EXPIRED => $this->configurationAdapter->get(Config::MOLLIE_MAIL_WHEN_EXPIRED),
+            Config::MOLLIE_MAIL_WHEN_REFUNDED => $this->configurationAdapter->get(Config::MOLLIE_MAIL_WHEN_REFUNDED),
+            Config::MOLLIE_MAIL_WHEN_CHARGEBACK => $this->configurationAdapter->get(Config::MOLLIE_MAIL_WHEN_CHARGEBACK),
+            Config::MOLLIE_ACCOUNT_SWITCH => $this->configurationAdapter->get(Config::MOLLIE_ACCOUNT_SWITCH),
 
-            Config::MOLLIE_DISPLAY_ERRORS => Configuration::get(Config::MOLLIE_DISPLAY_ERRORS),
-            Config::MOLLIE_DEBUG_LOG => Configuration::get(Config::MOLLIE_DEBUG_LOG),
-            Config::MOLLIE_API => Configuration::get(Config::MOLLIE_API),
+            Config::MOLLIE_DISPLAY_ERRORS => $this->configurationAdapter->get(Config::MOLLIE_DISPLAY_ERRORS),
+            Config::MOLLIE_DEBUG_LOG => $this->configurationAdapter->get(Config::MOLLIE_DEBUG_LOG),
+            Config::MOLLIE_API => $this->configurationAdapter->get(Config::MOLLIE_API),
 
-            Config::MOLLIE_AUTO_SHIP_MAIN => Configuration::get(Config::MOLLIE_AUTO_SHIP_MAIN),
+            Config::MOLLIE_AUTO_SHIP_MAIN => $this->configurationAdapter->get(Config::MOLLIE_AUTO_SHIP_MAIN),
 
-            Config::MOLLIE_STATUS_SHIPPING => Configuration::get(Config::MOLLIE_STATUS_SHIPPING),
-            Config::MOLLIE_MAIL_WHEN_SHIPPING => Configuration::get(Config::MOLLIE_MAIL_WHEN_SHIPPING),
-            Config::MOLLIE_KLARNA_INVOICE_ON => Configuration::get(Config::MOLLIE_KLARNA_INVOICE_ON),
+            Config::MOLLIE_STATUS_SHIPPING => $this->configurationAdapter->get(Config::MOLLIE_STATUS_SHIPPING),
+            Config::MOLLIE_MAIL_WHEN_SHIPPING => $this->configurationAdapter->get(Config::MOLLIE_MAIL_WHEN_SHIPPING),
+            Config::MOLLIE_AUTHORIZABLE_PAYMENT_INVOICE_ON_STATUS => $this->configurationAdapter->get(Config::MOLLIE_AUTHORIZABLE_PAYMENT_INVOICE_ON_STATUS),
         ];
 
-        if (Mollie\Utility\EnvironmentUtility::getApiKey() && $this->module->getApiClient() !== null) {
+        if (EnvironmentUtility::getApiKey() && $this->module->getApiClient() !== null) {
             foreach ($this->apiService->getMethodsForConfig($this->module->getApiClient()) as $method) {
                 $countryIds = $this->countryRepository->getMethodCountryIds($method['id']);
+
                 if ($countryIds) {
-                    $configFields = array_merge($configFields, [Config::MOLLIE_COUNTRIES . $method['id'] . '[]' => $countryIds]);
+                    $configFields[Config::MOLLIE_COUNTRIES . $method['id'] . '[]'] = $countryIds;
+
                     continue;
                 }
-                $configFields = array_merge($configFields, [Config::MOLLIE_COUNTRIES . $method['id'] . '[]' => []]);
+
+                $configFields[Config::MOLLIE_COUNTRIES . $method['id'] . '[]'] = [];
             }
         }
 
         $checkStatuses = [];
-        if (Configuration::get(Config::MOLLIE_AUTO_SHIP_STATUSES)) {
-            $checkConfs = @json_decode(Configuration::get(Config::MOLLIE_AUTO_SHIP_STATUSES), true);
+
+        if ($this->configurationAdapter->get(Config::MOLLIE_AUTO_SHIP_STATUSES)) {
+            $checkConfs = @json_decode($this->configurationAdapter->get(Config::MOLLIE_AUTO_SHIP_STATUSES), true);
         }
+
         if (!isset($checkConfs) || !is_array($checkConfs)) {
             $checkConfs = [];
         }
@@ -121,8 +127,6 @@ class ConfigFieldService
             $checkStatuses[Config::MOLLIE_AUTO_SHIP_STATUSES . '_' . (int) $conf] = true;
         }
 
-        $configFields = array_merge($configFields, $checkStatuses);
-
-        return $configFields;
+        return array_merge($configFields, $checkStatuses);
     }
 }

--- a/src/Service/OrderStatusService.php
+++ b/src/Service/OrderStatusService.php
@@ -157,6 +157,6 @@ class OrderStatusService
     {
         return ((int) $statusId === (int) Configuration::get(Config::MOLLIE_STATUS_PAID)) ||
             ((int) $statusId === (int) Configuration::get(Config::STATUS_PS_OS_OUTOFSTOCK_PAID)) ||
-            ((int) $statusId === (int) Configuration::get(Config::MOLLIE_STATUS_KLARNA_AUTHORIZED));
+            ((int) $statusId === (int) Configuration::get(Config::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_AUTHORIZED));
     }
 }

--- a/src/Validator/OrderConfMailValidator.php
+++ b/src/Validator/OrderConfMailValidator.php
@@ -59,7 +59,7 @@ class OrderConfMailValidator implements MailValidatorInterface
             return true;
         }
 
-        if ((int) $this->configurationAdapter->get(Config::MOLLIE_STATUS_KLARNA_AUTHORIZED) === $orderStateId) {
+        if ((int) $this->configurationAdapter->get(Config::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_AUTHORIZED) === $orderStateId) {
             return true;
         }
 

--- a/tests/Integration/Install/OrderStateInstallerTest.php
+++ b/tests/Integration/Install/OrderStateInstallerTest.php
@@ -86,7 +86,7 @@ class OrderStateInstallerTest extends BaseTestCase
                 'pdfInvoice' => false,
             ],
             [
-                'key' => Config::MOLLIE_STATUS_KLARNA_AUTHORIZED,
+                'key' => Config::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_AUTHORIZED,
                 'color' => '#8A2BE2',
                 'sendEmail' => true,
                 'logable' => true,
@@ -97,7 +97,7 @@ class OrderStateInstallerTest extends BaseTestCase
                 'pdfInvoice' => true,
             ],
             [
-                'key' => Config::MOLLIE_STATUS_KLARNA_SHIPPED,
+                'key' => Config::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_SHIPPED,
                 'color' => '#8A2BE2',
                 'sendEmail' => true,
                 'logable' => true,

--- a/tests/Unit/Service/PaymentMethod/PaymentMethodRestrictionValidation/VersionSpecificPaymentRestrictionValidationTest.php
+++ b/tests/Unit/Service/PaymentMethod/PaymentMethodRestrictionValidation/VersionSpecificPaymentRestrictionValidationTest.php
@@ -52,15 +52,9 @@ class VersionSpecificPaymentRestrictionValidationTest extends UnitTestCase
     /**
      * @dataProvider getVersionSpecificPaymentRestrictionValidationDataProvider
      */
-    public function testIsValid($isCountriesApplicable, $prestashopVersion, $countryExcluded, $countryAvailable, $expectedResult)
+    public function testIsValid($isCountriesApplicable, $countryExcluded, $countryAvailable, $expectedResult)
     {
         $this->paymentMethod->is_countries_applicable = $isCountriesApplicable;
-
-        $this->environmentVersionProvider
-            ->expects($this->any())
-            ->method('getPrestashopVersion')
-            ->willReturn($prestashopVersion)
-        ;
 
         $this->methodCountryRepository
             ->expects($this->any())
@@ -76,7 +70,6 @@ class VersionSpecificPaymentRestrictionValidationTest extends UnitTestCase
 
         $versionSpecificValidation = new EnvironmentVersionSpecificPaymentMethodRestrictionValidator(
             $this->context,
-            $this->environmentVersionProvider,
             $this->methodCountryRepository
         );
 
@@ -90,28 +83,24 @@ class VersionSpecificPaymentRestrictionValidationTest extends UnitTestCase
         return [
             'All checks pass' => [
                 'isCountriesApplicable' => true,
-                'prestashopVersion' => '1.7.0.5',
                 'countryExcluded' => false,
                 'countryAvailable' => true,
                 'expectedResult' => true,
             ],
             'Current environment version is not applicable to validation' => [
                 'isCountriesApplicable' => true,
-                'prestashopVersion' => '1.5.0.1',
                 'countryExcluded' => false,
                 'countryAvailable' => true,
                 'expectedResult' => true,
             ],
             'Method country is not available by not being in available list' => [
                 'isCountriesApplicable' => true,
-                'prestashopVersion' => '1.7.0.5',
                 'countryExcluded' => false,
                 'countryAvailable' => false,
                 'expectedResult' => false,
             ],
             'Method country is not available by exclusion and not being applicable' => [
                 'isCountriesApplicable' => false,
-                'prestashopVersion' => '1.7.0.5',
                 'countryExcluded' => true,
                 'countryAvailable' => false,
                 'expectedResult' => false,

--- a/upgrade/Upgrade-4.2.0.php
+++ b/upgrade/Upgrade-4.2.0.php
@@ -10,7 +10,7 @@
  */
 
 use Mollie\Config\Config;
-use Mollie\Install\Installer;
+use Mollie\Install\OrderStateInstaller;
 use Mollie\Service\OrderStateImageService;
 
 if (!defined('_PS_VERSION_')) {
@@ -30,14 +30,13 @@ function upgrade_module_4_2_0($module)
     $segment->setMessage('Mollie upgrade 4.2.0');
     $segment->track();
 
-    /** @var Installer $installer */
-    $installer = $module->getService(Installer::class);
+    /** @var OrderStateInstaller $orderStateInstaller */
+    $orderStateInstaller = $module->getService(OrderStateInstaller::class);
 
-    $installer->klarnaPaymentAuthorizedState();
-    $installer->klarnaPaymentShippedState();
+    $orderStateInstaller->install();
 
-    $acceptedStatusId = Configuration::get(Config::MOLLIE_STATUS_KLARNA_AUTHORIZED);
-    Configuration::updateValue(Config::MOLLIE_KLARNA_INVOICE_ON, $acceptedStatusId);
+    $acceptedStatusId = Configuration::get(Config::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_AUTHORIZED);
+    Configuration::updateValue(Config::MOLLIE_AUTHORIZABLE_PAYMENT_INVOICE_ON_STATUS, $acceptedStatusId);
 
     $module->registerHook('actionOrderGridQueryBuilderModifier');
     $module->registerHook('actionOrderGridDefinitionModifier');

--- a/upgrade/Upgrade-6.0.3.php
+++ b/upgrade/Upgrade-6.0.3.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * Mollie       https://www.mollie.nl
+ *
+ * @author      Mollie B.V. <info@mollie.nl>
+ * @copyright   Mollie B.V.
+ * @license     https://github.com/mollie/PrestaShop/blob/master/LICENSE.md
+ *
+ * @see        https://github.com/mollie/PrestaShop
+ */
+
+use Mollie\Adapter\ConfigurationAdapter;
+use Mollie\Config\Config;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_6_0_3(Mollie $module): bool
+{
+    updateConfigurationValues603($module);
+    updateOrderStatusNames603($module);
+
+    return true;
+}
+
+function updateConfigurationValues603(Mollie $module)
+{
+    /** @var ConfigurationAdapter $configuration */
+    $configuration = $module->getService(ConfigurationAdapter::class);
+
+    if (
+        !empty($configuration->get(Config::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_AUTHORIZED))
+        && !empty($configuration->get(Config::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_SHIPPED))
+        && !empty($configuration->get(Config::MOLLIE_AUTHORIZABLE_PAYMENT_INVOICE_ON_STATUS))
+        && empty($configuration->get('MOLLIE_STATUS_KLARNA_AUTHORIZED'))
+        && empty($configuration->get('MOLLIE_STATUS_KLARNA_SHIPPED'))
+        && empty($configuration->get('MOLLIE_KLARNA_INVOICE_ON'))
+    ) {
+        return;
+    }
+
+    $klarnaInvoiceOn = $configuration->get('MOLLIE_KLARNA_INVOICE_ON');
+
+    switch ($klarnaInvoiceOn) {
+        case 'MOLLIE_STATUS_KLARNA_AUTHORIZED':
+            $configuration->updateValue(
+                Config::MOLLIE_AUTHORIZABLE_PAYMENT_INVOICE_ON_STATUS,
+                Config::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_AUTHORIZED
+            );
+            break;
+        case 'MOLLIE_STATUS_KLARNA_SHIPPED':
+            $configuration->updateValue(
+                Config::MOLLIE_AUTHORIZABLE_PAYMENT_INVOICE_ON_STATUS,
+                Config::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_SHIPPED
+            );
+            break;
+        default:
+            $configuration->updateValue(
+                Config::MOLLIE_AUTHORIZABLE_PAYMENT_INVOICE_ON_STATUS,
+                Config::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_DEFAULT
+            );
+    }
+
+    $configuration->updateValue(Config::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_AUTHORIZED, (int) $configuration->get('MOLLIE_STATUS_KLARNA_AUTHORIZED'));
+    $configuration->updateValue(Config::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_SHIPPED, (int) $configuration->get('MOLLIE_STATUS_KLARNA_SHIPPED'));
+
+    $configuration->delete('MOLLIE_STATUS_KLARNA_AUTHORIZED');
+    $configuration->delete('MOLLIE_STATUS_KLARNA_SHIPPED');
+    $configuration->delete('MOLLIE_KLARNA_INVOICE_ON');
+}
+
+function updateOrderStatusNames603(Mollie $module)
+{
+    /** @var ConfigurationAdapter $configuration */
+    $configuration = $module->getService(ConfigurationAdapter::class);
+
+    $authorizablePaymentStatusShippedId = (int) $configuration->get(Config::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_SHIPPED);
+    $authorizablePaymentStatusShipped = new OrderState((int) $authorizablePaymentStatusShippedId);
+
+    if (is_array($authorizablePaymentStatusShipped->name)) {
+        foreach ($authorizablePaymentStatusShipped->name as $langId => $name) {
+            $authorizablePaymentStatusShipped->name[$langId] = 'Order payment shipped';
+        }
+    }
+
+    $authorizablePaymentStatusShipped->save();
+
+    $authorizablePaymentStatusAuthorizedId = (int) $configuration->get(Config::MOLLIE_AUTHORIZABLE_PAYMENT_STATUS_AUTHORIZED);
+    $authorizablePaymentStatusAuthorized = new OrderState((int) $authorizablePaymentStatusAuthorizedId);
+
+    if (is_array($authorizablePaymentStatusAuthorized->name)) {
+        foreach ($authorizablePaymentStatusAuthorized->name as $langId => $name) {
+            $authorizablePaymentStatusAuthorized->name[$langId] = 'Order payment authorized';
+        }
+    }
+
+    $authorizablePaymentStatusAuthorized->save();
+}

--- a/views/templates/admin/invoice_description.tpl
+++ b/views/templates/admin/invoice_description.tpl
@@ -7,10 +7,10 @@
 * @license     https://github.com/mollie/PrestaShop/blob/master/LICENSE.md
 *}
 <p>
-    {l s='Select when to send Klarna invoices' mod='mollie'}
+    {l s='Select when to create the Order invoice' mod='mollie'}
 </p>
 <p class="help-block">
-    {l s='Default: The invoice is created based on Order settings > Statuses. There is no custom status created for Klarna.' mod='mollie'}
+    {l s='Default: The invoice is created based on Order settings > Statuses. There is no custom status created.' mod='mollie'}
 </p>
 <p class="help-block">
     {l s='Authorised: Create a full invoice when the order is authorized. Custom status is created.' mod='mollie'}


### PR DESCRIPTION
As Billie payment method will have same actions as Klarna, we needed to use general naming for such methods. Renamed every const, variable, changed order status names and configuration values. 