### PR TITLE
PIPRES-483 canceled payment error handling

### DIFF
--- a/controllers/front/return.php
+++ b/controllers/front/return.php
@@ -107,7 +107,8 @@ class MollieReturnModuleFrontController extends AbstractMollieController
             }
             if (false === $data['mollie_info']) {
                 $data['mollie_info'] = [];
-                $logger->error(sprintf('There is no order with this order number - %s', (string) $orderNumber));
+                //NOTE: information instead of error as this might occur due to cancellation of the payment
+                $logger->info(sprintf('There is no order with this order number - %s', (string) $orderNumber));
 
                 $data['msg_details'] = $this->module->l('Your payment was not successful. Try again.', self::FILE_NAME);
                 $this->setWarning($data['msg_details']);

--- a/controllers/front/return.php
+++ b/controllers/front/return.php
@@ -107,7 +107,12 @@ class MollieReturnModuleFrontController extends AbstractMollieController
             }
             if (false === $data['mollie_info']) {
                 $data['mollie_info'] = [];
-                $data['msg_details'] = $this->module->l('There is no order with this ID.', self::FILE_NAME);
+                $logger->error(sprintf('There is no order with this order number - %s', (string) $orderNumber));
+
+                $data['msg_details'] = $this->module->l('Your payment was not successful. Try again.', self::FILE_NAME);
+                $this->setWarning($data['msg_details']);
+
+                Tools::redirect(Context::getContext()->link->getPageLink('cart', true));
             } elseif (PaymentMethod::BANKTRANSFER === $data['mollie_info']['method']
                 && PaymentStatus::STATUS_OPEN === $data['mollie_info']['bank_status']
             ) {


### PR DESCRIPTION
Some payment methods upon cancel does not call webhook. Previous message was not informative enough. Added redirection and improved error message to be more understandable. Also added log to be able easily debug this place