### PR TITLE
PIPRES-754: Fix Apple Pay Direct address and orphaned records bugs      

### DIFF
--- a/controllers/front/applePayDirectAjax.php
+++ b/controllers/front/applePayDirectAjax.php
@@ -48,21 +48,22 @@ class MollieApplePayDirectAjaxModuleFrontController extends AbstractMollieContro
         switch ($action) {
             case 'mollie_apple_pay_validation':
                 $this->getApplePaySession();
-                // no break
+                break;
             case 'mollie_apple_pay_update_shipping_contact':
                 $this->updateAppleShippingContact();
-                // no break
+                break;
             case 'mollie_apple_pay_update_shipping_method':
                 $this->updateShippingMethod();
-                // no break
+                break;
             case 'mollie_apple_pay_create_order':
                 $this->createApplePayOrder();
-                // no break
+                break;
             case 'mollie_apple_pay_get_total_price':
                 $this->getTotalApplePayCartPrice();
-                // no break
+                break;
             case 'mollie_apple_pay_remove_from_cart':
                 $this->removeProductFromCart();
+                break;
         }
 
         $logger->debug(sprintf('%s - Controller action ended', self::FILE_NAME));
@@ -268,4 +269,5 @@ class MollieApplePayDirectAjaxModuleFrontController extends AbstractMollieContro
 
         return $products;
     }
+
 }

--- a/src/Application/CommandHandler/CreateApplePayOrderHandler.php
+++ b/src/Application/CommandHandler/CreateApplePayOrderHandler.php
@@ -84,6 +84,13 @@ final class CreateApplePayOrderHandler
     public function handle(CreateApplePayOrder $command): array
     {
         $cart = new Cart($command->getCartId());
+
+        if ($cart->id_address_delivery == $cart->id_address_invoice) {
+            $invoiceAddress = $this->duplicateAddress($cart->id_address_invoice);
+            $cart->id_address_invoice = $invoiceAddress->id;
+            $cart->update();
+        }
+
         $this->updateCardInfo($cart->id_address_delivery, $command->getOrder()->getShippingContent());
         $this->updateCardInfo($cart->id_address_invoice, $command->getOrder()->getBillingContent());
         $this->updateCustomer($cart->id_customer, $command->getOrder()->getShippingContent());
@@ -227,6 +234,25 @@ final class CreateApplePayOrderHandler
         );
 
         return $this->mollieOrderCreationService->createMollieApplePayDirectOrder($paymentData, $paymentMethodObj);
+    }
+
+    private function duplicateAddress(int $addressId): Address
+    {
+        $original = new Address($addressId);
+        $copy = new Address();
+        $copy->id_customer = $original->id_customer;
+        $copy->alias = $original->alias;
+        $copy->firstname = $original->firstname;
+        $copy->lastname = $original->lastname;
+        $copy->address1 = $original->address1;
+        $copy->address2 = $original->address2;
+        $copy->city = $original->city;
+        $copy->postcode = $original->postcode;
+        $copy->id_country = $original->id_country;
+        $copy->country = $original->country;
+        $copy->add();
+
+        return $copy;
     }
 
     private function deleteAddress(int $addressId)

--- a/src/Application/CommandHandler/UpdateApplePayShippingContactHandler.php
+++ b/src/Application/CommandHandler/UpdateApplePayShippingContactHandler.php
@@ -57,10 +57,11 @@ final class UpdateApplePayShippingContactHandler
 
     public function handle(UpdateApplePayShippingContact $command): array
     {
-        $customer = $this->createCustomer($command->getCustomerId());
-        $deliveryAddress = $this->createAddress($customer->id, $command);
-        $invoiceAddress = $this->createAddress($customer->id, $command);
-        $cart = $this->updateCart($customer, $deliveryAddress->id, $invoiceAddress->id, $command->getCartId());
+        $cart = new Cart($command->getCartId());
+        $customer = $this->getOrCreateCustomer($command->getCustomerId(), $cart);
+        $deliveryAddress = $this->getOrCreateAddress($cart->id_address_delivery, $customer->id, $command);
+        $invoiceAddress = $this->getOrCreateAddress($cart->id_address_invoice, $customer->id, $command);
+        $this->updateCart($cart, $customer, $deliveryAddress->id, $invoiceAddress->id);
         $this->addProductToCart($cart, $command);
         $cart = new Cart($cart->id);
         $this->updateContext($cart, $customer);
@@ -93,8 +94,22 @@ final class UpdateApplePayShippingContactHandler
         ];
     }
 
-    private function createAddress(int $customerId, UpdateApplePayShippingContact $command): Address
+    private function getOrCreateAddress(int $existingAddressId, int $customerId, UpdateApplePayShippingContact $command): Address
     {
+        if ($existingAddressId) {
+            $address = new Address($existingAddressId);
+            if ($address->id && $address->alias === 'applePay') {
+                $address->postcode = $command->getPostalCode();
+                $address->id_country = Country::getByIso($command->getCountryCode());
+                $address->country = $command->getCountry();
+                $address->city = $command->getLocality();
+                $address->id_customer = $customerId;
+                $address->update();
+
+                return $address;
+            }
+        }
+
         $address = new Address();
         $address->address1 = 'ApplePay';
         $address->lastname = 'ApplePay';
@@ -110,10 +125,14 @@ final class UpdateApplePayShippingContactHandler
         return $address;
     }
 
-    private function createCustomer(int $customerId): Customer
+    private function getOrCreateCustomer(int $customerId, Cart $cart): Customer
     {
         if ($customerId) {
             return new Customer($customerId);
+        }
+
+        if ($cart->id_customer) {
+            return new Customer($cart->id_customer);
         }
 
         if (!Configuration::get('PS_GUEST_CHECKOUT_ENABLED')) {
@@ -124,23 +143,20 @@ final class UpdateApplePayShippingContactHandler
         $customer->is_guest = true;
         $customer->firstname = 'applePay';
         $customer->lastname = 'applePay';
-        $customer->email = 'applePay@mollie.com';
+        $customer->email = 'applepay-' . (int) $cart->id . '@mollie.com';
         $customer->passwd = Tools::hash(microtime());
         $customer->add();
 
         return $customer;
     }
 
-    private function updateCart(Customer $customer, int $deliveryAddressId, int $invoiceAddressId, int $cartId): cart
+    private function updateCart(Cart $cart, Customer $customer, int $deliveryAddressId, int $invoiceAddressId): void
     {
-        $cart = new Cart($cartId);
         $cart->secure_key = $customer->secure_key;
         $cart->id_address_delivery = $deliveryAddressId;
         $cart->id_address_invoice = $invoiceAddressId;
         $cart->id_customer = $customer->id;
         $cart->update();
-
-        return $cart;
     }
 
     private function addProductToCart(Cart $cart, UpdateApplePayShippingContact $command)


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the project!

Please take the time to edit the "Answers" rows below with the necessary information.

------------------------------------------------------------------------------>

| Questions       | Answers
|-----------------| -------------------------------------------------------
| Branch?         | Master/Release
| Description?    |  Fix shipping address being overwritten by billing address when both cart address IDs point to the same record  Reuse existing guest customer and temporary addresses instead of creating new orphaned ones on every address change in the Apple Pay sheet   Add break statements to prevent switch case fall-through in the AJAX controller
| Type?           | bug fix / improvement / new feature / refactoring
| How to test?    | Indicate how to verify that this change works as expected.
| Fixed issue ?   | If none leave blank
