### PR TITLE
PIPRES-338: Mixed cart subscription listing improvements

### DIFF
--- a/controllers/front/recurringOrderDetail.php
+++ b/controllers/front/recurringOrderDetail.php
@@ -27,7 +27,7 @@
 use Mollie\Controller\AbstractMollieController;
 use Mollie\Subscription\Handler\FreeOrderCreationHandler;
 use Mollie\Subscription\Handler\SubscriptionCancellationHandler;
-use Mollie\Subscription\Logger\RecurringOrderPresenter;
+use Mollie\Subscription\Presenter\RecurringOrderPresenter;
 use Mollie\Subscription\Repository\RecurringOrderRepositoryInterface;
 
 class MollieRecurringOrderDetailModuleFrontController extends AbstractMollieController

--- a/controllers/front/subscriptions.php
+++ b/controllers/front/subscriptions.php
@@ -1,7 +1,7 @@
 <?php
 
 use Mollie\Repository\MolCustomerRepository;
-use Mollie\Subscription\Logger\RecurringOrdersPresenter;
+use Mollie\Subscription\Presenter\RecurringOrdersPresenter;
 
 /**
  * 2007-2020 PrestaShop and Contributors

--- a/src/Install/DatabaseTableInstaller.php
+++ b/src/Install/DatabaseTableInstaller.php
@@ -145,33 +145,24 @@ final class DatabaseTableInstaller implements InstallerInterface
 
     private function alterTableCommands(): bool
     {
-        $queries = [
-            [
-                'verification' => '
-                    SELECT COUNT(*) > 0 AS count
-                    FROM information_schema.columns
-                    WHERE TABLE_SCHEMA = "' . _DB_NAME_ . '" AND table_name = "' . _DB_PREFIX_ . 'mollie_payments" AND column_name = "mandate_id";
-                ',
-                'alter' => [
-                    '
-                        ALTER TABLE ' . _DB_PREFIX_ . 'mollie_payments
-                        ADD COLUMN mandate_id VARCHAR(64);
-                    ',
-                ],
-            ],
-        ];
+        $query = '
+            SELECT COUNT(*) > 0 AS count
+            FROM information_schema.columns
+            WHERE TABLE_SCHEMA = "' . _DB_NAME_ . '" AND table_name = "' . _DB_PREFIX_ . 'mollie_payments" AND column_name = "mandate_id";
+        ';
 
-        foreach ($queries as $query) {
-            /* only run if it doesn't exist */
-            if (Db::getInstance()->getValue($query['verification'])) {
-                continue;
-            }
+        /* only run if it doesn't exist */
+        if (Db::getInstance()->getValue($query)) {
+            return true;
+        }
 
-            foreach ($query['alter'] as $alterQuery) {
-                if (!Db::getInstance()->execute($alterQuery)) {
-                    return false;
-                }
-            }
+        $query = '
+            ALTER TABLE ' . _DB_PREFIX_ . 'mollie_payments
+            ADD COLUMN mandate_id VARCHAR(64);
+        ';
+
+        if (!Db::getInstance()->execute($query)) {
+            return false;
         }
 
         return true;

--- a/src/Install/DatabaseTableInstaller.php
+++ b/src/Install/DatabaseTableInstaller.php
@@ -21,12 +21,12 @@ final class DatabaseTableInstaller implements InstallerInterface
         $commands = $this->getCommands();
 
         foreach ($commands as $query) {
-            if (false == Db::getInstance()->execute($query)) {
+            if (!Db::getInstance()->execute($query)) {
                 return false;
             }
         }
 
-        return true;
+        return $this->alterTableCommands();
     }
 
     /**
@@ -141,5 +141,39 @@ final class DatabaseTableInstaller implements InstallerInterface
         ';
 
         return $sql;
+    }
+
+    private function alterTableCommands(): bool
+    {
+        $queries = [
+            [
+                'verification' => '
+                    SELECT COUNT(*) > 0 AS count
+                    FROM information_schema.columns
+                    WHERE TABLE_SCHEMA = "' . _DB_NAME_ . '" AND table_name = "' . _DB_PREFIX_ . 'mollie_payments" AND column_name = "mandate_id";
+                ',
+                'alter' => [
+                    '
+                        ALTER TABLE ' . _DB_PREFIX_ . 'mollie_payments
+                        ADD COLUMN mandate_id VARCHAR(64);
+                    ',
+                ],
+            ],
+        ];
+
+        foreach ($queries as $query) {
+            /* only run if it doesn't exist */
+            if (Db::getInstance()->getValue($query['verification'])) {
+                continue;
+            }
+
+            foreach ($query['alter'] as $alterQuery) {
+                if (!Db::getInstance()->execute($alterQuery)) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
     }
 }

