### PR TITLE
PIPRES-694: Hide googlepay payment method from back office settings page

### DIFF
--- a/controllers/admin/AdminMolliePaymentMethodsController.php
+++ b/controllers/admin/AdminMolliePaymentMethodsController.php
@@ -354,6 +354,11 @@ class AdminMolliePaymentMethodsController extends ModuleAdminController
                         continue;
                     }
 
+                    // Hide Google Pay from the payment methods list for now
+                    if ($methodId === 'googlepay') {
+                        continue;
+                    }
+
                     $formattedMethods[] = [
                         'id' => $methodId,
                         'name' => $method['name'],
@@ -579,6 +584,12 @@ class AdminMolliePaymentMethodsController extends ModuleAdminController
 
             foreach ($apiMethods as $method) {
                 $methodId = $method['id'];
+
+                // Skip Google Pay
+                if ($methodId === 'googlepay') {
+                    continue;
+                }
+
                 $isNew = !in_array($methodId, $currentMethodIds);
 
                 try {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the project!

Please take the time to edit the "Answers" rows below with the necessary information.

------------------------------------------------------------------------------>

| Questions       | Answers
|-----------------| -------------------------------------------------------
| Branch?         | Master/Release
| Description?    | Google Pay is not yet GA on the Mollie Platform. Displaying it on the PrestaShop payment activation page may allow merchants to attempt to enable a non‑GA feature.
| Type?           | bug fix / improvement / new feature / refactoring
| How to test?    | Indicate how to verify that this change works as expected.
| Fixed issue ?   | If none leave blank
