### PR TITLE
PIPRES-738 Restore partial quantity support for Orders API order line actions

### DIFF
--- a/controllers/admin/AdminMollieAjaxController.php
+++ b/controllers/admin/AdminMollieAjaxController.php
@@ -237,11 +237,12 @@ class AdminMollieAjaxController extends ModuleAdminController
             $transactionId = Tools::getValue('transactionId');
             $refundAmount = (float) Tools::getValue('refundAmount') ?: null;
             $orderLineId = Tools::getValue('orderline') ?: null;
+            $quantity = Tools::getValue('quantity') ?: null;
 
             /** @var RefundService $refundService */
             $refundService = $this->module->getService(RefundService::class);
 
-            $status = $refundService->handleRefund($transactionId, $refundAmount, $orderLineId);
+            $status = $refundService->handleRefund($transactionId, $refundAmount, $orderLineId, $quantity);
 
             $this->ajaxRender(json_encode($status));
         } catch (\Throwable $e) {
@@ -261,6 +262,7 @@ class AdminMollieAjaxController extends ModuleAdminController
         $orderLines = Tools::getValue('orderLines') ?: [];
         $tracking = Tools::getValue('tracking');
         $orderlineId = Tools::getValue('orderline');
+        $quantity = Tools::getValue('quantity') ?: null;
 
         try {
             $order = new Order($orderId);
@@ -271,7 +273,7 @@ class AdminMollieAjaxController extends ModuleAdminController
 
             /** @var ShipService $shipService */
             $shipService = $this->module->getService(ShipService::class);
-            $status = $shipService->handleShip($transactionId, $orderlineId, $tracking);
+            $status = $shipService->handleShip($transactionId, $orderlineId, $tracking, $quantity);
 
             $this->ajaxRender(json_encode($status));
         } catch (\Throwable $e) {
@@ -319,6 +321,7 @@ class AdminMollieAjaxController extends ModuleAdminController
     {
         $orderId = (int) Tools::getValue('orderId');
         $orderlineId = Tools::getValue('orderline') ?: null;
+        $quantity = Tools::getValue('quantity') ?: null;
 
         try {
             $order = new Order($orderId);
@@ -329,7 +332,7 @@ class AdminMollieAjaxController extends ModuleAdminController
 
             /** @var CancelService $cancelService */
             $cancelService = $this->module->getService(CancelService::class);
-            $status = $cancelService->handleCancel($transactionId, $orderlineId);
+            $status = $cancelService->handleCancel($transactionId, $orderlineId, $quantity);
 
             $this->ajaxRender(json_encode($status));
         } catch (\Throwable $e) {

--- a/controllers/admin/AdminMollieAjaxController.php
+++ b/controllers/admin/AdminMollieAjaxController.php
@@ -237,7 +237,10 @@ class AdminMollieAjaxController extends ModuleAdminController
             $transactionId = Tools::getValue('transactionId');
             $refundAmount = (float) Tools::getValue('refundAmount') ?: null;
             $orderLineId = Tools::getValue('orderline') ?: null;
-            $quantity = Tools::getValue('quantity') ?: null;
+            $quantity = Tools::getValue('quantity') ? (int) Tools::getValue('quantity') : null;
+            if ($quantity !== null && $quantity < 1) {
+                $quantity = null;
+            }
 
             /** @var RefundService $refundService */
             $refundService = $this->module->getService(RefundService::class);
@@ -262,7 +265,10 @@ class AdminMollieAjaxController extends ModuleAdminController
         $orderLines = Tools::getValue('orderLines') ?: [];
         $tracking = Tools::getValue('tracking');
         $orderlineId = Tools::getValue('orderline');
-        $quantity = Tools::getValue('quantity') ?: null;
+        $quantity = Tools::getValue('quantity') ? (int) Tools::getValue('quantity') : null;
+        if ($quantity !== null && $quantity < 1) {
+            $quantity = null;
+        }
 
         try {
             $order = new Order($orderId);
@@ -321,7 +327,10 @@ class AdminMollieAjaxController extends ModuleAdminController
     {
         $orderId = (int) Tools::getValue('orderId');
         $orderlineId = Tools::getValue('orderline') ?: null;
-        $quantity = Tools::getValue('quantity') ?: null;
+        $quantity = Tools::getValue('quantity') ? (int) Tools::getValue('quantity') : null;
+        if ($quantity !== null && $quantity < 1) {
+            $quantity = null;
+        }
 
         try {
             $order = new Order($orderId);

--- a/mollie.php
+++ b/mollie.php
@@ -619,11 +619,30 @@ class Mollie extends PaymentModule
             $isShipped = $shipService->isShipped($mollieTransactionId);
             $isCanceled = $cancelService->isCanceled($mollieTransactionId);
 
+            $lineActions = [];
+            if ($mollieApiType === 'orders' && $products) {
+                foreach ($products as $line) {
+                    $isNonActionable = in_array($line->type, ['discount'], true);
+                    $isNonShippable = in_array($line->type, ['discount', 'shipping_fee', 'surcharge'], true);
+                    $fullyRefunded = (int) $line->quantityRefunded >= (int) $line->quantity;
+
+                    $lineActions[$line->id] = [
+                        'canShip' => !$isNonShippable && (int) $line->shippableQuantity > 0 && !$fullyRefunded,
+                        'canCancel' => !$isNonActionable && (int) $line->cancelableQuantity > 0 && !$fullyRefunded,
+                        'canRefund' => !$isNonActionable && (int) $line->refundableQuantity > 0,
+                        'shippableQuantity' => (int) $line->shippableQuantity,
+                        'cancelableQuantity' => (int) $line->cancelableQuantity,
+                        'refundableQuantity' => (int) $line->refundableQuantity,
+                    ];
+                }
+            }
+
             $this->context->smarty->assign([
                 'order_reference' => $order->reference,
                 'refundable_amount' => $refundableAmount,
                 'capturable_amount' => $capturableAmount,
                 'products' => $products,
+                'lineActions' => $lineActions,
                 'mollie_logo_path' => $mollieLogoPath,
                 'mollie_transaction_id' => $mollieTransactionId,
                 'mollie_api_type' => $mollieApiType,

--- a/src/Service/CancelService.php
+++ b/src/Service/CancelService.php
@@ -35,13 +35,17 @@ class CancelService
         $this->logger = $this->module->getService(LoggerInterface::class);
     }
 
-    public function handleCancel($transactionId, $orderlineId = null)
+    public function handleCancel($transactionId, $orderlineId = null, $quantity = null)
     {
         try {
             $order = $this->module->getApiClient()->orders->get($transactionId, ['embed' => 'payments']);
 
             if ($orderlineId) {
-                $order->cancelLines(['lines' => [['id' => $orderlineId]]]);
+                $lineData = ['id' => $orderlineId];
+                if ($quantity) {
+                    $lineData['quantity'] = (int) $quantity;
+                }
+                $order->cancelLines(['lines' => [$lineData]]);
                 $message = $this->module->l('Order line has been canceled successfully.');
             } else {
                 $order->cancel();

--- a/src/Service/RefundService.php
+++ b/src/Service/RefundService.php
@@ -50,7 +50,7 @@ class RefundService
      *
      * @return array
      */
-    public function handleRefund(string $transactionId, ?float $amount = null, ?string $orderLineId = null, $quantity = null)
+    public function handleRefund(string $transactionId, ?float $amount = null, ?string $orderLineId = null, ?int $quantity = null)
     {
         try {
             $payment = TransactionUtility::isOrderTransaction($transactionId)

--- a/src/Service/RefundService.php
+++ b/src/Service/RefundService.php
@@ -50,7 +50,7 @@ class RefundService
      *
      * @return array
      */
-    public function handleRefund(string $transactionId, ?float $amount = null, ?string $orderLineId = null)
+    public function handleRefund(string $transactionId, ?float $amount = null, ?string $orderLineId = null, $quantity = null)
     {
         try {
             $payment = TransactionUtility::isOrderTransaction($transactionId)
@@ -62,10 +62,12 @@ class RefundService
             $currency = $payment->amount->currency;
 
             if ($isPartialRefund && TransactionUtility::isOrderTransaction($transactionId)) {
+                $lineData = ['id' => $orderLineId];
+                if ($quantity) {
+                    $lineData['quantity'] = (int) $quantity;
+                }
                 $payment->refund([
-                    'lines' => [
-                        ['id' => $orderLineId],
-                    ],
+                    'lines' => [$lineData],
                 ]);
 
                 return $this->createSuccessResponse(true, null, $currency);

--- a/src/Service/RefundService.php
+++ b/src/Service/RefundService.php
@@ -61,16 +61,22 @@ class RefundService
 
             $currency = $payment->amount->currency;
 
-            if ($isPartialRefund && TransactionUtility::isOrderTransaction($transactionId)) {
-                $lineData = ['id' => $orderLineId];
-                if ($quantity) {
-                    $lineData['quantity'] = (int) $quantity;
-                }
-                $payment->refund([
-                    'lines' => [$lineData],
-                ]);
+            if (TransactionUtility::isOrderTransaction($transactionId)) {
+                if ($orderLineId) {
+                    $lineData = ['id' => $orderLineId];
+                    if ($quantity) {
+                        $lineData['quantity'] = (int) $quantity;
+                    }
+                    $payment->refund([
+                        'lines' => [$lineData],
+                    ]);
 
-                return $this->createSuccessResponse(true, null, $currency);
+                    return $this->createSuccessResponse(true, null, $currency);
+                }
+
+                $payment->refundAll();
+
+                return $this->createSuccessResponse(false, null, $currency);
             }
 
             $refundAmount = $this->calculateRefundAmount($payment, $amount);
@@ -80,7 +86,7 @@ class RefundService
 
             $isPartial = $amount !== null && (float) $refundAmount < (float) $payment->amount->value;
 
-            $this->processRefund($payment, $refundAmount, TransactionUtility::isOrderTransaction($transactionId));
+            $this->processRefund($payment, $refundAmount, false);
 
             return $this->createSuccessResponse($isPartial, $refundAmount, $currency);
         } catch (ApiException $e) {

--- a/src/Service/ShipService.php
+++ b/src/Service/ShipService.php
@@ -46,7 +46,7 @@ class ShipService
      *
      * @since 3.3.0
      */
-    public function handleShip($transactionId, $orderlineId = null, $tracking = null)
+    public function handleShip($transactionId, $orderlineId = null, $tracking = null, $quantity = null)
     {
         try {
             /** @var MollieOrderAlias $payment */
@@ -54,11 +54,11 @@ class ShipService
             $shipmentData = [];
 
             if ($orderlineId) {
-                $shipmentData['lines'] = [
-                    [
-                        'id' => $orderlineId,
-                    ],
-                ];
+                $lineData = ['id' => $orderlineId];
+                if ($quantity) {
+                    $lineData['quantity'] = (int) $quantity;
+                }
+                $shipmentData['lines'] = [$lineData];
             }
 
             if ($tracking['carrier'] && $tracking['code'] && $tracking['tracking_url']) {

--- a/src/Service/ShipService.php
+++ b/src/Service/ShipService.php
@@ -61,18 +61,23 @@ class ShipService
                 $shipmentData['lines'] = [$lineData];
             }
 
-            if ($tracking['carrier'] && $tracking['code'] && $tracking['tracking_url']) {
+            if (!empty($tracking['carrier']) && !empty($tracking['code'])) {
                 $validationResult = $this->validateTracking($tracking);
 
                 if (!$validationResult['success']) {
                     return $validationResult;
                 }
 
-                $shipmentData['tracking'] = [
+                $trackingData = [
                     'carrier' => $tracking['carrier'],
                     'code' => $tracking['code'],
-                    'url' => $tracking['tracking_url'],
                 ];
+
+                if (!empty($tracking['tracking_url'])) {
+                    $trackingData['url'] = $tracking['tracking_url'];
+                }
+
+                $shipmentData['tracking'] = $trackingData;
             }
 
             $order->createShipment($shipmentData);
@@ -125,7 +130,7 @@ class ShipService
 
     private function validateTracking(array $tracking): array
     {
-        if (!Validate::isAbsoluteUrl($tracking['tracking_url'])) {
+        if (!empty($tracking['tracking_url']) && !Validate::isAbsoluteUrl($tracking['tracking_url'])) {
             return [
                 'success' => false,
                 'message' => $this->module->l('Invalid tracking URL provided', self::FILE_NAME),

--- a/views/js/admin/library/package-lock.json
+++ b/views/js/admin/library/package-lock.json
@@ -1657,6 +1657,66 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.4.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.0.4",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.4.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.13.tgz",
@@ -3569,9 +3629,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3950,9 +4010,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4189,9 +4249,9 @@
       }
     },
     "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/views/js/admin/library/package-lock.json
+++ b/views/js/admin/library/package-lock.json
@@ -1122,9 +1122,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.52.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.2.tgz",
-      "integrity": "sha512-o3pcKzJgSGt4d74lSZ+OCnHwkKBeAbFDmbEm5gg70eA8VkyCuC/zV9TwBnmw6VjDlRdF4Pshfb+WE9E6XY1PoQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
       "cpu": [
         "arm"
       ],
@@ -1136,9 +1136,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.52.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.2.tgz",
-      "integrity": "sha512-cqFSWO5tX2vhC9hJTK8WAiPIm4Q8q/cU8j2HQA0L3E1uXvBYbOZMhE2oFL8n2pKB5sOCHY6bBuHaRwG7TkfJyw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
       "cpu": [
         "arm64"
       ],
@@ -1150,9 +1150,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.52.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.2.tgz",
-      "integrity": "sha512-vngduywkkv8Fkh3wIZf5nFPXzWsNsVu1kvtLETWxTFf/5opZmflgVSeLgdHR56RQh71xhPhWoOkEBvbehwTlVA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
       "cpu": [
         "arm64"
       ],
@@ -1164,9 +1164,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.52.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.2.tgz",
-      "integrity": "sha512-h11KikYrUCYTrDj6h939hhMNlqU2fo/X4NB0OZcys3fya49o1hmFaczAiJWVAFgrM1NCP6RrO7lQKeVYSKBPSQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
       "cpu": [
         "x64"
       ],
@@ -1178,9 +1178,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.52.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.2.tgz",
-      "integrity": "sha512-/eg4CI61ZUkLXxMHyVlmlGrSQZ34xqWlZNW43IAU4RmdzWEx0mQJ2mN/Cx4IHLVZFL6UBGAh+/GXhgvGb+nVxw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
       "cpu": [
         "arm64"
       ],
@@ -1192,9 +1192,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.52.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.2.tgz",
-      "integrity": "sha512-QOWgFH5X9+p+S1NAfOqc0z8qEpJIoUHf7OWjNUGOeW18Mx22lAUOiA9b6r2/vpzLdfxi/f+VWsYjUOMCcYh0Ng==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
       "cpu": [
         "x64"
       ],
@@ -1206,9 +1206,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.52.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.2.tgz",
-      "integrity": "sha512-kDWSPafToDd8LcBYd1t5jw7bD5Ojcu12S3uT372e5HKPzQt532vW+rGFFOaiR0opxePyUkHrwz8iWYEyH1IIQA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
       "cpu": [
         "arm"
       ],
@@ -1220,9 +1220,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.52.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.2.tgz",
-      "integrity": "sha512-gKm7Mk9wCv6/rkzwCiUC4KnevYhlf8ztBrDRT9g/u//1fZLapSRc+eDZj2Eu2wpJ+0RzUKgtNijnVIB4ZxyL+w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
       "cpu": [
         "arm"
       ],
@@ -1234,9 +1234,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.52.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.2.tgz",
-      "integrity": "sha512-66lA8vnj5mB/rtDNwPgrrKUOtCLVQypkyDa2gMfOefXK6rcZAxKLO9Fy3GkW8VkPnENv9hBkNOFfGLf6rNKGUg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
       "cpu": [
         "arm64"
       ],
@@ -1248,9 +1248,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.52.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.2.tgz",
-      "integrity": "sha512-s+OPucLNdJHvuZHuIz2WwncJ+SfWHFEmlC5nKMUgAelUeBUnlB4wt7rXWiyG4Zn07uY2Dd+SGyVa9oyLkVGOjA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
       "cpu": [
         "arm64"
       ],
@@ -1262,9 +1262,23 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.52.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.2.tgz",
-      "integrity": "sha512-8wTRM3+gVMDLLDdaT6tKmOE3lJyRy9NpJUS/ZRWmLCmOPIJhVyXwjBo+XbrrwtV33Em1/eCTd5TuGJm4+DmYjw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
       "cpu": [
         "loong64"
       ],
@@ -1276,9 +1290,23 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.52.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.2.tgz",
-      "integrity": "sha512-6yqEfgJ1anIeuP2P/zhtfBlDpXUb80t8DpbYwXQ3bQd95JMvUaqiX+fKqYqUwZXqdJDd8xdilNtsHM2N0cFm6A==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
       "cpu": [
         "ppc64"
       ],
@@ -1290,9 +1318,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.52.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.2.tgz",
-      "integrity": "sha512-sshYUiYVSEI2B6dp4jMncwxbrUqRdNApF2c3bhtLAU0qA8Lrri0p0NauOsTWh3yCCCDyBOjESHMExonp7Nzc0w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
       "cpu": [
         "riscv64"
       ],
@@ -1304,9 +1332,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.52.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.2.tgz",
-      "integrity": "sha512-duBLgd+3pqC4MMwBrKkFxaZerUxZcYApQVC5SdbF5/e/589GwVvlRUnyqMFbM8iUSb1BaoX/3fRL7hB9m2Pj8Q==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
       "cpu": [
         "riscv64"
       ],
@@ -1318,9 +1346,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.52.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.2.tgz",
-      "integrity": "sha512-tzhYJJidDUVGMgVyE+PmxENPHlvvqm1KILjjZhB8/xHYqAGeizh3GBGf9u6WdJpZrz1aCpIIHG0LgJgH9rVjHQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
       "cpu": [
         "s390x"
       ],
@@ -1332,9 +1360,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.52.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.2.tgz",
-      "integrity": "sha512-opH8GSUuVcCSSyHHcl5hELrmnk4waZoVpgn/4FDao9iyE4WpQhyWJ5ryl5M3ocp4qkRuHfyXnGqg8M9oKCEKRA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
       "cpu": [
         "x64"
       ],
@@ -1346,9 +1374,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.52.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.2.tgz",
-      "integrity": "sha512-LSeBHnGli1pPKVJ79ZVJgeZWWZXkEe/5o8kcn23M8eMKCUANejchJbF/JqzM4RRjOJfNRhKJk8FuqL1GKjF5oQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
       "cpu": [
         "x64"
       ],
@@ -1359,10 +1387,24 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.52.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.2.tgz",
-      "integrity": "sha512-uPj7MQ6/s+/GOpolavm6BPo+6CbhbKYyZHUDvZ/SmJM7pfDBgdGisFX3bY/CBDMg2ZO4utfhlApkSfZ92yXw7Q==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
       "cpu": [
         "arm64"
       ],
@@ -1374,9 +1416,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.52.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.2.tgz",
-      "integrity": "sha512-Z9MUCrSgIaUeeHAiNkm3cQyst2UhzjPraR3gYYfOjAuZI7tcFRTOD+4cHLPoS/3qinchth+V56vtqz1Tv+6KPA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
       "cpu": [
         "arm64"
       ],
@@ -1388,9 +1430,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.52.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.2.tgz",
-      "integrity": "sha512-+GnYBmpjldD3XQd+HMejo+0gJGwYIOfFeoBQv32xF/RUIvccUz20/V6Otdv+57NE70D5pa8W/jVGDoGq0oON4A==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
       "cpu": [
         "ia32"
       ],
@@ -1402,9 +1444,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.52.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.2.tgz",
-      "integrity": "sha512-ApXFKluSB6kDQkAqZOKXBjiaqdF1BlKi+/eqnYe9Ee7U2K3pUDKsIyr8EYm/QDHTJIM+4X+lI0gJc3TTRhd+dA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
       "cpu": [
         "x64"
       ],
@@ -1416,9 +1458,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.52.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.2.tgz",
-      "integrity": "sha512-ARz+Bs8kY6FtitYM96PqPEVvPXqEZmPZsSkXvyX19YzDqkCaIlhCieLLMI5hxO9SRZ2XtCtm8wxhy0iJ2jxNfw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
       "cpu": [
         "x64"
       ],
@@ -1656,6 +1698,66 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.4.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.0.4",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.4.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.13",
@@ -3709,9 +3811,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.52.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.2.tgz",
-      "integrity": "sha512-I25/2QgoROE1vYV+NQ1En9T9UFB9Cmfm2CJ83zZOlaDpvz29wGQSZXWKw7MiNXau7wYgB/T9fVIdIuEQ+KbiiA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3725,28 +3827,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.52.2",
-        "@rollup/rollup-android-arm64": "4.52.2",
-        "@rollup/rollup-darwin-arm64": "4.52.2",
-        "@rollup/rollup-darwin-x64": "4.52.2",
-        "@rollup/rollup-freebsd-arm64": "4.52.2",
-        "@rollup/rollup-freebsd-x64": "4.52.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.52.2",
-        "@rollup/rollup-linux-arm-musleabihf": "4.52.2",
-        "@rollup/rollup-linux-arm64-gnu": "4.52.2",
-        "@rollup/rollup-linux-arm64-musl": "4.52.2",
-        "@rollup/rollup-linux-loong64-gnu": "4.52.2",
-        "@rollup/rollup-linux-ppc64-gnu": "4.52.2",
-        "@rollup/rollup-linux-riscv64-gnu": "4.52.2",
-        "@rollup/rollup-linux-riscv64-musl": "4.52.2",
-        "@rollup/rollup-linux-s390x-gnu": "4.52.2",
-        "@rollup/rollup-linux-x64-gnu": "4.52.2",
-        "@rollup/rollup-linux-x64-musl": "4.52.2",
-        "@rollup/rollup-openharmony-arm64": "4.52.2",
-        "@rollup/rollup-win32-arm64-msvc": "4.52.2",
-        "@rollup/rollup-win32-ia32-msvc": "4.52.2",
-        "@rollup/rollup-win32-x64-gnu": "4.52.2",
-        "@rollup/rollup-win32-x64-msvc": "4.52.2",
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
         "fsevents": "~2.3.2"
       }
     },

--- a/views/js/admin/order_info.js
+++ b/views/js/admin/order_info.js
@@ -19,14 +19,14 @@ $(document).ready(function () {
       for (var i = 1; i <= maxQuantity; i++) {
         $select.append('<option value="' + i + '">' + i + 'x</option>');
       }
-      $select.val(maxQuantity);
+      $select.val(1);
       $group.show();
     } else {
       $group.hide();
     }
   }
 
-  function showModal(action, productId, productAmount, orderline, availableQuantity, productName) {
+  function showModal(action, productId, productAmount, orderline, availableQuantity) {
     var amount = productAmount;
 
     // For refund actions, get amount from input field if not provided
@@ -53,7 +53,6 @@ $(document).ready(function () {
       amount: amount,
       orderline: orderline || null,
       availableQuantity: availableQuantity || null,
-      productName: productName || null,
     };
 
     if (action === 'refund' || action === 'refundAll') {
@@ -99,18 +98,16 @@ $(document).ready(function () {
     var amount = $(this).data('price');
     var orderline = $(this).data('orderline');
     var availableQuantity = $(this).data('available-quantity');
-    var productName = $(this).data('product-name');
 
-    showModal('refund', productId, amount, orderline, availableQuantity, productName);
+    showModal('refund', productId, amount, orderline, availableQuantity);
   });
 
   $('.mollie-ship-btn').on('click', function() {
     var productId = $(this).data('product');
     var orderline = $(this).data('orderline');
     var availableQuantity = $(this).data('available-quantity');
-    var productName = $(this).data('product-name');
 
-    showModal('ship', productId, null, orderline, availableQuantity, productName);
+    showModal('ship', productId, null, orderline, availableQuantity);
   });
 
   $('.mollie-capture-btn').on('click', function() {
@@ -123,9 +120,8 @@ $(document).ready(function () {
   $('.mollie-cancel-btn').on('click', function() {
     var orderline = $(this).data('orderline');
     var availableQuantity = $(this).data('available-quantity');
-    var productName = $(this).data('product-name');
 
-    showModal('cancel', null, null, orderline, availableQuantity, productName);
+    showModal('cancel', null, null, orderline, availableQuantity);
   });
 
   $('#mollie-initiate-refund').on('click', function() {

--- a/views/js/admin/order_info.js
+++ b/views/js/admin/order_info.js
@@ -293,12 +293,9 @@ $(document).ready(function () {
             successMessage += ' ' + (response.detailed || response.msg_details);
           }
           showSuccessMessage(successMessage);
-          if (response.payment) {
-            console.log('Payment updated:', response.payment);
-          }
-          if (response.order) {
-            console.log('Order updated:', response.order);
-          }
+          setTimeout(function() {
+            location.reload();
+          }, 1500);
         } else {
           showErrorMessage(response.message || response.detailed || trans.errorOccurred);
         }

--- a/views/js/admin/order_info.js
+++ b/views/js/admin/order_info.js
@@ -10,7 +10,23 @@
 $(document).ready(function () {
   var actionContext = {};
 
-  function showModal(action, productId, productAmount, orderline) {
+  function populateQuantitySelector(selectId, groupId, maxQuantity) {
+    var $select = $(selectId);
+    var $group = $(groupId);
+    $select.empty();
+
+    if (maxQuantity && maxQuantity > 1) {
+      for (var i = 1; i <= maxQuantity; i++) {
+        $select.append('<option value="' + i + '">' + i + 'x</option>');
+      }
+      $select.val(maxQuantity);
+      $group.show();
+    } else {
+      $group.hide();
+    }
+  }
+
+  function showModal(action, productId, productAmount, orderline, availableQuantity, productName) {
     var amount = productAmount;
 
     // For refund actions, get amount from input field if not provided
@@ -36,6 +52,8 @@ $(document).ready(function () {
       resource: resource,
       amount: amount,
       orderline: orderline || null,
+      availableQuantity: availableQuantity || null,
+      productName: productName || null,
     };
 
     if (action === 'refund' || action === 'refundAll') {
@@ -47,8 +65,14 @@ $(document).ready(function () {
       } else {
         $('#mollie-refund-modal-message').text(trans.refundOrderConfirm);
       }
+      if (orderline) {
+        populateQuantitySelector('#mollie-refund-quantity', '#mollie-refund-quantity-group', availableQuantity);
+      } else {
+        $('#mollie-refund-quantity-group').hide();
+      }
       $('#mollieRefundModal').modal('show');
     } else if (action === 'ship' || action === 'shipAll') {
+      populateQuantitySelector('#mollie-ship-quantity', '#mollie-ship-quantity-group', availableQuantity);
       $('#mollieShipModal').modal('show');
     } else if (action === 'capture' || action === 'captureAll') {
       // Update modal message based on action type
@@ -65,6 +89,7 @@ $(document).ready(function () {
       } else {
         $('#mollie-cancel-modal-message').text(trans.cancelOrderLineConfirm);
       }
+      populateQuantitySelector('#mollie-cancel-quantity', '#mollie-cancel-quantity-group', availableQuantity);
       $('#mollieCancelModal').modal('show');
     }
   }
@@ -73,15 +98,19 @@ $(document).ready(function () {
     var productId = $(this).data('product');
     var amount = $(this).data('price');
     var orderline = $(this).data('orderline');
+    var availableQuantity = $(this).data('available-quantity');
+    var productName = $(this).data('product-name');
 
-    showModal('refund', productId, amount, orderline);
+    showModal('refund', productId, amount, orderline, availableQuantity, productName);
   });
 
   $('.mollie-ship-btn').on('click', function() {
     var productId = $(this).data('product');
     var orderline = $(this).data('orderline');
+    var availableQuantity = $(this).data('available-quantity');
+    var productName = $(this).data('product-name');
 
-    showModal('ship', productId, null, orderline);
+    showModal('ship', productId, null, orderline, availableQuantity, productName);
   });
 
   $('.mollie-capture-btn').on('click', function() {
@@ -93,8 +122,10 @@ $(document).ready(function () {
 
   $('.mollie-cancel-btn').on('click', function() {
     var orderline = $(this).data('orderline');
+    var availableQuantity = $(this).data('available-quantity');
+    var productName = $(this).data('product-name');
 
-    showModal('cancel', null, null, orderline);
+    showModal('cancel', null, null, orderline, availableQuantity, productName);
   });
 
   $('#mollie-initiate-refund').on('click', function() {
@@ -236,11 +267,12 @@ $(document).ready(function () {
 
     if (actionContext.orderline) {
       data.orderline = actionContext.orderline;
-    }
 
-    // Add cancel-specific data
-    if (context.action === 'cancel' || context.action === 'cancelAll') {
-      // Cancel actions don't need additional data beyond orderline
+      var quantitySelectId = '#mollie-' + context.action + '-quantity';
+      var selectedQuantity = $(quantitySelectId).val();
+      if (selectedQuantity) {
+        data.quantity = parseInt(selectedQuantity, 10);
+      }
     }
 
     if (!ajax_url) {

--- a/views/templates/hook/order_info.tpl
+++ b/views/templates/hook/order_info.tpl
@@ -62,15 +62,15 @@
               <td>{$product->quantityRefunded|escape:'html':'UTF-8'}</td>
               <td>
               {if $mollie_api_type == 'orders' && $product->type != 'discount'}
-                <button type="button" class="btn btn-default btn-xs mollie-ship-btn" data-price="{$product->totalAmount->value|escape:'html':'UTF-8'}" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$product->shippableQuantity|escape:'html':'UTF-8'}" {if $product->shippableQuantity < 1}disabled{/if}>
+                <button type="button" class="btn btn-default btn-xs mollie-ship-btn" data-price="{$product->totalAmount->value|escape:'html':'UTF-8'}" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$product->shippableQuantity|escape:'html':'UTF-8'}" {if !$product->shippableQuantity || $product->shippableQuantity <= 0}disabled{/if}>
                   <i class="material-icons">local_shipping</i> {l s='Ship' mod='mollie'}
                 </button>
-                <button type="button" class="btn btn-default btn-xs mollie-cancel-btn" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$product->cancelableQuantity|escape:'html':'UTF-8'}" {if $product->cancelableQuantity < 1}disabled{/if}>
+                <button type="button" class="btn btn-default btn-xs mollie-cancel-btn" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$product->cancelableQuantity|escape:'html':'UTF-8'}" {if !$product->cancelableQuantity || $product->cancelableQuantity <= 0}disabled{/if}>
                   <i class="material-icons">cancel</i> {l s='Cancel' mod='mollie'}
                 </button>
               {/if}
               {if $product->type != 'discount'}
-                <button type="button" class="btn btn-default btn-xs mollie-refund-btn" data-price="{$product->totalAmount->value|escape:'html':'UTF-8'}" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$product->refundableQuantity|escape:'html':'UTF-8'}" {if $product->refundableQuantity < 1}disabled{/if}>
+                <button type="button" class="btn btn-default btn-xs mollie-refund-btn" data-price="{$product->totalAmount->value|escape:'html':'UTF-8'}" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$product->refundableQuantity|escape:'html':'UTF-8'}" {if !$product->refundableQuantity || $product->refundableQuantity <= 0}disabled{/if}>
                   <i class="material-icons">replay</i> {l s='Refund' mod='mollie'}
                 </button>
               {/if}

--- a/views/templates/hook/order_info.tpl
+++ b/views/templates/hook/order_info.tpl
@@ -104,10 +104,10 @@
       <button type="button" class="btn btn-default btn-block" id="mollie-refund-all-orders" {if $isRefunded || $refundable_amount <= 0 || $isCanceled}disabled{/if}>
         <i class="material-icons">replay</i> {l s='Refund all' mod='mollie'}
       </button>
-      <button type="button" class="btn btn-default btn-block" id="mollie-ship-all" {if $isShipped || $isRefunded || $isCanceled}disabled{/if}>
+      <button type="button" class="btn btn-default btn-block" id="mollie-ship-all" {if $isShipped || $isRefunded || $isCanceled || $refundable_amount <= 0}disabled{/if}>
         <i class="material-icons">local_shipping</i> {l s='Ship All' mod='mollie'}
       </button>
-      <button type="button" class="btn btn-default btn-block" id="mollie-cancel-all" {if $isCanceled || $isRefunded || $isShipped}disabled{/if}>
+      <button type="button" class="btn btn-default btn-block" id="mollie-cancel-all" {if $isCanceled || $isRefunded || $isShipped || $refundable_amount <= 0}disabled{/if}>
         <i class="material-icons">cancel</i> {l s='Cancel All' mod='mollie'}
       </button>
     {/if}

--- a/views/templates/hook/order_info.tpl
+++ b/views/templates/hook/order_info.tpl
@@ -54,15 +54,15 @@
               <td>{$product->totalAmount->value|escape:'html':'UTF-8'}</td>
               <td>
               {if $mollie_api_type == 'orders' && $product->name != 'Discount'}
-                <button type="button" class="btn btn-default btn-xs mollie-ship-btn" data-price="{$product->totalAmount->value|escape:'html':'UTF-8'}" data-orderline="{$product->id|escape:'html':'UTF-8'}" {if $product->quantityShipped == $product->quantity || $product->quantityCanceled == $product->quantity}disabled{/if}>
+                <button type="button" class="btn btn-default btn-xs mollie-ship-btn" data-price="{$product->totalAmount->value|escape:'html':'UTF-8'}" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$product->shippableQuantity|escape:'html':'UTF-8'}" data-product-name="{$product->name|escape:'html':'UTF-8'}" {if $product->quantityShipped == $product->quantity || $product->quantityCanceled == $product->quantity}disabled{/if}>
                   <i class="material-icons">local_shipping</i> {l s='Ship' mod='mollie'}
                 </button>
-                <button type="button" class="btn btn-default btn-xs mollie-cancel-btn" data-orderline="{$product->id|escape:'html':'UTF-8'}" {if $product->quantityCanceled == $product->quantity || $isShipped}disabled{/if}>
+                <button type="button" class="btn btn-default btn-xs mollie-cancel-btn" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$product->cancelableQuantity|escape:'html':'UTF-8'}" data-product-name="{$product->name|escape:'html':'UTF-8'}" {if $product->quantityCanceled == $product->quantity || $isShipped}disabled{/if}>
                   <i class="material-icons">cancel</i> {l s='Cancel' mod='mollie'}
                 </button>
               {/if}
               {if $product->name != 'Discount'}
-                <button type="button" class="btn btn-default btn-xs mollie-refund-btn" data-price="{$product->totalAmount->value|escape:'html':'UTF-8'}" data-orderline="{$product->id|escape:'html':'UTF-8'}" {if $product->quantityRefunded == $product->quantity || $isCanceled}disabled{/if}>
+                <button type="button" class="btn btn-default btn-xs mollie-refund-btn" data-price="{$product->totalAmount->value|escape:'html':'UTF-8'}" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$product->refundableQuantity|escape:'html':'UTF-8'}" data-product-name="{$product->name|escape:'html':'UTF-8'}" {if $product->quantityRefunded == $product->quantity || $isCanceled}disabled{/if}>
                   <i class="material-icons">replay</i> {l s='Refund' mod='mollie'}
                 </button>
               {/if}

--- a/views/templates/hook/order_info.tpl
+++ b/views/templates/hook/order_info.tpl
@@ -65,11 +65,13 @@
                 <button type="button" class="btn btn-default btn-xs mollie-ship-btn" data-price="{$product->totalAmount->value|escape:'html':'UTF-8'}" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$product->shippableQuantity|escape:'html':'UTF-8'}" {if !$product->shippableQuantity || $product->shippableQuantity <= 0 || $product->quantityRefunded >= $product->quantity}disabled{/if}>
                   <i class="material-icons">local_shipping</i> {l s='Ship' mod='mollie'}
                 </button>
+              {/if}
+              {if $mollie_api_type == 'orders' && $product->type != 'discount'}
                 <button type="button" class="btn btn-default btn-xs mollie-cancel-btn" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$product->cancelableQuantity|escape:'html':'UTF-8'}" {if !$product->cancelableQuantity || $product->cancelableQuantity <= 0 || $product->quantityRefunded >= $product->quantity}disabled{/if}>
                   <i class="material-icons">cancel</i> {l s='Cancel' mod='mollie'}
                 </button>
               {/if}
-              {if $product->type != 'discount' && $product->type != 'shipping_fee' && $product->type != 'surcharge'}
+              {if $product->type != 'discount'}
                 <button type="button" class="btn btn-default btn-xs mollie-refund-btn" data-price="{$product->totalAmount->value|escape:'html':'UTF-8'}" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$product->refundableQuantity|escape:'html':'UTF-8'}" {if !$product->refundableQuantity || $product->refundableQuantity <= 0}disabled{/if}>
                   <i class="material-icons">replay</i> {l s='Refund' mod='mollie'}
                 </button>

--- a/views/templates/hook/order_info.tpl
+++ b/views/templates/hook/order_info.tpl
@@ -62,15 +62,15 @@
               <td>{$product->quantityRefunded|escape:'html':'UTF-8'}</td>
               <td>
               {if $mollie_api_type == 'orders' && $product->name != 'Discount'}
-                <button type="button" class="btn btn-default btn-xs mollie-ship-btn" data-price="{$product->totalAmount->value|escape:'html':'UTF-8'}" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$product->shippableQuantity|escape:'html':'UTF-8'}" {if $product->quantityShipped == $product->quantity || $product->quantityCanceled == $product->quantity}disabled{/if}>
+                <button type="button" class="btn btn-default btn-xs mollie-ship-btn" data-price="{$product->totalAmount->value|escape:'html':'UTF-8'}" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$product->shippableQuantity|escape:'html':'UTF-8'}" {if $product->shippableQuantity < 1}disabled{/if}>
                   <i class="material-icons">local_shipping</i> {l s='Ship' mod='mollie'}
                 </button>
-                <button type="button" class="btn btn-default btn-xs mollie-cancel-btn" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$product->cancelableQuantity|escape:'html':'UTF-8'}" {if $product->quantityCanceled == $product->quantity || $isShipped}disabled{/if}>
+                <button type="button" class="btn btn-default btn-xs mollie-cancel-btn" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$product->cancelableQuantity|escape:'html':'UTF-8'}" {if $product->cancelableQuantity < 1}disabled{/if}>
                   <i class="material-icons">cancel</i> {l s='Cancel' mod='mollie'}
                 </button>
               {/if}
               {if $product->name != 'Discount'}
-                <button type="button" class="btn btn-default btn-xs mollie-refund-btn" data-price="{$product->totalAmount->value|escape:'html':'UTF-8'}" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$product->refundableQuantity|escape:'html':'UTF-8'}" {if $product->quantityRefunded == $product->quantity || $isCanceled}disabled{/if}>
+                <button type="button" class="btn btn-default btn-xs mollie-refund-btn" data-price="{$product->totalAmount->value|escape:'html':'UTF-8'}" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$product->refundableQuantity|escape:'html':'UTF-8'}" {if $product->refundableQuantity < 1}disabled{/if}>
                   <i class="material-icons">replay</i> {l s='Refund' mod='mollie'}
                 </button>
               {/if}

--- a/views/templates/hook/order_info.tpl
+++ b/views/templates/hook/order_info.tpl
@@ -62,10 +62,10 @@
               <td>{$product->quantityRefunded|escape:'html':'UTF-8'}</td>
               <td>
               {if $mollie_api_type == 'orders' && $product->type != 'discount'}
-                <button type="button" class="btn btn-default btn-xs mollie-ship-btn" data-price="{$product->totalAmount->value|escape:'html':'UTF-8'}" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$product->shippableQuantity|escape:'html':'UTF-8'}" {if !$product->shippableQuantity || $product->shippableQuantity <= 0}disabled{/if}>
+                <button type="button" class="btn btn-default btn-xs mollie-ship-btn" data-price="{$product->totalAmount->value|escape:'html':'UTF-8'}" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$product->shippableQuantity|escape:'html':'UTF-8'}" {if !$product->shippableQuantity || $product->shippableQuantity <= 0 || $product->quantityRefunded >= $product->quantity}disabled{/if}>
                   <i class="material-icons">local_shipping</i> {l s='Ship' mod='mollie'}
                 </button>
-                <button type="button" class="btn btn-default btn-xs mollie-cancel-btn" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$product->cancelableQuantity|escape:'html':'UTF-8'}" {if !$product->cancelableQuantity || $product->cancelableQuantity <= 0}disabled{/if}>
+                <button type="button" class="btn btn-default btn-xs mollie-cancel-btn" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$product->cancelableQuantity|escape:'html':'UTF-8'}" {if !$product->cancelableQuantity || $product->cancelableQuantity <= 0 || $product->quantityRefunded >= $product->quantity}disabled{/if}>
                   <i class="material-icons">cancel</i> {l s='Cancel' mod='mollie'}
                 </button>
               {/if}

--- a/views/templates/hook/order_info.tpl
+++ b/views/templates/hook/order_info.tpl
@@ -61,7 +61,7 @@
               <td>{$product->quantityCanceled|escape:'html':'UTF-8'}</td>
               <td>{$product->quantityRefunded|escape:'html':'UTF-8'}</td>
               <td>
-              {if $mollie_api_type == 'orders' && $product->type != 'discount'}
+              {if $mollie_api_type == 'orders' && $product->type != 'discount' && $product->type != 'shipping_fee' && $product->type != 'surcharge'}
                 <button type="button" class="btn btn-default btn-xs mollie-ship-btn" data-price="{$product->totalAmount->value|escape:'html':'UTF-8'}" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$product->shippableQuantity|escape:'html':'UTF-8'}" {if !$product->shippableQuantity || $product->shippableQuantity <= 0 || $product->quantityRefunded >= $product->quantity}disabled{/if}>
                   <i class="material-icons">local_shipping</i> {l s='Ship' mod='mollie'}
                 </button>
@@ -69,7 +69,7 @@
                   <i class="material-icons">cancel</i> {l s='Cancel' mod='mollie'}
                 </button>
               {/if}
-              {if $product->type != 'discount'}
+              {if $product->type != 'discount' && $product->type != 'shipping_fee' && $product->type != 'surcharge'}
                 <button type="button" class="btn btn-default btn-xs mollie-refund-btn" data-price="{$product->totalAmount->value|escape:'html':'UTF-8'}" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$product->refundableQuantity|escape:'html':'UTF-8'}" {if !$product->refundableQuantity || $product->refundableQuantity <= 0}disabled{/if}>
                   <i class="material-icons">replay</i> {l s='Refund' mod='mollie'}
                 </button>

--- a/views/templates/hook/order_info.tpl
+++ b/views/templates/hook/order_info.tpl
@@ -61,7 +61,7 @@
               <td>{$product->quantityCanceled|escape:'html':'UTF-8'}</td>
               <td>{$product->quantityRefunded|escape:'html':'UTF-8'}</td>
               <td>
-              {if $mollie_api_type == 'orders' && $product->name != 'Discount'}
+              {if $mollie_api_type == 'orders' && $product->type != 'discount'}
                 <button type="button" class="btn btn-default btn-xs mollie-ship-btn" data-price="{$product->totalAmount->value|escape:'html':'UTF-8'}" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$product->shippableQuantity|escape:'html':'UTF-8'}" {if $product->shippableQuantity < 1}disabled{/if}>
                   <i class="material-icons">local_shipping</i> {l s='Ship' mod='mollie'}
                 </button>
@@ -69,7 +69,7 @@
                   <i class="material-icons">cancel</i> {l s='Cancel' mod='mollie'}
                 </button>
               {/if}
-              {if $product->name != 'Discount'}
+              {if $product->type != 'discount'}
                 <button type="button" class="btn btn-default btn-xs mollie-refund-btn" data-price="{$product->totalAmount->value|escape:'html':'UTF-8'}" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$product->refundableQuantity|escape:'html':'UTF-8'}" {if $product->refundableQuantity < 1}disabled{/if}>
                   <i class="material-icons">replay</i> {l s='Refund' mod='mollie'}
                 </button>

--- a/views/templates/hook/order_info.tpl
+++ b/views/templates/hook/order_info.tpl
@@ -54,15 +54,15 @@
               <td>{$product->totalAmount->value|escape:'html':'UTF-8'}</td>
               <td>
               {if $mollie_api_type == 'orders' && $product->name != 'Discount'}
-                <button type="button" class="btn btn-default btn-xs mollie-ship-btn" data-price="{$product->totalAmount->value|escape:'html':'UTF-8'}" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$product->shippableQuantity|escape:'html':'UTF-8'}" data-product-name="{$product->name|escape:'html':'UTF-8'}" {if $product->quantityShipped == $product->quantity || $product->quantityCanceled == $product->quantity}disabled{/if}>
+                <button type="button" class="btn btn-default btn-xs mollie-ship-btn" data-price="{$product->totalAmount->value|escape:'html':'UTF-8'}" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$product->shippableQuantity|escape:'html':'UTF-8'}" {if $product->quantityShipped == $product->quantity || $product->quantityCanceled == $product->quantity}disabled{/if}>
                   <i class="material-icons">local_shipping</i> {l s='Ship' mod='mollie'}
                 </button>
-                <button type="button" class="btn btn-default btn-xs mollie-cancel-btn" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$product->cancelableQuantity|escape:'html':'UTF-8'}" data-product-name="{$product->name|escape:'html':'UTF-8'}" {if $product->quantityCanceled == $product->quantity || $isShipped}disabled{/if}>
+                <button type="button" class="btn btn-default btn-xs mollie-cancel-btn" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$product->cancelableQuantity|escape:'html':'UTF-8'}" {if $product->quantityCanceled == $product->quantity || $isShipped}disabled{/if}>
                   <i class="material-icons">cancel</i> {l s='Cancel' mod='mollie'}
                 </button>
               {/if}
               {if $product->name != 'Discount'}
-                <button type="button" class="btn btn-default btn-xs mollie-refund-btn" data-price="{$product->totalAmount->value|escape:'html':'UTF-8'}" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$product->refundableQuantity|escape:'html':'UTF-8'}" data-product-name="{$product->name|escape:'html':'UTF-8'}" {if $product->quantityRefunded == $product->quantity || $isCanceled}disabled{/if}>
+                <button type="button" class="btn btn-default btn-xs mollie-refund-btn" data-price="{$product->totalAmount->value|escape:'html':'UTF-8'}" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$product->refundableQuantity|escape:'html':'UTF-8'}" {if $product->quantityRefunded == $product->quantity || $isCanceled}disabled{/if}>
                   <i class="material-icons">replay</i> {l s='Refund' mod='mollie'}
                 </button>
               {/if}

--- a/views/templates/hook/order_info.tpl
+++ b/views/templates/hook/order_info.tpl
@@ -42,6 +42,11 @@
         <tr>
           <th>{l s='Product' mod='mollie'}</th>
           <th>{l s='Price' mod='mollie'}</th>
+          {if $mollie_api_type == 'orders'}
+          <th>{l s='Shipped' mod='mollie'}</th>
+          <th>{l s='Canceled' mod='mollie'}</th>
+          <th>{l s='Refunded' mod='mollie'}</th>
+          {/if}
           <th>{l s='Actions' mod='mollie'}</th>
         </tr>
       </thead>
@@ -52,6 +57,9 @@
             <tr>
               <td><strong>{$product->quantity|escape:'html':'UTF-8'}x</strong> {$product->name|escape:'html':'UTF-8'}</td>
               <td>{$product->totalAmount->value|escape:'html':'UTF-8'}</td>
+              <td>{$product->quantityShipped|escape:'html':'UTF-8'}</td>
+              <td>{$product->quantityCanceled|escape:'html':'UTF-8'}</td>
+              <td>{$product->quantityRefunded|escape:'html':'UTF-8'}</td>
               <td>
               {if $mollie_api_type == 'orders' && $product->name != 'Discount'}
                 <button type="button" class="btn btn-default btn-xs mollie-ship-btn" data-price="{$product->totalAmount->value|escape:'html':'UTF-8'}" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$product->shippableQuantity|escape:'html':'UTF-8'}" {if $product->quantityShipped == $product->quantity || $product->quantityCanceled == $product->quantity}disabled{/if}>

--- a/views/templates/hook/order_info.tpl
+++ b/views/templates/hook/order_info.tpl
@@ -61,20 +61,23 @@
               <td>{$product->quantityCanceled|escape:'html':'UTF-8'}</td>
               <td>{$product->quantityRefunded|escape:'html':'UTF-8'}</td>
               <td>
-              {if $mollie_api_type == 'orders' && $product->type != 'discount' && $product->type != 'shipping_fee' && $product->type != 'surcharge'}
-                <button type="button" class="btn btn-default btn-xs mollie-ship-btn" data-price="{$product->totalAmount->value|escape:'html':'UTF-8'}" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$product->shippableQuantity|escape:'html':'UTF-8'}" {if !$product->shippableQuantity || $product->shippableQuantity <= 0 || $product->quantityRefunded >= $product->quantity}disabled{/if}>
+              {if $mollie_api_type == 'orders' && isset($lineActions[$product->id])}
+                {assign var="actions" value=$lineActions[$product->id]}
+                {if $actions.canShip || $actions.shippableQuantity > 0}
+                <button type="button" class="btn btn-default btn-xs mollie-ship-btn" data-price="{$product->totalAmount->value|escape:'html':'UTF-8'}" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$actions.shippableQuantity}" {if !$actions.canShip}disabled{/if}>
                   <i class="material-icons">local_shipping</i> {l s='Ship' mod='mollie'}
                 </button>
-              {/if}
-              {if $mollie_api_type == 'orders' && $product->type != 'discount'}
-                <button type="button" class="btn btn-default btn-xs mollie-cancel-btn" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$product->cancelableQuantity|escape:'html':'UTF-8'}" {if !$product->cancelableQuantity || $product->cancelableQuantity <= 0 || $product->quantityRefunded >= $product->quantity}disabled{/if}>
+                {/if}
+                {if $actions.canCancel || $actions.cancelableQuantity > 0}
+                <button type="button" class="btn btn-default btn-xs mollie-cancel-btn" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$actions.cancelableQuantity}" {if !$actions.canCancel}disabled{/if}>
                   <i class="material-icons">cancel</i> {l s='Cancel' mod='mollie'}
                 </button>
-              {/if}
-              {if $product->type != 'discount'}
-                <button type="button" class="btn btn-default btn-xs mollie-refund-btn" data-price="{$product->totalAmount->value|escape:'html':'UTF-8'}" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$product->refundableQuantity|escape:'html':'UTF-8'}" {if !$product->refundableQuantity || $product->refundableQuantity <= 0}disabled{/if}>
+                {/if}
+                {if $actions.canRefund || $actions.refundableQuantity > 0}
+                <button type="button" class="btn btn-default btn-xs mollie-refund-btn" data-price="{$product->totalAmount->value|escape:'html':'UTF-8'}" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$actions.refundableQuantity}" {if !$actions.canRefund}disabled{/if}>
                   <i class="material-icons">replay</i> {l s='Refund' mod='mollie'}
                 </button>
+                {/if}
               {/if}
               </td>
             </tr>

--- a/views/templates/hook/partials/modal_cancel.tpl
+++ b/views/templates/hook/partials/modal_cancel.tpl
@@ -17,6 +17,10 @@
       </div>
       <div class="modal-body">
         <p id="mollie-cancel-modal-message">{l s='Are you sure you want to cancel this order? This action cannot be undone.' mod='mollie'}</p>
+        <div class="form-group" id="mollie-cancel-quantity-group" style="display:none;">
+          <label for="mollie-cancel-quantity">{l s='Quantity to cancel' mod='mollie'}</label>
+          <select class="form-control" id="mollie-cancel-quantity"></select>
+        </div>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal">{l s='Cancel' mod='mollie'}</button>

--- a/views/templates/hook/partials/modal_refund.tpl
+++ b/views/templates/hook/partials/modal_refund.tpl
@@ -17,6 +17,10 @@
       </div>
       <div class="modal-body">
         <p id="mollie-refund-modal-message">{l s='Are you sure you want to refund this order? This action cannot be undone.' mod='mollie'}</p>
+        <div class="form-group" id="mollie-refund-quantity-group" style="display:none;">
+          <label for="mollie-refund-quantity">{l s='Quantity to refund' mod='mollie'}</label>
+          <select class="form-control" id="mollie-refund-quantity"></select>
+        </div>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal">{l s='Cancel' mod='mollie'}</button>

--- a/views/templates/hook/partials/modal_ship.tpl
+++ b/views/templates/hook/partials/modal_ship.tpl
@@ -16,6 +16,10 @@
         <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
       </div>
       <div class="modal-body">
+        <div class="form-group" id="mollie-ship-quantity-group" style="display:none;">
+          <label for="mollie-ship-quantity">{l s='Quantity to ship' mod='mollie'}</label>
+          <select class="form-control" id="mollie-ship-quantity"></select>
+        </div>
         <div class="form-group">
           <div class="checkbox">
             <label>


### PR DESCRIPTION
## Summary

- Restore partial quantity selection for cancel, refund, and ship actions on Orders API order lines (regression from v6.4.0 back-office redesign)
- Add shipped/canceled/refunded status columns to the order lines table so merchants can see action history per line
- Fix button disable states using PHP-computed flags from Mollie API quantity properties (shippableQuantity, cancelableQuantity, refundableQuantity)
- Fix Refund All for Orders API to use line-based `refundAll()` instead of amount-based refund
- Fix ShipService to treat tracking URL as optional (carrier + code is sufficient)
- Fix discount/shipping_fee/surcharge line handling: hide Ship for non-physical lines, allow Cancel and Refund on shipping fees
- Page reloads after successful action to reflect updated quantities

## Changes

**Backend (PHP):**
- `CancelService`, `ShipService`, `RefundService`: accept optional `$quantity` parameter, pass to Mollie API
- `AdminMollieAjaxController`: extract and validate quantity from request (int, >= 1)
- `RefundService`: Orders API Refund All now uses `$order->refundAll()` instead of amount-based refund
- `ShipService`: tracking URL is optional, only carrier + code required
- `mollie.php`: compute per-line button states (`canShip`, `canCancel`, `canRefund`) in PHP with proper int casting

**Frontend (JS/Templates):**
- Quantity selector `<select>` added to cancel, refund, and ship modals (hidden when only 1 item available)
- `data-available-quantity` attributes on order line buttons
- Quantity passed through AJAX to backend
- Status columns (Shipped, Canceled, Refunded) added to order lines table for Orders API
- Page reloads 1.5s after successful action

## Test plan

- [ ] Create order with Klarna/PayPal (Orders API) with multiple quantities (e.g. 5x Product A, 10x Product B)
- [ ] Test partial ship: Ship 3 of 5, verify quantity selector shows 1-5, verify Shipped column updates
- [ ] Test partial cancel: Cancel 2 of remaining, verify Cancel selector and Canceled column
- [ ] Test partial refund: Refund 1 of shipped items, verify Refund selector and Refunded column
- [ ] Test Ship All / Cancel All / Refund All bulk actions still work
- [ ] Test button disable states: fully shipped line disables Ship, fully refunded disables all, etc.
- [ ] Test shipping_fee line: no Ship button, Cancel and Refund available
- [ ] Test discount line: no action buttons shown
- [ ] Test Payment API orders: unaffected, no quantity selectors, amount-based refund works
- [ ] Test ship with tracking: carrier + code only (no URL) should work