### PR TITLE
Do not instantiate the module to optimize performance in module list page.

### DIFF
--- a/mollie.php
+++ b/mollie.php
@@ -88,7 +88,7 @@ class Mollie extends PaymentModule
         $this->tab = 'payments_gateways';
         $this->version = '6.0.5';
         $this->author = 'Mollie B.V.';
-        $this->need_instance = 1;
+        $this->need_instance = 0;
         $this->bootstrap = true;
         $this->module_key = 'a48b2f8918358bcbe6436414f48d8915';
 


### PR DESCRIPTION
When you instantiate module, it will:

- Compile
- Load env vars
- set API keys 
- etc etc 

So we can deactivate the instantiation of the module class in the module listing page, and read the information from the disk using the native prestashop `config.xml` file (this is managed natively in core).
