### PR TITLE
Fix for adding issuers for iDEAL in table: ps_ol_payment_method_issuer

### DIFF
--- a/src/Service/ApiService.php
+++ b/src/Service/ApiService.php
@@ -119,7 +119,7 @@ class ApiService implements ApiServiceInterface
         try {
             /** Requires local param or fails */
             /** @var BaseCollection|MethodCollection $apiMethods */
-            $apiMethods = $api->methods->allAvailable(['locale' => '']);
+            $apiMethods = $api->methods->allAvailable(['locale' => '', 'include' => 'issuers']);
             $apiMethods = $apiMethods->getArrayCopy();
             /** @var Method $method */
             foreach ($apiMethods as $key => $method) {


### PR DESCRIPTION
On a fresh prestashop installation 8.1.5 with mollie 6.1.0 installed and iDEAL is active. The ideal bank list on checkout is empty.

```
SELECT * FROM `ps_mol_payment_method_issuer`
0 results.
```

This commit fixes the `ps_mol_payment_method_issuer` table being filled when mollie module settings are saved.

To reproduce the issue for mollie v6.1.0: 
1. empty table with: `TRUNCATE ps_mol_payment_method_issuer` (if table is not empty when upgrading)
2. save mollie settings from module
3. SELECT * FROM `ps_mol_payment_method_issuer`
4. what results in 0 results, no ideal bank issuers information is available.

After adding `'include' => 'issuers'` to 
`$apiMethods = $api->methods->allAvailable(['locale' => '', 'include' => 'issuers']);`
will fix it, and table is being filled with ideal issuers data for iDEAL.

Module version 6.0.5 does work! But also contains:
`$apiMethods = $api->methods->allActive(['resource' => 'orders', 'include' => 'issuers', 'includeWallets' => 'applepay']);`
[link to ApiService.php:120](https://github.com/mollie/PrestaShop/blob/e52bede85096e28a3a8390f2051513814c6a73ee/src/Service/ApiService.php#L120)
We dont use applepay so can't test that, probably have to add that one too.