### PR TITLE
Fix template path with leading slash in hookDisplayCustomerAccount

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 + Added pre-translated email templates for FR, DE, ES, NL, IT languages
 + Removed unused Sentry error tracking code
 + Fixed errors in logs when changing order statuses of Payments API orders
++ Fixed template path in subscription account hook breaking theme overrides
 
 ## Changes in release 6.4.0
 + Back-office re-design

--- a/mollie.php
+++ b/mollie.php
@@ -1261,7 +1261,7 @@ class Mollie extends PaymentModule
             'id_customer' => $id_customer,
         ]);
 
-        return $this->display(dirname(__FILE__), '/views/templates/front/subscription/customerAccount.tpl');
+        return $this->display(__FILE__, 'views/templates/front/subscription/customerAccount.tpl');
     }
 
     /**


### PR DESCRIPTION
## Summary
- Fixed template path in `hookDisplayCustomerAccount` that had a leading slash breaking theme template override detection
- Changed `dirname(__FILE__)` to `__FILE__` to match pattern used elsewhere in the module
- The incorrect path caused double slashes in PrestaShop's `_isTemplateOverloadedStatic()` method

## Changes in release 6.4.1
- Fixed template path in subscription account hook breaking theme overrides

## Test plan
- [ ] Log in as customer on front office
- [ ] Go to My Account page
- [ ] Verify Subscriptions link appears correctly
- [ ] Create theme override at `themes/<theme>/modules/mollie/views/templates/front/subscription/customerAccount.tpl`
- [ ] Verify theme override is applied after clearing cache

Jira: https://mollie.atlassian.net/browse/PIPRES-700