### PR TITLE
PIPRES-432 Error message for incorrect first or last name added

### DIFF
--- a/src/Exception/OrderCreationException.php
+++ b/src/Exception/OrderCreationException.php
@@ -33,4 +33,6 @@ class OrderCreationException extends \Exception
     const ORDER_IS_NOT_CREATED = 7;
 
     const WRONG_FAMILY_NAME = 8;
+
+    const WRONG_GIVEN_NAME = 9;
 }

--- a/src/Handler/Exception/OrderExceptionHandler.php
+++ b/src/Handler/Exception/OrderExceptionHandler.php
@@ -32,6 +32,8 @@ class OrderExceptionHandler implements ExceptionHandlerInterface
             return new OrderCreationException($e->getMessage(), OrderCreationException::WRONG_SHIPPING_PHONE_NUMBER_EXCEPTION);
         } elseif (strpos($e->getMessage(), 'billingAddress.familyName')) {
             return new OrderCreationException($e->getMessage(), OrderCreationException::WRONG_FAMILY_NAME);
+        } elseif (strpos($e->getMessage(), 'billingAddress.givenName')) {
+            return new OrderCreationException($e->getMessage(), OrderCreationException::WRONG_GIVEN_NAME);
         } elseif (strpos($e->getMessage(), 'payment.amount')) {
             if (strpos($e->getMessage(), 'minimum')) {
                 throw new OrderCreationException($e->getMessage(), OrderCreationException::ORDER_TOTAL_LOWER_THAN_MINIMUM);

--- a/src/Service/ExceptionService.php
+++ b/src/Service/ExceptionService.php
@@ -43,6 +43,8 @@ class ExceptionService
                     OrderCreationException::WRONG_SHIPPING_PHONE_NUMBER_EXCEPTION => $this->module->l('It looks like you have entered incorrect phone number format in shipping address step. Please change the number and try again.', self::FILE_NAME),
                     OrderCreationException::ORDER_TOTAL_LOWER_THAN_MINIMUM => $this->module->l('Chosen payment option is unavailable for your order total amount. Please consider using other payment option and try again.', self::FILE_NAME),
                     OrderCreationException::ORDER_TOTAL_HIGHER_THAN_MAXIMUM => $this->module->l('Chosen payment option is unavailable for your order total amount. Please consider using other payment option and try again.', self::FILE_NAME),
+                    OrderCreationException::WRONG_GIVEN_NAME => $this->module->l('The first name is invalid. Please check and try again.', self::FILE_NAME),
+                    OrderCreationException::WRONG_FAMILY_NAME => $this->module->l('The second name is invalid. Please check and try again.', self::FILE_NAME),
             ],
             ShipmentCannotBeSentException::class => [
                 ShipmentCannotBeSentException::NO_SHIPPING_INFORMATION => $this->module->l('Shipment information cannot be sent. Order reference (%s) has no shipping information.', self::FILE_NAME),


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the project!

Please take the time to edit the "Answers" rows below with the necessary information.

------------------------------------------------------------------------------>

| Questions       | Answers
|-----------------| -------------------------------------------------------
| Branch?         | Release-6.2.6
| Description?    | Previously on error then first or second name is incorrect we were throwing default message. These changes will improve error handling and will tell enduser that his first name or family name is incorrect and he must check it.
| Type?           |  improvement
| How to test?    | Checkout with klarna method using one letter as first name or second name.
| Fixed issue ?   | PIPRES-432


![image](https://github.com/user-attachments/assets/495784cf-758d-4518-9a20-19be25ae2c68)
