### PR TITLE
PIPRES-366/ Sentry error logger consent option addded

### DIFF
--- a/controllers/admin/AdminMollieSettingsController.php
+++ b/controllers/admin/AdminMollieSettingsController.php
@@ -100,6 +100,8 @@ class AdminMollieSettingsController extends ModuleAdminController
             $this->module->getLocalPath() . 'views/templates/admin/logo.tpl'
         );
 
+        $this->content .= $this->context->smarty->fetch($this->module->getLocalPath() . 'views/templates/admin/mollie-error-logger-modal.tpl') ?: '';
+
         $this->initCloudSyncAndPsAccounts();
 
         /** @var \Mollie\Repository\ModuleRepository $moduleRepository */

--- a/src/Builder/FormBuilder.php
+++ b/src/Builder/FormBuilder.php
@@ -12,6 +12,7 @@
 
 namespace Mollie\Builder;
 
+use Exception;
 use HelperFormCore as HelperForm;
 use Mollie;
 use Mollie\Adapter\ConfigurationAdapter;
@@ -355,6 +356,32 @@ class FormBuilder
                 $this->module->l('Read more about [1]Single Click Payments[/1] and how it improves your conversion.', self::FILE_NAME),
                 [
                     $this->module->display($this->module->getPathUri(), 'views/templates/admin/mollie_single_click_payment_info.tpl'),
+                ]
+            ),
+            'is_bool' => true,
+            'values' => [
+                [
+                    'id' => 'active_on',
+                    'value' => true,
+                    'label' => $this->module->l('Enabled', self::FILE_NAME),
+                ],
+                [
+                    'id' => 'active_off',
+                    'value' => false,
+                    'label' => $this->module->l('Disabled', self::FILE_NAME),
+                ],
+            ],
+        ];
+
+        $input[] = [
+            'type' => 'switch',
+            'label' => $this->module->l('Error Logging', self::FILE_NAME),
+            'tab' => $generalSettings,
+            'name' => Config::MOLLIE_ERROR_LOGGING[(int) $this->configuration->get(Config::MOLLIE_ENVIRONMENT) ? 'production' : 'sandbox'],
+            'desc' => TagsUtility::ppTags(
+                $this->module->l('Read more about [1]Error Logging[/1] and how it improves your experience.', self::FILE_NAME),
+                [
+                    $this->module->display($this->module->getPathUri(), 'views/templates/admin/mollie_error_logging_info.tpl'),
                 ]
             ),
             'is_bool' => true,

--- a/src/Builder/FormBuilder.php
+++ b/src/Builder/FormBuilder.php
@@ -12,7 +12,6 @@
 
 namespace Mollie\Builder;
 
-use Exception;
 use HelperFormCore as HelperForm;
 use Mollie;
 use Mollie\Adapter\ConfigurationAdapter;

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -110,6 +110,12 @@ class Config
         'sandbox' => 'MOLLIE_SANDBOX_SINGLE_CLICK_PAYMENT',
         'production' => 'MOLLIE_PRODUCTION_SINGLE_CLICK_PAYMENT',
     ];
