### PR TITLE
PIPRES-316: hookActionFrontControllerAfterInit replacement on deprecated versions

### DIFF
--- a/mollie.php
+++ b/mollie.php
@@ -1254,6 +1254,16 @@ class Mollie extends PaymentModule
 
     public function hookActionFrontControllerAfterInit(): void
     {
+        $this->frontControllerAfterInit();
+    }
+
+    public function hookActionFrontControllerInitAfter(): void
+    {
+        $this->frontControllerAfterInit();
+    }
+
+    private function frontControllerAfterInit(): void
+    {
         if (!$this->context->controller instanceof OrderControllerCore) {
             return;
         }

--- a/subscription/Install/HookInstaller.php
+++ b/subscription/Install/HookInstaller.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Mollie\Subscription\Install;
 
 use Mollie;
+use Mollie\Utility\PsVersionUtility;
 
 class HookInstaller extends AbstractInstaller
 {
@@ -19,8 +20,16 @@ class HookInstaller extends AbstractInstaller
 
     public function install(): bool
     {
+        $hooks = $this->getHooks();
+
+        if (PsVersionUtility::isPsVersionGreaterOrEqualTo(_PS_VERSION_, '1.7.7.0')) {
+            $hooks[] = 'actionFrontControllerInitAfter';
+        } else {
+            $hooks[] = 'actionFrontControllerAfterInit';
+        }
+
         /* @phpstan-ignore-next-line */
-        $this->module->registerHook($this->getHooks());
+        $this->module->registerHook($hooks);
 
         return true;
     }
@@ -39,7 +48,6 @@ class HookInstaller extends AbstractInstaller
             'actionObjectAddressDeleteAfter',
             'actionBeforeCartUpdateQty',
             'actionAjaxDieCartControllerDisplayAjaxUpdateBefore',
-            'actionFrontControllerAfterInit',
         ];
     }
 }

--- a/upgrade/Upgrade-6.0.4.php
+++ b/upgrade/Upgrade-6.0.4.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Mollie       https://www.mollie.nl
+ *
+ * @author      Mollie B.V. <info@mollie.nl>
+ * @copyright   Mollie B.V.
+ * @license     https://github.com/mollie/PrestaShop/blob/master/LICENSE.md
+ *
+ * @see        https://github.com/mollie/PrestaShop
+ */
+
+use Mollie\Utility\PsVersionUtility;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_6_0_4(Mollie $module): bool
+{
+    if (PsVersionUtility::isPsVersionGreaterOrEqualTo(_PS_VERSION_, '1.7.7.0')) {
+        $module->unregisterHook('actionFrontControllerAfterInit');
+        $module->registerHook('actionFrontControllerInitAfter');
+    }
+
+    return true;
+}


### PR DESCRIPTION
Warning messages appear on PS8.

![image](https://github.com/mollie/PrestaShop/assets/61560082/3444950e-2536-4419-b42e-b512b17dbf28)
