### PR TITLE
Fix payment fee not displaying when maximum fee is set to 0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 ## Changes in release 6.4.1
 + Fixed issues with upgrade
 + Fixed payment fee calculation on checkout page
++ Fixed payment fee not displaying when maximum fee is set to 0
 + Re-added payment method title translations
 + Fixed partial refunds incorrectly triggering full refunds
 + Added pre-translated email templates for FR, DE, ES, NL, IT languages

--- a/src/Calculator/PaymentFeeCalculator.php
+++ b/src/Calculator/PaymentFeeCalculator.php
@@ -114,11 +114,11 @@ class PaymentFeeCalculator
         float $totalFeePriceTaxIncl,
         float $surchargeLimit
     ): bool {
-        if (NumberUtility::isGreaterThan($totalFeePriceTaxIncl, $surchargeLimit)) {
-            return true;
+        if (NumberUtility::isLowerOrEqualThan($surchargeLimit, 0)) {
+            return false;
         }
 
-        return false;
+        return NumberUtility::isGreaterThan($totalFeePriceTaxIncl, $surchargeLimit);
     }
 
     private function buildPaymentFee(


### PR DESCRIPTION
When surcharge_limit was set to 0 (meaning no limit), the code incorrectly interpreted it as cap fee at 0, causing percentage and combined fees to never display at checkout.

Added check to treat surchargeLimit <= 0 as no limit.

<!-----------------------------------------------------------------------------
Thank you for contributing to the project!

Please take the time to edit the "Answers" rows below with the necessary information.

------------------------------------------------------------------------------>

| Questions       | Answers
|-----------------| -------------------------------------------------------
| Branch?         | Master/Release
| Description?    | Please be specific when describing the PR. <br> Every detail helps: versions, browser/server configuration, specific module/theme, etc. Feel free to add more information below this table.
| Type?           | bug fix / improvement / new feature / refactoring
| How to test?    | Indicate how to verify that this change works as expected.
| Fixed issue ?   | If none leave blank
