### PR TITLE
PIPRES-681 Fix totalAmount mismatch when cart contains gift product

### DIFF
--- a/src/Service/CartLinesService.php
+++ b/src/Service/CartLinesService.php
@@ -223,6 +223,8 @@ class CartLinesService
                 continue;
             }
 
+            $roundedTotalWithTax = round($quantity * $cartItem['price_wt'], $apiRoundingPrecision);
+
             // Try to spread this product evenly and account for rounding differences on the order line
             $orderLines[$productHash][] = [
                 'name' => $cartItem['name'],


### PR DESCRIPTION
## Summary
- Fixed Mollie Orders API 422 error when cart contains the same product as both a gift (free) and a paid item
- The `totalAmount` was incorrectly calculated using pre-gift-subtraction values, causing validation failure (`totalAmount != unitPrice × quantity`)
- Added recalculation of `roundedTotalWithTax` after gift quantity subtraction

## Test plan
- [ ] Add a product to cart as a paid item
- [ ] Configure cart rule with "Send a free gift" using the same product
- [ ] Complete checkout with Mollie Orders API payment method (e.g., Klarna)
- [ ] Verify payment succeeds without 422 error

## Changes in release 6.4.1
- Fixed totalAmount mismatch error when cart contains gift product alongside paid item