### PR TITLE
PIPRES-319: Lock webhook controller

### DIFF
--- a/controllers/front/webhook.php
+++ b/controllers/front/webhook.php
@@ -59,10 +59,14 @@ class MollieWebhookModuleFrontController extends AbstractMollieController
 
         if (!$transactionId) {
             $this->respond('failed', HttpStatusCode::HTTP_UNPROCESSABLE_ENTITY, 'Missing transaction id');
+
+            exit;
         }
 
         if (!$this->module->getApiClient()) {
             $this->respond('failed', HttpStatusCode::HTTP_UNAUTHORIZED, 'API key is missing or incorrect');
+
+            exit;
         }
 
         /** @var Lock $lock */
@@ -85,10 +89,14 @@ class MollieWebhookModuleFrontController extends AbstractMollieController
             $errorHandler->handle($exception, $exception->getCode(), false);
 
             $this->respond('failed', HttpStatusCode::HTTP_BAD_REQUEST, 'Failed to lock process');
+
+            exit;
         }
 
         if (!$acquired) {
             $this->respond('failed', HttpStatusCode::HTTP_BAD_REQUEST, 'Another process is locked');
+
+            exit;
         }
 
         try {
@@ -106,6 +114,8 @@ class MollieWebhookModuleFrontController extends AbstractMollieController
             $errorHandler->handle($exception, $exception->getCode(), false);
 
             $this->respond('failed', HttpStatusCode::HTTP_BAD_REQUEST, 'Failed to process webhook');
+
+            exit;
         }
 
         $this->respond('success', HttpStatusCode::HTTP_OK, $result);

--- a/src/Logger/PrestaLogger.php
+++ b/src/Logger/PrestaLogger.php
@@ -16,6 +16,9 @@ use Mollie\Exception\NotImplementedException;
 
 class PrestaLogger implements PrestaLoggerInterface
 {
+    // TODO integrate sentry into logger service
+    // TODO integrate logs switch into logger service
+
     public function emergency($message, array $context = [])
     {
         throw new NotImplementedException('not implemented method');


### PR DESCRIPTION
Locking mechanism for webhook controller. 

Additionally improved a bit webhook error handle logic. Later on all processing should be moved to separate service out of controller.

Release is not called as destruct method will be called to release key. Tried to interrupt program to check what happens without release execution, but everything works fine in the next execution. 

![image](https://github.com/mollie/PrestaShop/assets/61560082/5a8275f4-6733-460f-8e0a-e1c697a7cbcc)
