### PR TITLE
PIPRES-726 Fix unset bug in compositeRoundingInaccuracies causing payment failures

### DIFF
--- a/src/Service/CartLinesService.php
+++ b/src/Service/CartLinesService.php
@@ -294,27 +294,30 @@ class CartLinesService
         $remaining = round($remaining, $apiRoundingPrecision);
         if ($remaining < 0) {
             foreach (array_reverse($orderLines) as $hash => $items) {
-                // Grab the line group's total amount
-                $totalAmount = array_sum(array_column($items, 'totalAmount'));
-
-                // Remove when total is lower than remaining
-                if ($totalAmount <= $remaining) {
-                    // The line total is less than remaining, we should remove this line group and continue
-                    $remaining = $remaining - $totalAmount;
-                    unset($items);
+                $lineType = isset($items[0]['type']) ? $items[0]['type'] : '';
+                if ($lineType !== 'physical' && $lineType !== 'digital') {
                     continue;
                 }
 
-                // Otherwise spread the cart line again with the updated total
-                //TODO: check why remaining comes -100 when testing and new total becomes different
+                $totalAmount = array_sum(array_column($items, 'totalAmount'));
+
+                if ($totalAmount <= $remaining) {
+                    $remaining = $remaining - $totalAmount;
+                    unset($orderLines[$hash]);
+                    continue;
+                }
+
                 $orderLines[$hash] = static::spreadCartLineGroup($items, $totalAmount + $remaining);
                 break;
             }
         } elseif ($remaining > 0) {
             foreach (array_reverse($orderLines) as $hash => $items) {
-                // Grab the line group's total amount
+                $lineType = isset($items[0]['type']) ? $items[0]['type'] : '';
+                if ($lineType !== 'physical' && $lineType !== 'digital') {
+                    continue;
+                }
+
                 $totalAmount = array_sum(array_column($items, 'totalAmount'));
-                // Otherwise spread the cart line again with the updated total
                 $orderLines[$hash] = static::spreadCartLineGroup($items, $totalAmount + $remaining);
                 break;
             }

--- a/tests/Unit/Service/CompositeRoundingInaccuraciesTest.php
+++ b/tests/Unit/Service/CompositeRoundingInaccuraciesTest.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Mollie       https://www.mollie.nl
+ *
+ * @author      Mollie B.V. <info@mollie.nl>
+ * @copyright   Mollie B.V.
+ * @license     https://github.com/mollie/PrestaShop/blob/master/LICENSE.md
+ *
+ * @see        https://github.com/mollie/PrestaShop
+ * @codingStandardsIgnoreStart
+ */
+
+namespace Mollie\Tests\Unit\Service;
+
+if (!defined('_PS_VERSION_')) {
+    define('_PS_VERSION_', '8.2.3');
+}
+
+use Mollie\DTO\PaymentFeeData;
+use Mollie\Service\CartLinesService;
+use PHPUnit\Framework\TestCase;
+
+class CompositeRoundingInaccuraciesTest extends TestCase
+{
+    private function invokeMethod($remaining, $orderLines)
+    {
+        $service = (new \ReflectionClass(CartLinesService::class))->newInstanceWithoutConstructor();
+        $method = new \ReflectionMethod(CartLinesService::class, 'compositeRoundingInaccuracies');
+        $method->setAccessible(true);
+
+        return $method->invoke($service, $remaining, 2, $orderLines, new PaymentFeeData(false, 0, 0, 0));
+    }
+
+    private function sumLines($result)
+    {
+        $sum = 0;
+        foreach ($result as $items) {
+            foreach ($items as $item) {
+                $sum += $item['totalAmount'];
+            }
+        }
+
+        return round($sum, 2);
+    }
+
+    /**
+     * @dataProvider roundingProvider
+     */
+    public function testCompositeRoundingInaccuracies(
+        $remaining,
+        $orderLines,
+        $expectedSum,
+        $expectedGroupCount
+    ) {
+        $result = $this->invokeMethod($remaining, $orderLines);
+
+        self::assertEquals($expectedSum, $this->sumLines($result));
+        self::assertCount($expectedGroupCount, $result);
+    }
+
+    public function roundingProvider()
+    {
+        return [
+            'negative remaining with discount — product adjusted, discount untouched' => [
+                -0.01,
+                [
+                    '23¤0¤0' => [
+                        ['name' => 'Product', 'type' => 'physical', 'quantity' => 1, 'unitPrice' => 12.04, 'totalAmount' => 12.04, 'vatRate' => '20.00', 'vatAmount' => 2.01, 'targetVat' => '20.00', 'categories' => []],
+                        ['name' => 'Product', 'type' => 'physical', 'quantity' => 1, 'unitPrice' => 12.04, 'totalAmount' => 12.04, 'vatRate' => '20.00', 'vatAmount' => 2.01, 'targetVat' => '20.00', 'categories' => []],
+                        ['name' => 'Product', 'type' => 'physical', 'quantity' => 1, 'unitPrice' => 12.04, 'totalAmount' => 12.04, 'vatRate' => '20.00', 'vatAmount' => 2.01, 'targetVat' => '20.00', 'categories' => []],
+                    ],
+                    'discount' => [
+                        ['name' => 'Voucher', 'type' => 'discount', 'quantity' => 1, 'unitPrice' => -5.00, 'totalAmount' => -5.00, 'vatRate' => '0.00', 'vatAmount' => 0],
+                    ],
+                ],
+                31.11,
+                2,
+            ],
+            'negative remaining — shipping untouched, product adjusted' => [
+                -0.01,
+                [
+                    '10¤0¤0' => [
+                        ['name' => 'Product', 'type' => 'physical', 'quantity' => 1, 'unitPrice' => 40.00, 'totalAmount' => 40.00, 'vatRate' => '20.00', 'vatAmount' => 6.67, 'targetVat' => '20.00', 'categories' => []],
+                    ],
+                    'shipping' => [
+                        ['name' => 'Shipping', 'type' => 'shipping_fee', 'quantity' => 1, 'unitPrice' => 5.00, 'totalAmount' => 5.00, 'vatRate' => '20.00', 'vatAmount' => 0.83],
+                    ],
+                ],
+                44.99,
+                2,
+            ],
+            'positive remaining — discount untouched, product adjusted' => [
+                0.01,
+                [
+                    '5¤0¤0' => [
+                        ['name' => 'Product', 'type' => 'physical', 'quantity' => 1, 'unitPrice' => 20.00, 'totalAmount' => 20.00, 'vatRate' => '20.00', 'vatAmount' => 3.33, 'targetVat' => '20.00', 'categories' => []],
+                    ],
+                    'discount' => [
+                        ['name' => 'Discount', 'type' => 'discount', 'quantity' => 1, 'unitPrice' => -2.00, 'totalAmount' => -2.00, 'vatRate' => '0.00', 'vatAmount' => 0],
+                    ],
+                ],
+                18.01,
+                2,
+            ],
+            'zero remaining — no changes' => [
+                0,
+                [
+                    '1¤0¤0' => [
+                        ['name' => 'Product', 'type' => 'physical', 'quantity' => 1, 'unitPrice' => 25.00, 'totalAmount' => 25.00, 'vatRate' => '21.00', 'vatAmount' => 4.34, 'targetVat' => '21.00', 'categories' => []],
+                    ],
+                    'discount' => [
+                        ['name' => 'Discount', 'type' => 'discount', 'quantity' => 1, 'unitPrice' => -3.00, 'totalAmount' => -3.00, 'vatRate' => '0.00', 'vatAmount' => 0],
+                    ],
+                ],
+                22.00,
+                2,
+            ],
+            'negative remaining — product only, no discount or shipping' => [
+                -0.02,
+                [
+                    '7¤0¤0' => [
+                        ['name' => 'Product', 'type' => 'physical', 'quantity' => 1, 'unitPrice' => 30.00, 'totalAmount' => 30.00, 'vatRate' => '20.00', 'vatAmount' => 5.00, 'targetVat' => '20.00', 'categories' => []],
+                    ],
+                ],
+                29.98,
+                1,
+            ],
+            'negative remaining — digital product adjusted' => [
+                -0.01,
+                [
+                    '3¤0¤0' => [
+                        ['name' => 'Digital', 'type' => 'digital', 'quantity' => 1, 'unitPrice' => 9.99, 'totalAmount' => 9.99, 'vatRate' => '20.00', 'vatAmount' => 1.67, 'targetVat' => '20.00', 'categories' => []],
+                    ],
+                ],
+                9.98,
+                1,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- Fixed `unset($items)` in `compositeRoundingInaccuracies()` — it only removed the local foreach variable, not the actual `$orderLines` entry. Changed to `unset($orderLines[$hash])`
- Added type filtering so only physical/digital product lines are adjusted for rounding — discount and shipping lines are now skipped
- When a discount line was processed first (via `array_reverse`), its negative totalAmount inflated the remaining value instead of being removed, distorting product prices by the full discount amount and causing Mollie API rejection

## Root cause
Cart with products + fixed discount voucher + specific rounding (PS_ROUND_TYPE=2) produced a -0.01 remaining. The discount line iterated first, `unset($items)` had no effect, remaining flipped from -0.01 to +4.99, and the product line was spread to an inflated total — creating a gap between line totals and order amount.

## Test plan
- [x] Added `CompositeRoundingInaccuraciesTest` with 6 data-driven test cases covering: discount+products, shipping+product, positive remaining, zero remaining, product-only, digital product
- [ ] Verify checkout with products + discount voucher completes payment successfully
- [ ] Verify checkout without discount still works
- [ ] Verify checkout with shipping fee + discount works