### PR TITLE
PIPRES-113: Billie payment method additional check for vat number

### DIFF
--- a/src/Repository/AddressFormatRepository.php
+++ b/src/Repository/AddressFormatRepository.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Mollie\Repository;
+
+class AddressFormatRepository extends AbstractRepository implements AddressFormatRepositoryInterface
+{
+    public function __construct()
+    {
+        parent::__construct(\AddressFormat::class);
+    }
+}

--- a/src/Repository/AddressFormatRepositoryInterface.php
+++ b/src/Repository/AddressFormatRepositoryInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Mollie\Repository;
+
+interface AddressFormatRepositoryInterface extends ReadOnlyRepositoryInterface
+{
+}

--- a/src/ServiceProvider/BaseServiceProvider.php
+++ b/src/ServiceProvider/BaseServiceProvider.php
@@ -41,6 +41,8 @@ use Mollie\Provider\Shipment\AutomaticShipmentSenderStatusesProvider;
 use Mollie\Provider\Shipment\AutomaticShipmentSenderStatusesProviderInterface;
 use Mollie\Provider\UpdateMessageProvider;
 use Mollie\Provider\UpdateMessageProviderInterface;
+use Mollie\Repository\AddressFormatRepository;
+use Mollie\Repository\AddressFormatRepositoryInterface;
 use Mollie\Repository\AddressRepository;
 use Mollie\Repository\AddressRepositoryInterface;
 use Mollie\Repository\CartRepository;
@@ -158,6 +160,7 @@ final class BaseServiceProvider
             );
 
         $this->addService($container, AddressRepositoryInterface::class, $container->get(AddressRepository::class));
+        $this->addService($container, AddressFormatRepositoryInterface::class, $container->get(AddressFormatRepository::class));
         $this->addService($container, TaxRulesGroupRepositoryInterface::class, $container->get(TaxRulesGroupRepository::class));
         $this->addService($container, TaxRuleRepositoryInterface::class, $container->get(TaxRuleRepository::class));
         $this->addService($container, TaxRepositoryInterface::class, $container->get(TaxRepository::class));

--- a/tests/Integration/Service/PaymentMethod/PaymentMethodRestrictionValidation/B2bPaymentMethodRestrictionValidatorTest.php
+++ b/tests/Integration/Service/PaymentMethod/PaymentMethodRestrictionValidation/B2bPaymentMethodRestrictionValidatorTest.php
@@ -59,6 +59,46 @@ class B2bPaymentMethodRestrictionValidatorTest extends BaseTestCase
         $this->assertEquals(true, $valid);
     }
 
+    public function testItSuccessfullyValidatedIsValidMissingVatNumberInFormat(): void
+    {
+        Configuration::set('PS_B2B_ENABLE', 1);
+
+        $molPaymentMethod = new \MolPaymentMethod();
+        $molPaymentMethod->id_method = PaymentMethod::BILLIE;
+
+        $customer = CustomerFactory::create([
+            'siret' => 'test-siret-number',
+        ]);
+
+        $billingAddress = AddressFactory::create([
+            'vat_number' => 'vat-number',
+        ]);
+
+        $addressFormat = new \AddressFormat($billingAddress->id_country);
+
+        $originalCountryFormat = $addressFormat->format;
+
+        $addressFormat->format = 'test-format';
+        $addressFormat->save();
+
+        $this->contextBuilder->setCart(CartFactory::create());
+        $this->contextBuilder->getContext()->cart->id_address_invoice = $billingAddress->id;
+        $this->contextBuilder->getContext()->cart->id_customer = $customer->id;
+
+        /** @var B2bPaymentMethodRestrictionValidator $b2bPaymentMethodRestrictionValidator */
+        $b2bPaymentMethodRestrictionValidator = $this->getService(B2bPaymentMethodRestrictionValidator::class);
+
+        $supports = $b2bPaymentMethodRestrictionValidator->supports($molPaymentMethod);
+
+        $valid = $b2bPaymentMethodRestrictionValidator->isValid($molPaymentMethod);
+
+        $addressFormat->format = $originalCountryFormat;
+        $addressFormat->save();
+
+        $this->assertEquals(true, $supports);
+        $this->assertEquals(true, $valid);
+    }
+
     public function testItUnsuccessfullyValidatedIsValidMethodNotSupported(): void
     {
         Configuration::set('PS_B2B_ENABLE', 1);


### PR DESCRIPTION
Added condition to check if vat_number is included into address format. If not, identification number is still left as condition for b2b customer.