### PR TITLE
INTERNAL Configure Dependabot to target develop branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    target-branch: develop
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: npm
+    directory: "/views/assets"
+    schedule:
+      interval: weekly
+    target-branch: develop
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: composer
+    directory: "/"
+    schedule:
+      interval: weekly
+    target-branch: develop
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    target-branch: develop
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

Routes all Dependabot dependency update PRs to the \`develop\` branch instead of \`master\`, aligning with the team's gitflow release process.

## Why

Currently Dependabot opens PRs against \`master\` by default. Since the team merges all work into \`develop\` first (and only promotes to \`master\` at release time), this causes:
- Lockfile conflicts on retargeted PRs (lockfileVersion 1 on master vs version 3 on develop)
- Dependency bumps bypassing the same QA cycle as feature work
- Manual retargeting needed on every Dependabot PR

## What changes

Adds \`.github/dependabot.yml\` covering:
- npm (root and \`/views/assets\`)
- composer
- github-actions

All ecosystems set to \`target-branch: develop\`, weekly schedule.

## Risk

None. Config-only file read by GitHub's Dependabot service. No PHP, JS, or build pipeline changes. Worst case (yaml typo): Dependabot falls back to current behavior.

## After merge

Existing open Dependabot PRs (#1391, #1398, #1390, #1380) will need \`@dependabot recreate\` comments to regenerate against \`develop\`.

## Test plan

- [ ] Merge to master
- [ ] Verify next Dependabot run opens PRs against \`develop\`
- [ ] Recreate existing open Dependabot PRs to retarget them