### PR TITLE
PIPRES-348: Form handler compatibility for lower PS versions

### DIFF
--- a/views/templates/admin/Subscription/subscriptions-settings.html.twig
+++ b/views/templates/admin/Subscription/subscriptions-settings.html.twig
@@ -22,6 +22,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  * #}
+
 {% set subscriptionOptions = subscriptionOptionsForm %}
 
 {% if subscriptionOptionsForm.subscription_options is defined and subscriptionOptionsForm.subscription_options %}

--- a/views/templates/admin/Subscription/subscriptions-settings.html.twig
+++ b/views/templates/admin/Subscription/subscriptions-settings.html.twig
@@ -24,7 +24,9 @@
  * #}
 
 {% if subscriptionOptionsForm.subscription_options is defined and subscriptionOptionsForm.subscription_options %}
-  {% set subscriptionOptionsForm = subscriptionOptionsForm.subscription_options %}
+  {% set subscriptionOptions = subscriptionOptionsForm.subscription_options %}
+{% else %}
+  {% set subscriptionOptions = subscriptionOptionsForm %}
 {% endif %}
 
 {% block subscription_options %}
@@ -41,11 +43,10 @@
               {# TODO translations will be enabled only after we will migrate to moden translation system #}
               {{ ps.label_with_help('Carrier to use in subscription orders'|trans, 'WARNING: do not change selection after getting first subscription order.'|trans) }}
               <div class="col-sm">
-                {{ form_errors(subscriptionOptionsForm.carrier) }}
-                {{ form_widget(subscriptionOptionsForm.carrier) }}
+                {{ form_errors(subscriptionOptions.carrier) }}
+                {{ form_widget(subscriptionOptions.carrier) }}
               </div>
             </div>
-            {{ form_rest(subscriptionOptionsForm) }}
           </div>
         </div>
         <div class="card-footer">
@@ -55,6 +56,7 @@
           </div>
         </div>
       </div>
+      {{ form_rest(subscriptionOptionsForm) }}
       {{ form_end(subscriptionOptionsForm) }}
     </div>
   </div>

--- a/views/templates/admin/Subscription/subscriptions-settings.html.twig
+++ b/views/templates/admin/Subscription/subscriptions-settings.html.twig
@@ -22,11 +22,10 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  * #}
+{% set subscriptionOptions = subscriptionOptionsForm %}
 
 {% if subscriptionOptionsForm.subscription_options is defined and subscriptionOptionsForm.subscription_options %}
   {% set subscriptionOptions = subscriptionOptionsForm.subscription_options %}
-{% else %}
-  {% set subscriptionOptions = subscriptionOptionsForm %}
 {% endif %}
 
 {% block subscription_options %}


### PR DESCRIPTION
For lower PS versions noticed that _token is missing in form data and CSRF token error appears. Found out that we were trying to use only subscription_options values for the form.