--- a/src/Install/DatabaseTableUninstaller.php
+++ b/src/Install/DatabaseTableUninstaller.php
@@ -34,7 +34,6 @@ final class DatabaseTableUninstaller implements UninstallerInterface
         $sql[] = 'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'mol_country`;';
         $sql[] = 'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'mol_payment_method`;';
         $sql[] = 'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'mol_payment_method_issuer`;';
-        $sql[] = 'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'mol_order_payment_fee`;';
         $sql[] = 'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'mol_carrier_information`;';
         $sql[] = 'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'mol_pending_order_cart`;';
         $sql[] = 'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'mol_excluded_country`;';

--- a/src/Service/MailService.php
+++ b/src/Service/MailService.php
@@ -185,8 +185,16 @@ class MailService
         Customer $customer
     ): array {
         $product = new Product($recurringOrderProduct->id_product, false, $customer->id_lang);
-        $totalPrice = NumberUtility::toPrecision((float) $recurringOrder->total_tax_incl, 2);
-        $unitPrice = NumberUtility::toPrecision((float) $recurringOrderProduct->unit_price, 2);
+
+        $totalPrice = NumberUtility::toPrecision(
+            (float) $recurringOrder->total_tax_incl,
+            NumberUtility::DECIMAL_PRECISION
+        );
+
+        $unitPrice = NumberUtility::toPrecision(
+            (float) $recurringOrderProduct->unit_price,
+            NumberUtility::DECIMAL_PRECISION
+        );
 
         return [
             'subscription_reference' => $recurringOrder->mollie_subscription_id,

--- a/src/Service/MailService.php
+++ b/src/Service/MailService.php
@@ -28,7 +28,6 @@ use Mollie\Adapter\ProductAttributeAdapter;
 use Mollie\Adapter\ToolsAdapter;
 use Mollie\Subscription\Repository\RecurringOrderRepositoryInterface;
 use Mollie\Subscription\Repository\RecurringOrdersProductRepositoryInterface;
-use Mollie\Utility\NumberUtility;
 use MolRecurringOrder;
 use MolRecurringOrdersProduct;
 use Order;
@@ -186,7 +185,7 @@ class MailService
         Customer $customer
     ): array {
         $product = new Product($recurringOrderProduct->id_product, false, $customer->id_lang);
-        $totalPrice = NumberUtility::times((float) $recurringOrderProduct->unit_price, (float) $recurringOrderProduct->quantity);
+        $totalPrice = $recurringOrder->total_tax_incl;
         $unitPrice = new Number((string) $recurringOrderProduct->unit_price);
 
         return [

--- a/src/Service/MailService.php
+++ b/src/Service/MailService.php
@@ -28,12 +28,12 @@ use Mollie\Adapter\ProductAttributeAdapter;
 use Mollie\Adapter\ToolsAdapter;
 use Mollie\Subscription\Repository\RecurringOrderRepositoryInterface;
 use Mollie\Subscription\Repository\RecurringOrdersProductRepositoryInterface;
+use Mollie\Utility\NumberUtility;
 use MolRecurringOrder;
 use MolRecurringOrdersProduct;
 use Order;
 use OrderState;
 use PDF;
-use PrestaShop\Decimal\Number;
 use Product;
 use State;
 use Tools;
@@ -185,13 +185,13 @@ class MailService
         Customer $customer
     ): array {
         $product = new Product($recurringOrderProduct->id_product, false, $customer->id_lang);
-        $totalPrice = $recurringOrder->total_tax_incl;
-        $unitPrice = new Number((string) $recurringOrderProduct->unit_price);
+        $totalPrice = NumberUtility::toPrecision((float) $recurringOrder->total_tax_incl, 2);
+        $unitPrice = NumberUtility::toPrecision((float) $recurringOrderProduct->unit_price, 2);
 
         return [
             'subscription_reference' => $recurringOrder->mollie_subscription_id,
             'product_name' => $product->name,
-            'unit_price' => $this->toolsAdapter->displayPrice($unitPrice->toPrecision(2), new Currency($recurringOrder->id_currency)),
+            'unit_price' => $this->toolsAdapter->displayPrice($unitPrice, new Currency($recurringOrder->id_currency)),
             'quantity' => $recurringOrderProduct->quantity,
             'total_price' => $this->toolsAdapter->displayPrice($totalPrice, new Currency($recurringOrder->id_currency)),
             'firstName' => $customer->firstname,

--- a/subscription/Entity/MolRecurringOrder.php
+++ b/subscription/Entity/MolRecurringOrder.php
@@ -29,6 +29,9 @@ class MolRecurringOrder extends ObjectModel
     /** @var string */
     public $status;
 
+    /** @var float */
+    public $total_tax_incl;
+
     /** @var string */
     public $payment_method;
 
@@ -71,6 +74,7 @@ class MolRecurringOrder extends ObjectModel
             'mollie_customer_id' => ['type' => self::TYPE_STRING, 'validate' => 'isString'],
             'description' => ['type' => self::TYPE_STRING, 'validate' => 'isString'],
             'status' => ['type' => self::TYPE_STRING, 'validate' => 'isString'],
+            'total_tax_incl' => ['type' => self::TYPE_FLOAT, 'validate' => 'isFloat'],
             'payment_method' => ['type' => self::TYPE_STRING, 'validate' => 'isString'],
             'next_payment' => ['type' => self::TYPE_DATE],
             'reminder_at' => ['type' => self::TYPE_DATE],

--- a/subscription/Factory/CreateSubscriptionDataFactory.php
+++ b/subscription/Factory/CreateSubscriptionDataFactory.php
@@ -74,10 +74,14 @@ class CreateSubscriptionDataFactory
         $currency = $this->currencyAdapter->getById((int) $order->id_currency);
         $description = $this->subscriptionDescription->getSubscriptionDescription($order);
 
+        $orderTotal = (float) $subscriptionProduct['total_price_tax_incl']
+            + (float) $order->total_wrapping_tax_incl
+            + (float) $order->total_shipping_tax_incl;
+
         /**
          * NOTE: we will only send product price as total for subscriptions
          */
-        $orderAmount = new Amount((float) $subscriptionProduct['total_price_tax_incl'], $currency->iso_code);
+        $orderAmount = new Amount($orderTotal, $currency->iso_code);
         $subscriptionData = new SubscriptionDataDTO(
             $molCustomer->customer_id,
             $orderAmount,

--- a/subscription/Grid/SubscriptionGridDefinitionFactory.php
+++ b/subscription/Grid/SubscriptionGridDefinitionFactory.php
@@ -104,10 +104,10 @@ class SubscriptionGridDefinitionFactory extends AbstractGridDefinitionFactory
                     'sortable' => true,
                 ])
             )
-            ->add((new DataColumn('unit_price'))
-                ->setName($this->module->l('Unit price', self::FILE_NAME))
+            ->add((new DataColumn('total_price'))
+                ->setName($this->module->l('Total price', self::FILE_NAME))
                 ->setOptions([
-                    'field' => 'unit_price',
+                    'field' => 'total_price',
                     'sortable' => true,
                 ])
             )
@@ -220,14 +220,14 @@ class SubscriptionGridDefinitionFactory extends AbstractGridDefinitionFactory
                 ])
                 ->setAssociatedColumn('status')
             )
-            ->add((new Filter('unit_price', MoneyType::class))
+            ->add((new Filter('total_price', MoneyType::class))
                 ->setTypeOptions([
                     'required' => false,
                     'attr' => [
-                        'placeholder' => $this->module->l('Unit price', self::FILE_NAME),
+                        'placeholder' => $this->module->l('Total price', self::FILE_NAME),
                     ],
                 ])
-                ->setAssociatedColumn('unit_price')
+                ->setAssociatedColumn('total_price')
             )
             ->add((new Filter('iso_code', TextType::class))
                 ->setTypeOptions([

--- a/subscription/Grid/SubscriptionGridQueryBuilder.php
+++ b/subscription/Grid/SubscriptionGridQueryBuilder.php
@@ -47,7 +47,7 @@ class SubscriptionGridQueryBuilder extends AbstractDoctrineQueryBuilder
         $qb = $this->getQueryBuilder($searchCriteria->getFilters())
             ->select('recurring_order.*')
             ->addSelect($this->getNameField() . ' as fullname')
-            ->addSelect('ROUND(orders.total_paid, 2) as unit_price')
+            ->addSelect('recurring_order.total_tax_incl as total_price')
             ->addSelect('currency.iso_code')
         ;
 
@@ -106,7 +106,7 @@ class SubscriptionGridQueryBuilder extends AbstractDoctrineQueryBuilder
             'fullname' => $this->getNameField(),
             'description' => 'recurring_order.description',
             'status' => 'recurring_order.status',
-            'unit_price' => 'orders.total_paid',
+            'total_price' => 'recurring_order.total_tax_incl',
             'iso_code' => 'currency.iso_code',
         ];
 

--- a/subscription/Grid/SubscriptionGridQueryBuilder.php
+++ b/subscription/Grid/SubscriptionGridQueryBuilder.php
@@ -47,7 +47,7 @@ class SubscriptionGridQueryBuilder extends AbstractDoctrineQueryBuilder
         $qb = $this->getQueryBuilder($searchCriteria->getFilters())
             ->select('recurring_order.*')
             ->addSelect($this->getNameField() . ' as fullname')
-            ->addSelect('recurring_order.total_tax_incl as total_price')
+            ->addSelect('ROUND(recurring_order.total_tax_incl, 2) as total_price')
             ->addSelect('currency.iso_code')
         ;
 

--- a/subscription/Handler/SubscriptionCreationHandler.php
+++ b/subscription/Handler/SubscriptionCreationHandler.php
@@ -85,6 +85,7 @@ class SubscriptionCreationHandler
         $recurringOrder->id_address_invoice = $order->id_address_invoice;
         $recurringOrder->description = $subscription->description;
         $recurringOrder->status = $subscription->status;
+        $recurringOrder->total_tax_incl = (float) $subscription->amount->value;
         $recurringOrder->payment_method = $method;
         $recurringOrder->next_payment = $subscription->nextPaymentDate;
         $recurringOrder->reminder_at = $subscription->nextPaymentDate; //todo: add logic to get reminder date when reminder is done

--- a/subscription/Install/DatabaseTableInstaller.php
+++ b/subscription/Install/DatabaseTableInstaller.php
@@ -13,7 +13,7 @@ final class DatabaseTableInstaller extends AbstractInstaller
         $commands = $this->getCommands();
 
         foreach ($commands as $query) {
-            if (false == Db::getInstance()->execute($query)) {
+            if (!Db::getInstance()->execute($query)) {
                 return false;
             }
         }
@@ -66,19 +66,6 @@ final class DatabaseTableInstaller extends AbstractInstaller
     private function alterTableCommands(): bool
     {
         $queries = [
-            [
-                'verification' => '
-                    SELECT COUNT(*) > 0 AS count
-                    FROM information_schema.columns
-                    WHERE TABLE_SCHEMA = "' . _DB_NAME_ . '" AND table_name = "' . _DB_PREFIX_ . 'mollie_payments" AND column_name = "mandate_id";
-                ',
-                'alter' => [
-                    '
-                        ALTER TABLE ' . _DB_PREFIX_ . 'mollie_payments
-                        ADD COLUMN mandate_id VARCHAR(64);
-                    ',
-                ],
-            ],
             [
                 'verification' => '
                     SELECT COUNT(*) > 0 AS count

--- a/subscription/Presenter/OrderPresenter.php
+++ b/subscription/Presenter/OrderPresenter.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Mollie\Subscription\Presenter;
+
+class OrderPresenter
+{
+    public function present(
+        \Order $order,
+        int $recurringOrderProductAttributeId,
+        float $recurringOrderTotalTaxIncl
+    ): RecurringOrderLazyArray {
+        $orderProducts = $order->getCartProducts();
+
+        foreach ($orderProducts as $orderProduct) {
+            if ((int) $orderProduct['id_product_attribute'] !== $recurringOrderProductAttributeId) {
+                $order->total_paid_tax_excl -= (float) $orderProduct['total_price_tax_excl'];
+
+                continue;
+            }
+
+            $order->total_products = (float) $orderProduct['total_price_tax_excl'];
+            $order->total_products_wt = (float) $orderProduct['total_price_tax_incl'];
+            $order->total_paid_tax_incl = $recurringOrderTotalTaxIncl;
+            $order->total_paid = $recurringOrderTotalTaxIncl;
+
+            break;
+        }
+
+        $orderLazyArray = new RecurringOrderLazyArray($order);
+
+        $orderLazyArray->setRecurringOrderProductAttributeId($recurringOrderProductAttributeId);
+
+        return $orderLazyArray;
+    }
+}

--- a/subscription/Presenter/RecurringOrderLazyArray.php
+++ b/subscription/Presenter/RecurringOrderLazyArray.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Mollie\Subscription\Presenter;
+
+use PrestaShop\PrestaShop\Adapter\Presenter\Order\OrderLazyArray;
+
+class RecurringOrderLazyArray extends OrderLazyArray
+{
+    /** @var int */
+    private $recurringOrderProductAttributeId;
+
+    public function setRecurringOrderProductAttributeId(int $recurringOrderProductAttributeId): void
+    {
+        $this->recurringOrderProductAttributeId = $recurringOrderProductAttributeId;
+    }
+
+    /**
+     * @arrayAccess
+     *
+     * @return array
+     */
+    public function getProducts(): array
+    {
+        $subscriptionProduct = [];
+
+        $orderProducts = parent::getProducts();
+
+        foreach ($orderProducts as $orderProduct) {
+            if ((int) $orderProduct['id_product_attribute'] !== $this->recurringOrderProductAttributeId) {
+                continue;
+            }
+
+            $subscriptionProduct[] = $orderProduct;
+
+            break;
+        }
+
+        return $subscriptionProduct;
+    }
+}

--- a/subscription/Presenter/RecurringOrderPresenter.php
+++ b/subscription/Presenter/RecurringOrderPresenter.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Mollie\Subscription\Logger;
+namespace Mollie\Subscription\Presenter;
 
 use Currency;
 use Mollie\Adapter\Language;
@@ -10,7 +10,6 @@ use Mollie\Subscription\Api\MethodApi;
 use Mollie\Subscription\Repository\RecurringOrderRepositoryInterface;
 use Mollie\Subscription\Repository\RecurringOrdersProductRepositoryInterface;
 use Order;
-use PrestaShop\PrestaShop\Adapter\Presenter\Order\OrderPresenter;
 use Product;
 
 class RecurringOrderPresenter
@@ -23,17 +22,21 @@ class RecurringOrderPresenter
     private $language;
     /** @var MethodApi */
     private $methodApi;
+    /** @var OrderPresenter */
+    private $orderPresenter;
 
     public function __construct(
         RecurringOrderRepositoryInterface $recurringOrderRepository,
         RecurringOrdersProductRepositoryInterface $recurringOrdersProductRepository,
         Language $language,
-        MethodApi $methodApi
+        MethodApi $methodApi,
+        OrderPresenter $orderPresenter
     ) {
         $this->recurringOrderRepository = $recurringOrderRepository;
         $this->recurringOrdersProductRepository = $recurringOrdersProductRepository;
         $this->language = $language;
         $this->methodApi = $methodApi;
+        $this->orderPresenter = $orderPresenter;
     }
 
     public function present(int $recurringOrderId): array
@@ -56,7 +59,11 @@ class RecurringOrderPresenter
         $recurringOrderData['recurring_order'] = $recurringOrder;
         $recurringOrderData['recurring_product'] = $recurringProduct;
         $recurringOrderData['product'] = $product;
-        $recurringOrderData['order'] = (new OrderPresenter())->present($order);
+        $recurringOrderData['order'] = $this->orderPresenter->present(
+            $order,
+            (int) $recurringProduct->id_product_attribute,
+            (float) $recurringOrder->total_tax_incl
+        );
         $recurringOrderData['payment_methods'] = $this->methodApi->getMethodsForFirstPayment($this->language->getContextLanguage()->locale, $currency->iso_code);
 
         return $recurringOrderData;

--- a/subscription/Presenter/RecurringOrderPresenter.php
+++ b/subscription/Presenter/RecurringOrderPresenter.php
@@ -9,6 +9,7 @@ use Mollie\Adapter\Language;
 use Mollie\Subscription\Api\MethodApi;
 use Mollie\Subscription\Repository\RecurringOrderRepositoryInterface;
 use Mollie\Subscription\Repository\RecurringOrdersProductRepositoryInterface;
+use Mollie\Utility\NumberUtility;
 use Order;
 use Product;
 
@@ -62,7 +63,7 @@ class RecurringOrderPresenter
         $recurringOrderData['order'] = $this->orderPresenter->present(
             $order,
             (int) $recurringProduct->id_product_attribute,
-            (float) $recurringOrder->total_tax_incl
+            NumberUtility::toPrecision((float) $recurringOrder->total_tax_incl, 2)
         );
         $recurringOrderData['payment_methods'] = $this->methodApi->getMethodsForFirstPayment($this->language->getContextLanguage()->locale, $currency->iso_code);
 

--- a/subscription/Presenter/RecurringOrderPresenter.php
+++ b/subscription/Presenter/RecurringOrderPresenter.php
@@ -63,7 +63,10 @@ class RecurringOrderPresenter
         $recurringOrderData['order'] = $this->orderPresenter->present(
             $order,
             (int) $recurringProduct->id_product_attribute,
-            NumberUtility::toPrecision((float) $recurringOrder->total_tax_incl, 2)
+            NumberUtility::toPrecision(
+                (float) $recurringOrder->total_tax_incl,
+                NumberUtility::DECIMAL_PRECISION
+            )
         );
         $recurringOrderData['payment_methods'] = $this->methodApi->getMethodsForFirstPayment($this->language->getContextLanguage()->locale, $currency->iso_code);
 

--- a/subscription/Presenter/RecurringOrdersPresenter.php
+++ b/subscription/Presenter/RecurringOrdersPresenter.php
@@ -2,19 +2,17 @@
 
 declare(strict_types=1);
 
-namespace Mollie\Subscription\Logger;
+namespace Mollie\Subscription\Presenter;
 
 use Currency;
 use Mollie\Adapter\Context;
 use Mollie\Adapter\Language;
 use Mollie\Adapter\Link;
 use Mollie\Adapter\ToolsAdapter;
-use Mollie\Repository\OrderRepositoryInterface;
 use Mollie\Subscription\Repository\RecurringOrderRepositoryInterface;
 use Mollie\Subscription\Repository\RecurringOrdersProductRepositoryInterface;
 use Mollie\Utility\NumberUtility;
 use MolRecurringOrder;
-use Order;
 use Product;
 
 class RecurringOrdersPresenter
@@ -29,8 +27,6 @@ class RecurringOrdersPresenter
     private $language;
     /** @var ToolsAdapter */
     private $tools;
-    /** @var OrderRepositoryInterface */
-    private $orderRepository;
     /** @var Context */
     private $context;
 
@@ -40,7 +36,6 @@ class RecurringOrdersPresenter
         Link $link,
         Language $language,
         ToolsAdapter $tools,
-        OrderRepositoryInterface $orderRepository,
         Context $context
     ) {
         $this->recurringOrderRepository = $recurringOrderRepository;
@@ -48,7 +43,6 @@ class RecurringOrdersPresenter
         $this->recurringOrdersProductRepository = $recurringOrdersProductRepository;
         $this->language = $language;
         $this->tools = $tools;
-        $this->orderRepository = $orderRepository;
         $this->context = $context;
     }
 
@@ -64,11 +58,6 @@ class RecurringOrdersPresenter
         $recurringOrdersPresentData = [];
         /** @var MolRecurringOrder $recurringOrder */
         foreach ($recurringOrders as $recurringOrder) {
-            /** @var Order $order */
-            $order = $this->orderRepository->findOneBy([
-                'id_order' => $recurringOrder->id_order,
-            ]);
-
             $recurringProduct = $this->recurringOrdersProductRepository->findOneBy([
                 'id_mol_recurring_orders_product' => $recurringOrder->id,
             ]);
@@ -79,7 +68,7 @@ class RecurringOrdersPresenter
             $recurringOrderData['recurring_order'] = $recurringOrder;
             $recurringOrderData['details_url'] = $this->link->getModuleLink('mollie', 'recurringOrderDetail', ['id_mol_recurring_order' => $recurringOrder->id]);
             $recurringOrderData['product_name'] = is_array($product->name) ? $product->name[$this->context->getLanguageId()] : $product->name;
-            $recurringOrderData['total_price'] = $this->tools->displayPrice(NumberUtility::toPrecision((float) $order->total_paid, 2), new Currency($recurringOrder->id_currency));
+            $recurringOrderData['total_price'] = $this->tools->displayPrice(NumberUtility::toPrecision((float) $recurringOrder->total_tax_incl, 2), new Currency($recurringOrder->id_currency));
             $recurringOrderData['currency'] = new \Currency($recurringOrder->id_currency);
             $recurringOrdersPresentData[] = $recurringOrderData;
         }

--- a/tests/Integration/Subscription/Presenter/OrderPresenterTest.php
+++ b/tests/Integration/Subscription/Presenter/OrderPresenterTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Mollie\Tests\Integration\Subscription\Presenter;
+
+use Mollie\Subscription\Presenter\OrderPresenter;
+use Mollie\Tests\Integration\BaseTestCase;
+
+class OrderPresenterTest extends BaseTestCase
+{
+    public function testItSuccessfullyPresentsOrder(): void
+    {
+        $products = [
+            [
+                'product_attribute_id' => 1,
+                'id_product_attribute' => 1,
+                'total_price_tax_excl' => 10.00,
+                'product_price' => 10.00,
+                'total_price' => 10.00,
+                'total_price_tax_incl' => 12.10,
+                'product_price_wt' => 12.10,
+                'total_wt' => 12.10,
+                'product_name' => 'test-product-1',
+                'product_quantity' => 1,
+                'product_id' => 1,
+                'id_customization' => 1,
+            ],
+            [
+                'product_attribute_id' => 2,
+                'id_product_attribute' => 2,
+                'total_price_tax_excl' => 100.00,
+                'product_price' => 100.00,
+                'total_price' => 100.00,
+                'total_price_tax_incl' => 121.00,
+                'product_price_wt' => 121.00,
+                'total_wt' => 121.00,
+                'product_name' => 'test-product-2',
+                'product_quantity' => 2,
+                'product_id' => 2,
+                'id_customization' => 1,
+            ],
+            [
+                'product_attribute_id' => 3,
+                'id_product_attribute' => 3,
+                'total_price_tax_excl' => 1000.00,
+                'product_price' => 1000.00,
+                'total_price' => 1000.00,
+                'total_price_tax_incl' => 1210.00,
+                'product_price_wt' => 1210.00,
+                'total_wt' => 1210.00,
+                'product_name' => 'test-product-3',
+                'product_quantity' => 3,
+                'product_id' => 3,
+                'id_customization' => 1,
+            ],
+        ];
+
+        $order = $this->createMock(\Order::class);
+        $order->total_paid_tax_excl = 1500;
+        $order->id_currency = 1;
+        $order->method('getCartProducts')->willReturn($products);
+        $order->method('getProducts')->willReturn($products);
+
+        $orderPresenter = new OrderPresenter();
+
+        $result = $orderPresenter->present(
+            $order,
+            3,
+            1300
+        );
+
+        $this->assertCount(1, $result->getProducts());
+        $this->assertEquals(3, $result->getProducts()[0]['id_product_attribute']);
+    }
+}

--- a/tests/Integration/Subscription/Presenter/OrderPresenterTest.php
+++ b/tests/Integration/Subscription/Presenter/OrderPresenterTest.php
@@ -60,7 +60,8 @@ class OrderPresenterTest extends BaseTestCase
         $order->method('getCartProducts')->willReturn($products);
         $order->method('getProducts')->willReturn($products);
 
-        $orderPresenter = new OrderPresenter();
+        /** @var OrderPresenter $orderPresenter */
+        $orderPresenter = $this->getService(OrderPresenter::class);
 
         $result = $orderPresenter->present(
             $order,

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,9 +1,21 @@
 <?php
 
-$projectDir = __DIR__ . '/../';
-require_once $projectDir . 'vendor/autoload.php';
-
 $rootDirectory = __DIR__ . '/../../../';
-require_once $rootDirectory . 'autoload.php';
-require_once $rootDirectory . 'vendor/autoload.php';
+$projectDir = __DIR__ . '/../';
+
+require_once $projectDir . 'vendor/autoload.php';
 require_once $rootDirectory . 'config/config.inc.php';
+
+if (file_exists($rootDirectory . 'vendor/autoload.php')) {
+    require_once $rootDirectory . 'vendor/autoload.php';
+}
+
+if (file_exists($rootDirectory . 'autoload.php')) {
+    require_once $rootDirectory . 'autoload.php';
+}
+
+if (class_exists(AppKernel::class)) {
+    $kernel = new AppKernel('dev', _PS_MODE_DEV_);
+    $kernel->boot();
+}
+// any actions to apply before any given tests can be done here

--- a/upgrade/Upgrade-6.0.4.php
+++ b/upgrade/Upgrade-6.0.4.php
@@ -112,16 +112,16 @@ function updateOrderStatusNames604(Mollie $module)
 function modifyExistingTables604(): bool
 {
     $sql = '
-    SELECT COUNT(*) > 0 AS count
-    FROM information_schema.columns
-    WHERE TABLE_SCHEMA = "' . _DB_NAME_ . '" AND table_name = "' . _DB_PREFIX_ . 'mol_recurring_order" AND column_name = "total_tax_incl";
+        SELECT COUNT(*) > 0 AS count
+        FROM information_schema.columns
+        WHERE TABLE_SCHEMA = "' . _DB_NAME_ . '" AND table_name = "' . _DB_PREFIX_ . 'mol_recurring_order" AND column_name = "total_tax_incl";
     ';
 
     /** only add it if it doesn't exist */
     if (!(int) Db::getInstance()->getValue($sql)) {
         $sql = '
-        ALTER TABLE ' . _DB_PREFIX_ . 'mol_recurring_order
-        ADD COLUMN total_tax_incl decimal(20, 6) NOT NULL;
+            ALTER TABLE ' . _DB_PREFIX_ . 'mol_recurring_order
+            ADD COLUMN total_tax_incl decimal(20, 6) NOT NULL;
         ';
 
         try {
@@ -147,6 +147,30 @@ function modifyExistingTables604(): bool
         PrestaShopLogger::addLog("Mollie upgrade error: {$e->getMessage()}");
 
         return false;
+    }
+
+    $sql = '
+        SELECT COUNT(*) > 0 AS count
+        FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = "' . _DB_NAME_ . '" AND TABLE_NAME = "' . _DB_PREFIX_ . 'mollie_payments" AND COLUMN_NAME = "mandate_id"
+    ';
+
+    /** only add it if it doesn't exist */
+    if (!Db::getInstance()->getValue($sql)) {
+        $sql = '
+            ALTER TABLE ' . _DB_PREFIX_ . 'mollie_payments
+            ADD `mandate_id` VARCHAR(64);
+        ';
+
+        try {
+            if (!Db::getInstance()->execute($sql)) {
+                return false;
+            }
+        } catch (Exception $e) {
+            PrestaShopLogger::addLog("Mollie upgrade error: {$e->getMessage()}");
+
+            return false;
+        }
     }
 
     return true;


### PR DESCRIPTION
Added alter table improvements for install process as following tables are not being removed during uninstall process at all so there were several merchants, which had previously installed Mollie module and came back to install it after some time. Due to this flow some columns were not appended as no upgrade script was executed.

Improvements for subscription order listing in BO and FO.

In BO instead of unit_price started showing total order price. Additionally changed email data for total price.
In FO improved subscriptions order listing to show only subscription order total price (previously full mixed order price was shown)
In FO added decorated OrderLazyArray class and changed OrderProvider to give only products and totals for subscription context. Adding example of recurring order, which had in the cart only subscription product to show that prices are the same. Original order had multiple random products but only one subscription.

![image](https://github.com/mollie/PrestaShop/assets/61560082/812cb489-dcb1-495c-90c7-f9171d8510d4)
Original order:
![image](https://github.com/mollie/PrestaShop/assets/61560082/64c70598-1afc-4864-8033-3c924b92973b)
![image](https://github.com/mollie/PrestaShop/assets/61560082/4988e30c-a474-491d-8c96-71cb097d232c)
Subscription order view without other products
![image](https://github.com/mollie/PrestaShop/assets/61560082/b2c06023-f2bb-4600-85c8-bb5b2ea51040)
New recurring order from webhook
![image](https://github.com/mollie/PrestaShop/assets/61560082/a6f35058-8db8-4505-a27e-ffe44863964a)
