### PR TITLE
INTERNAL cloudsync screen is optional if error ocurred in dependant modules.

### DIFF
--- a/controllers/admin/AdminMollieSettingsController.php
+++ b/controllers/admin/AdminMollieSettingsController.php
@@ -123,7 +123,17 @@ class AdminMollieSettingsController extends ModuleAdminController
             $this->module->getLocalPath() . 'views/templates/admin/logo.tpl'
         );
 
+        try {
         $this->initCloudSyncAndPsAccounts();
+        } catch (Exception $e) {
+            /** @var Logger $logger * */
+            $logger = $this->module->getService(LoggerInterface::class);
+
+            $logger->error('Failed to initiate cloud sync and ps accounts', [
+                'context' => [],
+                'exceptions' => ExceptionUtility::getExceptions($e),
+            ]);
+        }
 
         /** @var \Mollie\Repository\ModuleRepository $moduleRepository */
         $moduleRepository = $this->module->getService(\Mollie\Repository\ModuleRepository::class);

--- a/controllers/admin/AdminMollieSettingsController.php
+++ b/controllers/admin/AdminMollieSettingsController.php
@@ -117,6 +117,9 @@ class AdminMollieSettingsController extends ModuleAdminController
         /** @var \Mollie\Service\Content\TemplateParserInterface $templateParser */
         $templateParser = $this->module->getService(\Mollie\Service\Content\TemplateParserInterface::class);
 
+        /** @var Logger $logger * */
+        $logger = $this->module->getService(LoggerInterface::class);
+
         $this->content = $templateParser->parseTemplate(
             $this->context->smarty,
             $this->module->getService(\Mollie\Builder\Content\LogoInfoBlock::class),
@@ -124,11 +127,8 @@ class AdminMollieSettingsController extends ModuleAdminController
         );
 
         try {
-        $this->initCloudSyncAndPsAccounts();
+            $this->initCloudSyncAndPsAccounts();
         } catch (Exception $e) {
-            /** @var Logger $logger * */
-            $logger = $this->module->getService(LoggerInterface::class);
-
             $logger->error('Failed to initiate cloud sync and ps accounts', [
                 'context' => [],
                 'exceptions' => ExceptionUtility::getExceptions($e),


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the project!

Please take the time to edit the "Answers" rows below with the necessary information.

------------------------------------------------------------------------------>

| Questions       | Answers
|-----------------| -------------------------------------------------------
| Branch?         | Master/Release
| Description?    | Made cloudsync/ps_account optional in case of error is thrown on those modules.
| Type?           | Improvement
| How to test?    | --
| Fixed issue ?   | --
