### PR TITLE
PIPRES-705 hide admin order mollie block then orders is not paid

### DIFF
--- a/mollie.php
+++ b/mollie.php
@@ -601,6 +601,10 @@ class Mollie extends PaymentModule
 
             $order = new Order($params['id_order']);
 
+            if (!$order->hasBeenPaid()) {
+                return false;
+            }
+
             $products = TransactionUtility::isOrderTransaction($mollieTransactionId)
                 ? $this->getApiClient()->orders->get($mollieTransactionId, ['embed' => 'payments'])->lines
                 : $this->getApiClient()->payments->get($mollieTransactionId, ['embed' => 'payments'])->lines; // @phpstan-ignore-line


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the project!

Please take the time to edit the "Answers" rows below with the necessary information.

------------------------------------------------------------------------------>

| Questions       | Answers
|-----------------| -------------------------------------------------------
| Branch?         | Master/Release
| Description?    | When an order is in "Awaiting Mollie payment" (for example when the customer selected bank transfer / SEPA but has not completed the transfer yet), the Mollie block on the order page still lets the merchant use "Initiate Capture", "Initiate Refund", "Ship", "Ship All" and "Refund all". Clicking these leads to errors (e.g. "Die Zahlung konnte nicht erfasst werden!") because the payment is not completed or authorized in Mollie yet.
| Type?           | bug fix / improvement / new feature / refactoring
| How to test?    | Indicate how to verify that this change works as expected.
| Fixed issue ?   | If none leave blank
