### PR TITLE
Fix Apple Pay Direct on product page overriding existing cart

### DIFF
--- a/views/js/front/applePayDirect/applePayDirectProduct.js
+++ b/views/js/front/applePayDirect/applePayDirectProduct.js
@@ -43,7 +43,7 @@ $(document).ready(function () {
         const subtotal = product.quantity_wanted * product.price_amount;
         var supportedApplePaySessionVersion = 3;
         const session = new ApplePaySession(supportedApplePaySessionVersion, createRequest(countryCode, currencyCode, totalLabel, subtotal))
-        var cartId;
+        var applePayCartId = cartId;
         session.begin()
         session.onvalidatemerchant = (applePayValidateMerchantEvent) => {
             jQuery.ajax({
@@ -51,12 +51,13 @@ $(document).ready(function () {
                 method: 'POST',
                 data: {
                     action: 'mollie_apple_pay_validation',
-                    validationUrl: applePayValidateMerchantEvent.validationURL
+                    validationUrl: applePayValidateMerchantEvent.validationURL,
+                    cartId: applePayCartId
                 },
                 success: (merchantSession) => {
                     merchantSession = JSON.parse(merchantSession);
                     if (merchantSession.success === true) {
-                        cartId = merchantSession.cartId
+                        applePayCartId = merchantSession.cartId
                         session.completeMerchantValidation(JSON.parse(merchantSession.data))
                     } else {
                         console.warn(merchantSession.error)
@@ -89,7 +90,7 @@ $(document).ready(function () {
                     shippingContact: ApplePayPayment.payment.shippingContact,
                     billingContact: ApplePayPayment.payment.billingContact,
                     token: ApplePayPayment.payment.token,
-                    cartId: cartId,
+                    cartId: applePayCartId,
                 },
                 success: (authorizationResult) => {
                     let result = JSON.parse(authorizationResult)
@@ -118,7 +119,7 @@ $(document).ready(function () {
                     action: 'mollie_apple_pay_update_shipping_method',
                     shippingMethod: event.shippingMethod,
                     simplifiedContact: updatedContactInfo,
-                    cartId: cartId
+                    cartId: applePayCartId
                 },
                 success: (applePayShippingMethodUpdate) => {
                     let response = JSON.parse(applePayShippingMethodUpdate)
@@ -161,7 +162,7 @@ $(document).ready(function () {
                     postalCode: event.shippingContact.postalCode,
                     simplifiedContact: event.shippingContact,
                     products: products,
-                    cartId: cartId,
+                    cartId: applePayCartId,
                     customerId: customerId
                 },
                 success: (applePayShippingContactUpdate) => {


### PR DESCRIPTION
## Summary

- Fixed Apple Pay Direct CTA on product pages creating a new empty cart instead of using the customer's existing cart
- This caused incorrect totals (0 EUR) and loss of existing cart items when canceling the Apple Pay flow

## Root Cause

The product page JavaScript (`applePayDirectProduct.js`) was:
1. Declaring a local `var cartId;` that shadowed the global `cartId` injected from PHP
2. Not passing the `cartId` in the validation request
3. This caused `RequestApplePayPaymentSessionHandler` to create a new empty cart

## Changes

- Added local variable `applePayCartId` initialized with the global `cartId` (preserves global state)
- Pass `applePayCartId` to the merchant validation AJAX request
- Use `applePayCartId` throughout the Apple Pay session instead of modifying the global

## Test plan

- [ ] Add products A and B to cart
- [ ] Navigate to product C page
- [ ] Click Apple Pay Direct button
- [ ] Verify Apple Pay sheet shows total for A + B + C
- [ ] Cancel the Apple Pay flow
- [ ] Navigate to cart
- [ ] Verify cart contains A, B, and C (existing items preserved, clicked product added)
- [ ] Verify global `cartId` is not modified after canceling