### PR TITLE
PIPRES-450/phone input validation fix

### DIFF
--- a/src/DTO/OrderData.php
+++ b/src/DTO/OrderData.php
@@ -433,7 +433,7 @@ class OrderData implements JsonSerializable
                 'familyName' => $this->cleanUpInput($this->getBillingAddress()->lastname),
                 'email' => $this->cleanUpInput($this->getEmail()),
                 'title' => $this->cleanUpInput($this->getTitle()),
-                'phone' => $this->cleanUpInput($this->getBillingPhoneNumber()),
+                'phone' => $this->getBillingPhoneNumber(),
             ],
             'shippingAddress' => [
                 'organizationName' => $this->cleanUpInput($this->getShippingAddress()->company),
@@ -446,7 +446,7 @@ class OrderData implements JsonSerializable
                 'familyName' => $this->cleanUpInput($this->getShippingAddress()->lastname),
                 'email' => $this->cleanUpInput($this->getEmail()),
                 'title' => $this->cleanUpInput($this->getTitle()),
-                'phone' => $this->cleanUpInput($this->getDeliveryPhoneNumber()),
+                'phone' => $this->getDeliveryPhoneNumber(),
             ],
             'redirectUrl' => $this->getRedirectUrl(),
             'webhookUrl' => $this->getWebhookUrl(),


### PR DESCRIPTION
Then phone is optional logic was setting phone field value to N/A which triggers incorrect format. 