### PR TITLE
PIPRES-790 Fix Apple Pay Direct placeholder address and customer contamination

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,8 @@
 + Added Bulgarian translations
 + Fixed Apple Pay not displaying at checkout on PrestaShop 9
 + Fixed Apple Pay Direct button on the product page in the Hummingbird theme
++ Fixed Apple Pay Direct creating fictitious "ApplePay" placeholder addresses and guest records on customer accounts
++ Prevented Apple Pay Direct from overwriting a registered customer's saved name and email
 + Fixed Payments API per-line Refund button not updating after a successful refund
 + Surfaced a clearer message when Mollie rejects a refund as a duplicate of a recent one
 + Fixed refund confirmation modal amount to reflect selected quantity for multi-unit order lines

--- a/src/Application/CommandHandler/CreateApplePayOrderHandler.php
+++ b/src/Application/CommandHandler/CreateApplePayOrderHandler.php
@@ -205,10 +205,16 @@ final class CreateApplePayOrderHandler
     private function updateCustomer(int $customerId, ShippingContent $shippingContent)
     {
         $customer = new \Customer($customerId);
+
+        // Never overwrite a registered customer's account details with the Apple Pay contact; only the throwaway guest created for this flow is filled in and restored from its temporary soft-deleted state.
+        if (!$customer->is_guest) {
+            return;
+        }
+
         $customer->firstname = $shippingContent->getGivenName();
         $customer->lastname = $shippingContent->getFamilyName();
         $customer->email = $shippingContent->getEmailAddress();
-
+        $customer->deleted = false;
         $customer->update();
     }
 
@@ -250,6 +256,7 @@ final class CreateApplePayOrderHandler
         $copy->postcode = $original->postcode;
         $copy->id_country = $original->id_country;
         $copy->country = $original->country;
+        $copy->deleted = $original->deleted;
         $copy->add();
 
         return $copy;

--- a/src/Application/CommandHandler/UpdateApplePayShippingContactHandler.php
+++ b/src/Application/CommandHandler/UpdateApplePayShippingContactHandler.php
@@ -104,6 +104,7 @@ final class UpdateApplePayShippingContactHandler
                 $address->country = $command->getCountry();
                 $address->city = $command->getLocality();
                 $address->id_customer = $customerId;
+                $address->deleted = true;
                 $address->update();
 
                 return $address;
@@ -120,6 +121,8 @@ final class UpdateApplePayShippingContactHandler
         $address->id_country = Country::getByIso($command->getCountryCode());
         $address->country = $command->getCountry();
         $address->city = $command->getLocality();
+        // Soft-deleted on purpose: this is a temporary Apple Pay sheet address. Keeping it deleted hides it from the customer's address book if the payment is abandoned; real data is written on order creation.
+        $address->deleted = true;
         $address->add();
 
         return $address;
@@ -145,6 +148,8 @@ final class UpdateApplePayShippingContactHandler
         $customer->lastname = 'applePay';
         $customer->email = 'applepay-' . (int) $cart->id . '@mollie.com';
         $customer->passwd = Tools::hash(microtime());
+        // Soft-deleted on purpose: hides this throwaway guest from the Customers list if the payment is abandoned; it is restored on order creation.
+        $customer->deleted = true;
         $customer->add();
 
         return $customer;

--- a/views/js/front/applePayDirect/applePayDirectCart.js
+++ b/views/js/front/applePayDirect/applePayDirectCart.js
@@ -230,10 +230,12 @@ function createRequest(countryCode, currencyCode, totalLabel, subtotal) {
         merchantCapabilities: ['supports3DS'],
         shippingType: 'shipping',
         requiredBillingContactFields: [
+            'name',
             'postalAddress',
             'email'
         ],
         requiredShippingContactFields: [
+            'name',
             'postalAddress',
             'email'
         ],

--- a/views/js/front/applePayDirect/applePayDirectProduct.js
+++ b/views/js/front/applePayDirect/applePayDirectProduct.js
@@ -246,10 +246,12 @@ function createRequest(countryCode, currencyCode, totalLabel, subtotal) {
         merchantCapabilities: ['supports3DS'],
         shippingType: 'shipping',
         requiredBillingContactFields: [
+            'name',
             'postalAddress',
             'email'
         ],
         requiredShippingContactFields: [
+            'name',
             'postalAddress',
             'email'
         ],


### PR DESCRIPTION
## Problem
Apple Pay Direct materialised a temporary address (and a guest customer) before payment authorisation to drive PrestaShop carrier/total calculation, and only cleaned them up on the success path. Abandoned or failed sheets left fictitious "ApplePay ApplePay" addresses and guest records on customer accounts. A merchant reported 360 such addresses across 167 customers; reproduced and confirmed on their staging (Mollie 6.4.3).

## Fix
- Create/reuse the temporary Apple Pay address and guest customer as soft-deleted (`deleted = 1`) so abandoned payments leave no visible records; they are restored to normal visible records on a successful order.
- Guard `updateCustomer` so a registered customer's saved name and email are never overwritten by the Apple Pay contact.
- `duplicateAddress` inherits the `deleted` flag.
- Request the buyer `name` in the Apple Pay sheet (product + cart) so completed orders save the real shipping name and address.

## Testing
- Abandon, registered and guest: no visible address or customer created (DB confirms all `deleted = 1`).
- Completed payment (order creation mocked for registered + guest): order created against the soft-deleted address, shows the real buyer name/address, registered account untouched, guest restored as a normal visible customer.
- Order creation verified safe with a soft-deleted address (core `validateOrder` references addresses by id, no deleted filter).