### PR TITLE
PIPRES-425: Add exception handling for incorrect family name

### DIFF
--- a/src/Exception/OrderCreationException.php
+++ b/src/Exception/OrderCreationException.php
@@ -31,4 +31,6 @@ class OrderCreationException extends \Exception
     const ORDER_RESOURSE_IS_MISSING = 6;
 
     const ORDER_IS_NOT_CREATED = 7;
+
+    const WRONG_FAMILY_NAME = 8;
 }

--- a/src/Handler/Exception/OrderExceptionHandler.php
+++ b/src/Handler/Exception/OrderExceptionHandler.php
@@ -30,6 +30,8 @@ class OrderExceptionHandler implements ExceptionHandlerInterface
             return new OrderCreationException($e->getMessage(), OrderCreationException::WRONG_BILLING_PHONE_NUMBER_EXCEPTION);
         } elseif (strpos($e->getMessage(), 'shippingAddress.phone')) {
             return new OrderCreationException($e->getMessage(), OrderCreationException::WRONG_SHIPPING_PHONE_NUMBER_EXCEPTION);
+        } elseif (strpos($e->getMessage(), 'billingAddress.familyName')) {
+            return new OrderCreationException($e->getMessage(), OrderCreationException::WRONG_FAMILY_NAME);
         } elseif (strpos($e->getMessage(), 'payment.amount')) {
             if (strpos($e->getMessage(), 'minimum')) {
                 throw new OrderCreationException($e->getMessage(), OrderCreationException::ORDER_TOTAL_LOWER_THAN_MINIMUM);

--- a/src/Service/MollieOrderCreationService.php
+++ b/src/Service/MollieOrderCreationService.php
@@ -21,6 +21,7 @@ use Mollie\Api\Types\PaymentStatus;
 use Mollie\Config\Config;
 use Mollie\DTO\OrderData;
 use Mollie\DTO\PaymentData;
+use Mollie\Errors\Http\HttpStatusCode;
 use Mollie\Exception\OrderCreationException;
 use Mollie\Handler\ErrorHandler\ErrorHandler;
 use Mollie\Handler\Exception\OrderExceptionHandler;
@@ -66,10 +67,10 @@ class MollieOrderCreationService
                 $apiPayment = $this->createPayment($data, $paymentMethodObj->method);
             } catch (OrderCreationException $e) {
                 $errorHandler = ErrorHandler::getInstance();
-                $errorHandler->handle($e, $e->getCode(), true);
+                $errorHandler->handle($e, HttpStatusCode::HTTP_BAD_REQUEST, true);
             } catch (Exception $e) {
                 $errorHandler = ErrorHandler::getInstance();
-                $errorHandler->handle($e, $e->getCode(), true);
+                $errorHandler->handle($e, HttpStatusCode::HTTP_INTERNAL_SERVER_ERROR, true);
             }
         }
 


### PR DESCRIPTION
A new exception type WRONG_FAMILY_NAME has been added to highlight cases when the family name provided in the billing address is incorrect. This exception is triggered from the OrderExceptionHandler. Additionally, fixed the error handling in MollieOrderCreationService to always respond with proper HTTP status codes.