### PR TITLE
PIPRES-479: subscription attribute bug fix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 # Changelog #
 ## Changes in release 6.2.3 ##
++ Subscription attribute editing fix
+
+## Changes in release 6.2.3 ##
 + Multi shop improvements with order states
 + Logging improvements
 + Phone field validation improvements

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 ![Mollie](https://www.mollie.nl/files/Mollie-Logo-Style-Small.png)
 
 # Changelog #
-## Changes in release 6.2.3 ##
+## Changes in release 6.2.4 ##
 + Subscription attribute editing fix
 
 ## Changes in release 6.2.3 ##

--- a/mollie.php
+++ b/mollie.php
@@ -1335,11 +1335,6 @@ class Mollie extends PaymentModule
         $this->frontControllerAfterInit();
     }
 
-    public function hookActionObjectAttributeUpdateBefore($params)
-    {
-        $a = $params;
-    }
-
     public function hookActionFrontControllerInitAfter(): void
     {
         $this->frontControllerAfterInit();

--- a/mollie.php
+++ b/mollie.php
@@ -26,8 +26,8 @@ use Mollie\Repository\MolOrderPaymentFeeRepositoryInterface;
 use Mollie\Repository\PaymentMethodRepositoryInterface;
 use Mollie\Service\ExceptionService;
 use Mollie\ServiceProvider\LeagueServiceContainerProvider;
-use Mollie\Subscription\Handler\CustomerAddressUpdateHandler;
 use Mollie\Subscription\Config\Config as SubscriptionConfig;
+use Mollie\Subscription\Handler\CustomerAddressUpdateHandler;
 use Mollie\Subscription\Handler\UpdateSubscriptionCarrierHandler;
 use Mollie\Subscription\Install\AttributeInstaller;
 use Mollie\Subscription\Install\DatabaseTableInstaller;
@@ -1408,14 +1408,14 @@ class Mollie extends PaymentModule
 
     public function hookActionAttributeSave($params): void
     {
-        if (isset($params['id_attribute']) && (int)$params['id_attribute'] > 0) {
-            $attribute = new ProductAttribute((int)$params['id_attribute']);
+        if (isset($params['id_attribute']) && (int) $params['id_attribute'] > 0) {
+            $attribute = new ProductAttribute((int) $params['id_attribute']);
 
             if (Validate::isLoadedObject($attribute)) {
                 /** @var ConfigurationAdapter $configuration */
                 $configuration = $this->getService(ConfigurationAdapter::class);
 
-                if ((int)$attribute->id_attribute_group === (int) $configuration->get(SubscriptionConfig::SUBSCRIPTION_ATTRIBUTE_GROUP)) {
+                if ((int) $attribute->id_attribute_group === (int) $configuration->get(SubscriptionConfig::SUBSCRIPTION_ATTRIBUTE_GROUP)) {
                     // Add an error message if it's the Mollie group
                     $this->context->controller->errors[] = $this->l('New attributes are not compatible with Mollie subscription.');
                 }

--- a/upgrade/Upgrade-6.2.4.php
+++ b/upgrade/Upgrade-6.2.4.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Mollie       https://www.mollie.nl
+ *
+ * @author      Mollie B.V. <info@mollie.nl>
+ * @copyright   Mollie B.V.
+ * @license     https://github.com/mollie/PrestaShop/blob/master/LICENSE.md
+ *
+ * @see        https://github.com/mollie/PrestaShop
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_6_2_4(Mollie $module): bool
+{
+    return $module->registerHook('actionAttributeSave');
+}


### PR DESCRIPTION
Prestashop allowes to add new attributes inside mollie subscription attribute group. Added hook to prevent from creating it as by adding on the product prevents from adding it to the cart