### PR TITLE
PIPRES-691 Fix totalAmount mismatch when rounding is set to round on each item

### DIFF
--- a/src/Service/CartLinesService.php
+++ b/src/Service/CartLinesService.php
@@ -224,14 +224,15 @@ class CartLinesService
             }
 
             // Try to spread this product evenly and account for rounding differences on the order line
+            $unitPrice = round($cartItem['price_wt'], $apiRoundingPrecision);
             $orderLines[$productHash][] = [
                 'name' => $cartItem['name'],
                 'type' => 'physical',
                 'sku' => $productHash,
                 'targetVat' => (float) $cartItem['rate'],
                 'quantity' => $quantity,
-                'unitPrice' => round($cartItem['price_wt'], $apiRoundingPrecision),
-                'totalAmount' => (float) $roundedTotalWithTax,
+                'unitPrice' => $unitPrice,
+                'totalAmount' => $unitPrice * $quantity,
                 'categories' => $this->voucherService->getVoucherCategory($cartItem, $selectedVoucherCategory),
                 'product_url' => $this->context->getProductLink($cartItem['id_product']),
                 'image_url' => $this->context->getImageLink($cartItem['link_rewrite'], $cartItem['id_image']),
@@ -239,7 +240,7 @@ class CartLinesService
                     'idProduct' => $cartItem['id_product'],
                 ],
             ];
-            $remaining -= $roundedTotalWithTax;
+            $remaining -= ($unitPrice * $quantity);
         }
 
         return [$orderLines, $remaining];


### PR DESCRIPTION
Summary

- Fixed Mollie API 422 errors caused by totalAmount mismatch when PrestaShop rounding is set to "Round on each item"
- Changed CartLinesService.php to calculate totalAmount as unitPrice multiplied by quantity instead of using PrestaShop's pre-calculated total_wt value

Root Cause

When PrestaShop's "Round on each item" setting is enabled, it rounds each line item's total independently, which introduces small rounding differences compared to Mollie's expected calculation (unitPrice x quantity).

Test Plan

- Create a product with a price that includes VAT (e.g., 73.00 EUR with 19% VAT)
- Set PrestaShop rounding to "Round on each item"
- Add product with quantity greater than 1 to cart
- Complete checkout with Mollie payment
- Verify no 422 errors occur