### PR TITLE
PIPRES-113: Billie payment method additional data send

### DIFF
--- a/src/Adapter/Context.php
+++ b/src/Adapter/Context.php
@@ -111,7 +111,7 @@ class Context
         );
     }
 
-    public function getAddressInvoiceId(): int
+    public function getInvoiceAddressId(): int
     {
         return (int) PrestashopContext::getContext()->cart->id_address_invoice;
     }

--- a/src/DTO/Object/Company.php
+++ b/src/DTO/Object/Company.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Mollie\DTO\Object;
+
+class Company implements \JsonSerializable
+{
+    /** @var string */
+    private $vatNumber;
+    /** @var string */
+    private $registrationNumber;
+
+    /**
+     * @return string
+     */
+    public function getVatNumber(): string
+    {
+        return $this->vatNumber;
+    }
+
+    /**
+     * @param string $vatNumber
+     *
+     * @maps vatNumber
+     */
+    public function setVatNumber(string $vatNumber): void
+    {
+        $this->vatNumber = $vatNumber;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRegistrationNumber(): string
+    {
+        return $this->registrationNumber;
+    }
+
+    /**
+     * @param string $registrationNumber
+     *
+     * @maps registrationNumber
+     */
+    public function setRegistrationNumber(string $registrationNumber): void
+    {
+        $this->registrationNumber = $registrationNumber;
+    }
+
+    public function jsonSerialize()
+    {
+        $json = [];
+        $json['vatNumber'] = $this->getVatNumber();
+        $json['registrationNumber'] = $this->getRegistrationNumber();
+
+        return array_filter($json, static function ($val) {
+            return $val !== null && $val !== '';
+        });
+    }
+}

--- a/src/DTO/Object/Payment.php
+++ b/src/DTO/Object/Payment.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Mollie\DTO\Object;
+
+class Payment implements \JsonSerializable
+{
+    /** @var ?string */
+    private $cardToken;
+    /** @var string */
+    private $webhookUrl;
+    /** @var ?string */
+    private $issuer;
+    /** @var ?string */
+    private $customerId;
+    /** @var ?string */
+    private $applePayPaymentToken;
+    /** @var ?Company */
+    private $company;
+
+    /**
+     * @return ?string
+     */
+    public function getCardToken(): ?string
+    {
+        return $this->cardToken;
+    }
+
+    /**
+     * @param string $cardToken
+     *
+     * @maps cardToken
+     */
+    public function setCardToken(string $cardToken): void
+    {
+        $this->cardToken = $cardToken;
+    }
+
+    /**
+     * @return string
+     */
+    public function getWebhookUrl(): string
+    {
+        return $this->webhookUrl;
+    }
+
+    /**
+     * @param string $webhookUrl
+     *
+     * @maps webhookUrl
+     */
+    public function setWebhookUrl(string $webhookUrl): void
+    {
+        $this->webhookUrl = $webhookUrl;
+    }
+
+    /**
+     * @return ?string
+     */
+    public function getIssuer(): ?string
+    {
+        return $this->issuer;
+    }
+
+    /**
+     * @param string $issuer
+     *
+     * @maps issuer
+     */
+    public function setIssuer(string $issuer): void
+    {
+        $this->issuer = $issuer;
+    }
+
+    /**
+     * @return ?string
+     */
+    public function getCustomerId(): ?string
+    {
+        return $this->customerId;
+    }
+
+    /**
+     * @param string $customerId
+     *
+     * @maps customerId
+     */
+    public function setCustomerId(string $customerId): void
+    {
+        $this->customerId = $customerId;
+    }
+
+    /**
+     * @return ?string
+     */
+    public function getApplePayPaymentToken(): ?string
+    {
+        return $this->applePayPaymentToken;
+    }
+
+    /**
+     * @param string $applePayPaymentToken
+     *
+     * @maps applePayPaymentToken
+     */
+    public function setApplePayPaymentToken(string $applePayPaymentToken): void
+    {
+        $this->applePayPaymentToken = $applePayPaymentToken;
+    }
+
+    /**
+     * @return ?Company
+     */
+    public function getCompany(): ?Company
+    {
+        return $this->company;
+    }
+
+    /**
+     * @param \Mollie\DTO\Object\Company $company
+     *
+     * @maps company
+     */
+    public function setCompany(Company $company): void
+    {
+        $this->company = $company;
+    }
+
+    public function jsonSerialize()
+    {
+        $result = [];
+        $result['cardToken'] = $this->getCardToken();
+        $result['webhookUrl'] = $this->getWebhookUrl();
+        $result['issuer'] = $this->getIssuer();
+        $result['customerId'] = $this->getCustomerId();
+        $result['applePayPaymentToken'] = $this->getApplePayPaymentToken();
+        $result['company'] = $this->getCompany() ? $this->getCompany()->jsonSerialize() : null;
+
+        return array_filter($result, static function ($val) {
+            return $val !== null && $val !== '';
+        });
+    }
+}

--- a/src/DTO/OrderData.php
+++ b/src/DTO/OrderData.php
@@ -16,6 +16,7 @@ use Address;
 use Country;
 use JsonSerializable;
 use Mollie\DTO\Object\Amount;
+use Mollie\DTO\Object\Payment;
 
 class OrderData implements JsonSerializable
 {
@@ -85,7 +86,7 @@ class OrderData implements JsonSerializable
     private $lines;
 
     /**
-     * @var array
+     * @var Payment
      */
     private $payment;
 
@@ -363,17 +364,19 @@ class OrderData implements JsonSerializable
     }
 
     /**
-     * @return array
+     * @return Payment
      */
-    public function getPayment()
+    public function getPayment(): Payment
     {
         return $this->payment;
     }
 
     /**
-     * @param array $payment
+     * @param \Mollie\DTO\Object\Payment $payment
+     *
+     * @maps payment
      */
-    public function setPayment($payment)
+    public function setPayment(Payment $payment): void
     {
         $this->payment = $payment;
     }
@@ -460,7 +463,7 @@ class OrderData implements JsonSerializable
             'locale' => $this->getLocale(),
             'orderNumber' => $this->getOrderNumber(),
             'lines' => $lines,
-            'payment' => $this->getPayment(),
+            'payment' => $this->getPayment()->jsonSerialize(),
             'consumerDateOfBirth' => $this->getConsumerDateOfBirth(),
         ];
 
@@ -476,7 +479,9 @@ class OrderData implements JsonSerializable
             $result['sequenceType'] = $this->sequenceType;
         }
 
-        return $result;
+        return array_filter($result, static function ($val) {
+            return $val !== null && $val !== '';
+        });
     }
 
     private function cleanUpInput($input, $defaultValue = 'N/A')

--- a/src/Service/PaymentMethod/PaymentMethodRestrictionValidation/B2bPaymentMethodRestrictionValidator.php
+++ b/src/Service/PaymentMethod/PaymentMethodRestrictionValidation/B2bPaymentMethodRestrictionValidator.php
@@ -74,7 +74,7 @@ class B2bPaymentMethodRestrictionValidator implements PaymentMethodRestrictionVa
 
     private function isVatNumberValid(): bool
     {
-        $billingAddressId = $this->context->getAddressInvoiceId();
+        $billingAddressId = $this->context->getInvoiceAddressId();
 
         /** @var \Address $billingAddress */
         $billingAddress = $this->addressRepository->findOneBy([


### PR DESCRIPTION
Additional info about company based on docs: https://docs.mollie.com/reference/v2/orders-api/create-order#payment-parameters

Inside jsonSerialize calling other jsonSerialize methods because we are using Mollie's package, which accepts request data as array. It is not json_encoded.