### PR TITLE
Fix Apple Pay button disappearing on cart page when quantity is changed

### DIFF
--- a/views/js/front/applePayDirect/applePayDirectCart.js
+++ b/views/js/front/applePayDirect/applePayDirectCart.js
@@ -23,14 +23,15 @@ $(document).ready(function () {
     createAppleButton(applePayMethodElement, buttonStyle)
 
     $( document ).ajaxComplete(function( event, request, settings) {
-        var method = getUrlParam('action', settings.url)
-
-        if (method === 'refresh') {
+        setTimeout(function() {
             applePayMethodElement = document.querySelector(
                 '#mollie-applepay-direct-button',
             )
-            createAppleButton(applePayMethodElement, buttonStyle)
-        }
+
+            if (applePayMethodElement && !document.querySelector('#mollie_applepay_button')) {
+                createAppleButton(applePayMethodElement, buttonStyle)
+            }
+        }, 100);
     });
 
 


### PR DESCRIPTION
The Apple Pay button was disappearing when changing product quantity on the cart page because the ajaxComplete handler only recreated the button when the AJAX action was 'refresh'. Cart quantity updates use different actions, so the button was not recreated after the cart HTML re-rendered.

Changes:
- Remove action type check, recreate button on any AJAX completion
- Add 100ms delay to ensure DOM is fully updated before checking
- Only recreate if container exists but button is missing

<!-----------------------------------------------------------------------------
Thank you for contributing to the project!

Please take the time to edit the "Answers" rows below with the necessary information.

------------------------------------------------------------------------------>

| Questions       | Answers
|-----------------| -------------------------------------------------------
| Branch?         | Master/Release
| Description?    | Please be specific when describing the PR. <br> Every detail helps: versions, browser/server configuration, specific module/theme, etc. Feel free to add more information below this table.
| Type?           | bug fix / improvement / new feature / refactoring
| How to test?    | Indicate how to verify that this change works as expected.
| Fixed issue ?   | If none leave blank
