### PR TITLE
PIPRES-768 Fix refund confirmation modal amount for selected quantity

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 # Changelog #
 
 ## Changes in release 6.4.3
++ Fixed refund confirmation modal amount to reflect selected quantity for multi-unit order lines
 + Fixed Payment API race condition causing false "payment failed" errors
 + Fixed rounding distribution for whole-number differences in order line amounts
 + Fixed Apple Pay Direct payment when country is not active in shop

--- a/views/js/admin/order_info.js
+++ b/views/js/admin/order_info.js
@@ -26,7 +26,7 @@ $(document).ready(function () {
     }
   }
 
-  function showModal(action, productId, productAmount, orderline, availableQuantity) {
+  function showModal(action, productId, productAmount, orderline, availableQuantity, unitPrice) {
     var amount = productAmount;
 
     // For refund actions, get amount from input field if not provided
@@ -53,6 +53,7 @@ $(document).ready(function () {
       amount: amount,
       orderline: orderline || null,
       availableQuantity: availableQuantity || null,
+      unitPrice: unitPrice ? parseFloat(unitPrice) : null,
     };
 
     if (action === 'refund' || action === 'refundAll') {
@@ -66,6 +67,7 @@ $(document).ready(function () {
       }
       if (orderline) {
         populateQuantitySelector('#mollie-refund-quantity', '#mollie-refund-quantity-group', availableQuantity);
+        $('#mollie-refund-quantity').trigger('change');
       } else {
         $('#mollie-refund-quantity-group').hide();
       }
@@ -98,8 +100,19 @@ $(document).ready(function () {
     var amount = $(this).data('price');
     var orderline = $(this).data('orderline');
     var availableQuantity = $(this).data('available-quantity');
+    var unitPrice = $(this).data('unit-price');
 
-    showModal('refund', productId, amount, orderline, availableQuantity);
+    showModal('refund', productId, amount, orderline, availableQuantity, unitPrice);
+  });
+
+  $('#mollie-refund-quantity').on('change', function() {
+    if (actionContext.action !== 'refund' || !actionContext.unitPrice) {
+      return;
+    }
+    var quantity = parseInt($(this).val(), 10) || 1;
+    var newAmount = (actionContext.unitPrice * quantity).toFixed(2);
+    actionContext.amount = newAmount;
+    $('#mollie-refund-modal-message').text(trans.refundPartialConfirm.replace('%s', newAmount));
   });
 
   $('.mollie-ship-btn').on('click', function() {

--- a/views/templates/hook/order_info.tpl
+++ b/views/templates/hook/order_info.tpl
@@ -74,7 +74,7 @@
                 </button>
                 {/if}
                 {if $actions.canRefund || $actions.refundableQuantity > 0}
-                <button type="button" class="btn btn-default btn-xs mollie-refund-btn" data-price="{$product->totalAmount->value|escape:'html':'UTF-8'}" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$actions.refundableQuantity}" {if !$actions.canRefund}disabled{/if}>
+                <button type="button" class="btn btn-default btn-xs mollie-refund-btn" data-price="{$product->totalAmount->value|escape:'html':'UTF-8'}" data-unit-price="{$product->unitPrice->value|escape:'html':'UTF-8'}" data-orderline="{$product->id|escape:'html':'UTF-8'}" data-available-quantity="{$actions.refundableQuantity}" {if !$actions.canRefund}disabled{/if}>
                   <i class="material-icons">replay</i> {l s='Refund' mod='mollie'}
                 </button>
                 {/if}


### PR DESCRIPTION
## Summary
- Refund confirmation modal now reflects the amount for the selected quantity instead of always showing the full order line total
- Uses Mollie SDK's native `unitPrice` from the OrderLine resource for accurate per-unit pricing
- Modal message recomputes as the user changes the quantity dropdown

## Changes
- `views/templates/hook/order_info.tpl`: added `data-unit-price` to the per-line Refund button (Orders API)
- `views/js/admin/order_info.js`: store `unitPrice` in action context; bind `change` handler on quantity selector; trigger an initial recompute when the modal opens
- `changelog.md`: 6.4.3 entry

## Test plan
- [x] Real Mollie iDEAL payment, multi-quantity order line (2× Framed Poster @ €34.80, total €69.60)
- [x] Modal opens with qty=1 selected → message shows €34.80
- [x] Change qty to 2 → message shows €69.60
- [x] Back to qty=1 → message recomputes to €34.80
- [x] Synthetic edge cases (qty=1 single line, missing unit price, refundAll, capture flow) unaffected