### PR TITLE
PIPRES-489 php-scoper implementation for vendor namespaces

### DIFF
--- a/.github/workflows/create_zip.yml
+++ b/.github/workflows/create_zip.yml
@@ -23,9 +23,11 @@ jobs:
       - name: Build module ZIP
         run: |
           composer install --no-dev --optimize-autoloader --classmap-authoritative
+          composer global require humbug/php-scoper --no-progress --no-interaction
+          ~/.composer/vendor/bin/php-scoper add-prefix && cp -r build/vendor/* vendor/
           composer dump-autoload --no-dev --optimize --classmap-authoritative
           cp .github/.htaccess vendor/.htaccess
-          rm -rf .git .docker .editorconfig .github tests .php-cs-fixer.php Makefile cypress .docker cypress.config.js cypress.env.json docker-compose*.yml .gitignore bin codeception.yml package-lock.json package.json .php_cs.dist .php-cs-fixer.dist .php-cs-fixer.dist.php
+          rm -rf .git .docker .editorconfig .github tests .php-cs-fixer.php Makefile cypress .docker cypress.config.js cypress.env.json docker-compose*.yml .gitignore bin codeception.yml package-lock.json package.json .php_cs.dist .php-cs-fixer.dist .php-cs-fixer.dist.php php-scoper.inc.php
           mv .env.dist .env
           mkdir ${{ env.MODULE_NAME }}
           rsync -Rr ./ ./${{ env.MODULE_NAME }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,8 +85,10 @@ jobs:
       - name: Build module ZIP
         run: |
           composer install --no-dev --optimize-autoloader --classmap-authoritative
+          composer global require humbug/php-scoper --no-progress --no-interaction
+          ~/.composer/vendor/bin/php-scoper add-prefix && cp -r build/vendor/* vendor/
           composer dump-autoload --no-dev --optimize --classmap-authoritative
-          rm -rf .git .github tests .php-cs-fixer.php Makefile cypress* docker-compose*.yml package.json package-lock.json .docker
+          rm -rf .git .github tests .php-cs-fixer.php Makefile cypress* docker-compose*.yml package.json package-lock.json .docker php-scoper.inc.php
           mkdir ${{ env.MODULE_NAME }}
           rsync -Rr ./ ./${{ env.MODULE_NAME }}
           shopt -s extglob

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
             "Mollie\\": "src/",
             "Mollie\\Subscription\\": "subscription/",
             "Mollie\\Shared\\": "shared/",
-            "Mollie\\Vendor\\Psr\\Container\\": "vendor\/psr\/container\/src\/"
+            "Mollie\\Vendor\\Psr\\Container\\": "vendor\/psr\/container\/src\/",
+            "Mollie\\Vendor\\League\\Container\\": "vendor\/league\/container\/src\/"
         },
         "classmap": [
             "mollie.php",

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
         "psr-4": {
             "Mollie\\": "src/",
             "Mollie\\Subscription\\": "subscription/",
-            "Mollie\\Shared\\": "shared/"
+            "Mollie\\Shared\\": "shared/",
+            "Mollie\\Vendor\\Psr\\Container\\": "vendor\/psr\/container\/src\/"
         },
         "classmap": [
             "mollie.php",

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -26,6 +26,19 @@ return [
                 'vendor-bin',
                 'console',
             ])
+            ->in('vendor/league'),
+        Finder::create()
+            ->files()
+            ->ignoreVCS(true)
+            ->notName('/LICENSE|.*\\.md|.*\\.dist|Makefile|composer\\.json|composer\\.lock/')
+            ->exclude([
+                'test',
+                'test_old',
+                'tests',
+                'Tests',
+                'vendor-bin',
+                'console',
+            ])
             ->in('vendor/psr'),
         Finder::create()->append([
             'composer.json',

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Isolated\Symfony\Component\Finder\Finder;
+
+return [
+    // The prefix configuration. If a non null value will be used, a random prefix will be generated.
+    'prefix' => 'Mollie\\Vendor',
+
+    // By default when running php-scoper add-prefix, it will prefix all relevant code found in the current working
+    // directory. You can however define which files should be scoped by defining a collection of Finders in the
+    // following configuration key.
+    //
+    // For more see: https://github.com/humbug/php-scoper#finders-and-paths
+    'finders' => [
+        Finder::create()
+            ->files()
+            ->ignoreVCS(true)
+            ->notName('/LICENSE|.*\\.md|.*\\.dist|Makefile|composer\\.json|composer\\.lock/')
+            ->exclude([
+                'test',
+                'test_old',
+                'tests',
+                'Tests',
+                'vendor-bin',
+                'console',
+            ])
+            ->in('vendor/psr'),
+        Finder::create()->append([
+            'composer.json',
+        ]),
+    ],
+];

--- a/src/ServiceProvider/BaseServiceProvider.php
+++ b/src/ServiceProvider/BaseServiceProvider.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace Mollie\ServiceProvider;
 
-use Mollie\Vendor\League\Container\Container;
 use Mollie;
 use Mollie\Adapter\ConfigurationAdapter;
 use Mollie\Adapter\Context;
@@ -142,6 +141,7 @@ use Mollie\Subscription\Utility\ClockInterface;
 use Mollie\Utility\Decoder\DecoderInterface;
 use Mollie\Utility\Decoder\JsonDecoder;
 use Mollie\Utility\NumberIdempotencyProvider;
+use Mollie\Vendor\League\Container\Container;
 use Mollie\Verification\PaymentType\CanBeRegularPaymentType;
 use Mollie\Verification\PaymentType\PaymentTypeVerificationInterface;
 use Mollie\Verification\Shipment\CanSendShipment;

--- a/src/ServiceProvider/BaseServiceProvider.php
+++ b/src/ServiceProvider/BaseServiceProvider.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 
 namespace Mollie\ServiceProvider;
 
-use League\Container\Container;
+use Mollie\Vendor\League\Container\Container;
 use Mollie;
 use Mollie\Adapter\ConfigurationAdapter;
 use Mollie\Adapter\Context;

--- a/src/ServiceProvider/LeagueServiceContainerProvider.php
+++ b/src/ServiceProvider/LeagueServiceContainerProvider.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 
 namespace Mollie\ServiceProvider;
 
-use League\Container\Container;
-use League\Container\ReflectionContainer;
+use Mollie\Vendor\League\Container\Container;
+use Mollie\Vendor\League\Container\ReflectionContainer;
 
 if (!defined('_PS_VERSION_')) {
     exit;

--- a/src/ServiceProvider/PrestashopContainer.php
+++ b/src/ServiceProvider/PrestashopContainer.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
 namespace Mollie\ServiceProvider;
 
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
-use Psr\Container\ContainerInterface as PsrContainerInterface;
+use Mollie\Vendor\Psr\Container\ContainerInterface as PsrContainerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 if (!defined('_PS_VERSION_')) {

--- a/src/ServiceProvider/PrestashopContainer.php
+++ b/src/ServiceProvider/PrestashopContainer.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 
 namespace Mollie\ServiceProvider;
 
-use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use Mollie\Vendor\Psr\Container\ContainerInterface as PsrContainerInterface;
+use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 if (!defined('_PS_VERSION_')) {

--- a/subscription/Install/AttributeInstaller.php
+++ b/subscription/Install/AttributeInstaller.php
@@ -23,7 +23,7 @@ use Mollie\Subscription\Config\Config;
 use Mollie\Subscription\Repository\LanguageRepository;
 use PrestaShopDatabaseException;
 use PrestaShopException;
-use Psr\Log\LogLevel;
+use Mollie\Vendor\Psr\Log\LogLevel;
 use Validate;
 
 if (!defined('_PS_VERSION_')) {

--- a/subscription/Install/AttributeInstaller.php
+++ b/subscription/Install/AttributeInstaller.php
@@ -21,9 +21,9 @@ use Mollie\Adapter\ProductAttributeAdapter;
 use Mollie\Logger\PrestaLoggerInterface;
 use Mollie\Subscription\Config\Config;
 use Mollie\Subscription\Repository\LanguageRepository;
+use Mollie\Vendor\Psr\Log\LogLevel;
 use PrestaShopDatabaseException;
 use PrestaShopException;
-use Mollie\Vendor\Psr\Log\LogLevel;
 use Validate;
 
 if (!defined('_PS_VERSION_')) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the project!

Please take the time to edit the "Answers" rows below with the necessary information.

------------------------------------------------------------------------------>

| Questions       | Answers
|-----------------| -------------------------------------------------------
| Branch?         | 6.2.5
| Description?    | Added namespaces to vendor `Psr` and `League` to met Prestashop 9 requirements
| Type?           | Improvement
| How to test?    | Build zip and see if everything works as expected without any critical errors related to namespaces to autoloading
| Fixed issue ?   | -