+
+    const MOLLIE_ERROR_LOGGING = [
+        'sandbox' => 'MOLLIE_SANDBOX_ERROR_LOGGING',
+        'production' => 'MOLLIE_PRODUCTION_ERROR_LOGGING',
+    ];
+
     const MOLLIE_IMAGES = 'MOLLIE_IMAGES';
     const MOLLIE_SHOW_RESEND_PAYMENT_LINK = 'MOLLIE_SHOW_RESEND_PAYMENT_LINK';
     const MOLLIE_ISSUERS = [

--- a/src/Handler/ErrorHandler/ErrorHandler.php
+++ b/src/Handler/ErrorHandler/ErrorHandler.php
@@ -102,7 +102,7 @@ class ErrorHandler
     public function handle(\Throwable $error, ?int $code = null, ?bool $throw = true): void
     {
         // NOTE: The error is not being sent if the error logging is disabled
-        if ((int) !\Configuration::get(Config::MOLLIE_ERROR_LOGGING[\Configuration::get(Config::MOLLIE_ENVIRONMENT) ? 'production' : 'sandbox'] )) {
+        if ((int) !\Configuration::get(Config::MOLLIE_ERROR_LOGGING[\Configuration::get(Config::MOLLIE_ENVIRONMENT) ? 'production' : 'sandbox'])) {
             return;
         }
 

--- a/src/Handler/ErrorHandler/ErrorHandler.php
+++ b/src/Handler/ErrorHandler/ErrorHandler.php
@@ -101,6 +101,11 @@ class ErrorHandler
      */
     public function handle(\Throwable $error, ?int $code = null, ?bool $throw = true): void
     {
+        // NOTE: The error is not being sent if the error logging is disabled
+        if ((int) !\Configuration::get(Config::MOLLIE_ERROR_LOGGING[\Configuration::get(Config::MOLLIE_ENVIRONMENT) ? 'production' : 'sandbox'] )) {
+            return;
+        }
+
         $this->client->captureException($error, $this->exceptionContext);
 
         if ($code && true === $throw) {

--- a/src/Install/Installer.php
+++ b/src/Install/Installer.php
@@ -215,6 +215,7 @@ class Installer implements InstallerInterface
         $this->configurationAdapter->updateValue(Config::MOLLIE_BANCONTACT_QR_CODE_ENABLED, 0);
 
         $this->configurationAdapter->updateValue(Config::MOLLIE_SUBSCRIPTION_ORDER_CARRIER_ID, 0);
+        $this->configurationAdapter->updateValue(Config::MOLLIE_ERROR_LOGGING, 0);
     }
 
     public function setDefaultCarrierStatuses()

--- a/src/Install/Uninstall.php
+++ b/src/Install/Uninstall.php
@@ -97,6 +97,7 @@ class Uninstall
             Config::MOLLIE_MAIL_WHEN_COMPLETED,
             Config::MOLLIE_API_KEY_TEST,
             Config::MOLLIE_SUBSCRIPTION_ORDER_CARRIER_ID,
+            Config::MOLLIE_ERROR_LOGGING,
         ];
 
         $this->deleteConfigurations($configurations);

--- a/src/Service/ConfigFieldService.php
+++ b/src/Service/ConfigFieldService.php
@@ -64,6 +64,7 @@ class ConfigFieldService
             Config::MOLLIE_SEND_ORDER_CONFIRMATION => $this->configurationAdapter->get(Config::MOLLIE_SEND_ORDER_CONFIRMATION),
             Config::MOLLIE_IFRAME[(int) $this->configurationAdapter->get(Config::MOLLIE_ENVIRONMENT) ? 'production' : 'sandbox'] => $this->configurationAdapter->get(Config::MOLLIE_IFRAME),
             Config::MOLLIE_SINGLE_CLICK_PAYMENT[(int) $this->configurationAdapter->get(Config::MOLLIE_ENVIRONMENT) ? 'production' : 'sandbox'] => $this->configurationAdapter->get(Config::MOLLIE_SINGLE_CLICK_PAYMENT),
+            Config::MOLLIE_ERROR_LOGGING[(int) $this->configurationAdapter->get(Config::MOLLIE_ENVIRONMENT) ? 'production' : 'sandbox'] => $this->configurationAdapter->get(Config::MOLLIE_ERROR_LOGGING),
 
             Config::MOLLIE_CSS => $this->configurationAdapter->get(Config::MOLLIE_CSS),
             Config::MOLLIE_IMAGES => $this->configurationAdapter->get(Config::MOLLIE_IMAGES),

--- a/src/Service/SettingsSaveService.php
+++ b/src/Service/SettingsSaveService.php
@@ -243,6 +243,8 @@ class SettingsSaveService
         $mollieOrderConfirmationSand = $this->tools->getValue(Config::MOLLIE_SEND_ORDER_CONFIRMATION);
         $mollieIFrameEnabled = $this->tools->getValue(Config::MOLLIE_IFRAME[$environment ? 'production' : 'sandbox']);
         $mollieSingleClickPaymentEnabled = $this->tools->getValue(Config::MOLLIE_SINGLE_CLICK_PAYMENT[$environment ? 'production' : 'sandbox']);
+        $mollieErrorLoggingEnabled = $this->tools->getValue(Config::MOLLIE_ERROR_LOGGING[$environment ? 'production' : 'sandbox']);
+
         $mollieImages = $this->tools->getValue(Config::MOLLIE_IMAGES);
         $showResentPayment = $this->tools->getValue(Config::MOLLIE_SHOW_RESEND_PAYMENT_LINK);
         $mollieIssuers = $this->tools->getValue(Config::MOLLIE_ISSUERS[$environment ? 'production' : 'sandbox']);
@@ -307,6 +309,7 @@ class SettingsSaveService
             $this->configurationAdapter->updateValue(Config::MOLLIE_SEND_ORDER_CONFIRMATION, $mollieOrderConfirmationSand);
             $this->configurationAdapter->updateValue(Config::MOLLIE_IFRAME, $mollieIFrameEnabled);
             $this->configurationAdapter->updateValue(Config::MOLLIE_SINGLE_CLICK_PAYMENT, $mollieSingleClickPaymentEnabled);
+            $this->configurationAdapter->updateValue(Config::MOLLIE_ERROR_LOGGING, $mollieErrorLoggingEnabled);
             $this->configurationAdapter->updateValue(Config::MOLLIE_IMAGES, $mollieImages);
             $this->configurationAdapter->updateValue(Config::MOLLIE_SHOW_RESEND_PAYMENT_LINK, $showResentPayment);
             $this->configurationAdapter->updateValue(Config::MOLLIE_ISSUERS, $mollieIssuers);

--- a/upgrade/Upgrade-6.2.0.php
+++ b/upgrade/Upgrade-6.2.0.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Mollie       https://www.mollie.nl
+ *
+ * @author      Mollie B.V. <info@mollie.nl>
+ * @copyright   Mollie B.V.
+ * @license     https://github.com/mollie/PrestaShop/blob/master/LICENSE.md
+ *
+ * @see        https://github.com/mollie/PrestaShop
+ */
+
+use Mollie\Adapter\ConfigurationAdapter;
+use Mollie\Config\Config;
+use Mollie\Utility\PsVersionUtility;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_6_2_0(Mollie $module): bool
+{
+    /** @var ConfigurationAdapter $configuration */
+    $configuration = $module->getService(ConfigurationAdapter::class);
+
+    $configuration->updateValue(Config::MOLLIE_ERROR_LOGGING['sandbox'], 0);
+    $configuration->updateValue(Config::MOLLIE_ERROR_LOGGING['production'], 0);
+
+    return true;
+}

--- a/views/templates/admin/mollie-error-logger-modal.tpl
+++ b/views/templates/admin/mollie-error-logger-modal.tpl
@@ -1,3 +1,13 @@
+{**
+ * Mollie       https://www.mollie.nl
+ *
+ * @author      Mollie B.V. <info@mollie.nl>
+ * @copyright   Mollie B.V.
+ * @license     https://github.com/mollie/PrestaShop/blob/master/LICENSE.md
+ *
+ * @see        https://github.com/mollie/PrestaShop
+ * @codingStandardsIgnoreStart
+ *}
 <!-- Modal -->
 <div class="modal fade" id="errorLoggingModal" tabindex="-1" role="dialog" aria-labelledby="errorLoggingModalTitle" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered" role="document">

--- a/views/templates/admin/mollie-error-logger-modal.tpl
+++ b/views/templates/admin/mollie-error-logger-modal.tpl
@@ -1,0 +1,25 @@
+<!-- Modal -->
+<div class="modal fade" id="errorLoggingModal" tabindex="-1" role="dialog" aria-labelledby="errorLoggingModalTitle" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h3 class="modal-title" id="errorLoggingModalTitle" style="font-weight: 600;">{l s='Error and Logging Information Sharing Consent' mod='mollie'}</h3>
+            </div>
+            <div class="modal-body">
+                <p class="h4">{l s='To provide you with a better experience and improve our services, we would like to collect error and logging information from your device. This information will help us identify and fix any issues you may encounter while using our application.' mod='mollie'}</p>
+                <p class="h4" style="font-weight: 600;">{l s='The error and logging information may include:' mod='mollie'}</p>
+                <ul class="h4">
+                    <li>{l s='Error messages and the request code.' mod='mollie'}</li>
+                    <li>{l s='Device information (such as device model, operating system version)' mod='mollie'}</li>
+                    <li>{l s='Application version' mod='mollie'}</li>
+                    <li>{l s='Time and date of the error occurrence' mod='mollie'}</li>
+                </ul>
+                <br>
+                <p class="h4">{l s='By granting consent, you agree to allow us to collect and analyze this information. Rest assured, all data will be treated in accordance with our privacy policy and will only be used for the purpose of improving our applications performance and stability.' mod='mollie'}</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">{l s='Close'}</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/views/templates/admin/mollie-error-logger-modal.tpl
+++ b/views/templates/admin/mollie-error-logger-modal.tpl
@@ -28,7 +28,7 @@
                 <p class="h4">{l s='By granting consent, you agree to allow us to collect and analyze this information. Rest assured, all data will be treated in accordance with our privacy policy and will only be used for the purpose of improving our applications performance and stability.' mod='mollie'}</p>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-dismiss="modal">{l s='Close'}</button>
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">{l s='Close' mod='mollie'}</button>
             </div>
         </div>
     </div>

--- a/views/templates/admin/mollie_error_logging_info.tpl
+++ b/views/templates/admin/mollie_error_logging_info.tpl
@@ -1,0 +1,14 @@
+{**
+ * Mollie       https://www.mollie.nl
+ *
+ * @author      Mollie B.V. <info@mollie.nl>
+ * @copyright   Mollie B.V.
+ * @license     https://github.com/mollie/PrestaShop/blob/master/LICENSE.md
+ *
+ * @see        https://github.com/mollie/PrestaShop
+ * @codingStandardsIgnoreStart
+ *}
+<a  data-toggle="modal" data-target="#errorLoggingModal" href="#"
+   target="_blank"
+   rel="noopener noreferrer"
+>


### PR DESCRIPTION
### New option:
![image](https://github.com/mollie/PrestaShop/assets/96050852/a8db2b7b-034f-407f-b2bf-9a0707c63d55)

### Upon clicking the link modal appears:
![image](https://github.com/mollie/PrestaShop/assets/96050852/64efd4b0-7540-4c42-8607-fb487a4a8832)
