### PR TITLE
Fix: order management actions do nothing on PS 1.7.7+ Symfony order page

### DIFF
--- a/mollie.php
+++ b/mollie.php
@@ -702,6 +702,35 @@ class Mollie extends PaymentModule
                 'isCaptured' => $isCaptured,
                 'isShipped' => $isShipped,
                 'isCanceled' => $isCanceled,
+                // Load order_info.js and its config from this hook, which receives the order id and
+                // runs on the PS 1.7.7+ Symfony order page (/sell/orders/{id}/view).
+                // hookActionAdminControllerSetMedia is guarded by Tools::getValue('controller') and
+                // Tools::getValue('id_order'), both empty on a Symfony route, so the order management
+                // JS was never enqueued there and the action buttons did nothing.
+                'mollie_order_info_js' => $this->getPathUri() . 'views/js/admin/order_info.js',
+                'mollie_order_info_config' => json_encode([
+                    'ajax_url' => $this->context->link->getAdminLink('AdminMollieAjax'),
+                    'transaction_id' => $mollieTransactionId,
+                    'resource' => $mollieApiType,
+                    'order_id' => (int) $params['id_order'],
+                    'trans' => [
+                        'processing' => $this->l('Processing...'),
+                        'configurationError' => $this->l('Configuration error'),
+                        'refundFullOrderConfirm' => $this->l('Are you sure you want to refund the full order amount? This action cannot be undone.'),
+                        'refundPartialConfirm' => $this->l('Are you sure you want to refund %s? This action cannot be undone.'),
+                        'refundOrderConfirm' => $this->l('Are you sure you want to refund this order? This action cannot be undone.'),
+                        'captureFullOrderConfirm' => $this->l('Are you sure you want to capture the full order amount?'),
+                        'capturePaymentConfirm' => $this->l('Are you sure you want to capture this payment?'),
+                        'cancelFullOrderConfirm' => $this->l('Are you sure you want to cancel the entire order? This action cannot be undone.'),
+                        'cancelOrderLineConfirm' => $this->l('Are you sure you want to cancel this order line? This action cannot be undone.'),
+                        'validRefundAmountRequired' => $this->l('Please enter a valid refund amount'),
+                        'validCaptureAmountRequired' => $this->l('Please enter a valid capture amount'),
+                        'ajaxUrlNotFound' => $this->l('AJAX URL not found'),
+                        'actionCompletedSuccessfully' => $this->l('Action completed successfully'),
+                        'errorOccurred' => $this->l('An error occurred'),
+                        'networkErrorOccurred' => $this->l('Network error occurred'),
+                    ],
+                ], JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP),
             ]);
 
             return $this->display($this->getPathUri(), 'views/templates/hook/order_info.tpl');

--- a/views/js/admin/order_info.js
+++ b/views/js/admin/order_info.js
@@ -8,6 +8,11 @@
  * @see        https://github.com/mollie/PrestaShop
  */
 $(document).ready(function () {
+  // Idempotency guard: the script may be enqueued both by the media pipeline (legacy pages)
+  // and inline from the template (Symfony order page); bind the handlers only once.
+  if (window.mollieOrderInfoInitialized) { return; }
+  window.mollieOrderInfoInitialized = true;
+
   var actionContext = {};
 
   function populateQuantitySelector(selectId, groupId, maxQuantity) {

--- a/views/templates/hook/order_info.tpl
+++ b/views/templates/hook/order_info.tpl
@@ -123,3 +123,20 @@
 {include file="module:mollie/views/templates/hook/partials/modal_ship.tpl"}
 {include file="module:mollie/views/templates/hook/partials/modal_capture.tpl"}
 {include file="module:mollie/views/templates/hook/partials/modal_cancel.tpl"}
+
+{* Define the globals expected by order_info.js and load the script inline. Required on the
+   PS 1.7.7+ Symfony order page, where hookActionAdminControllerSetMedia does not enqueue these
+   assets (its 'controller'/'id_order' GET-parameter guard is never satisfied on a Symfony route). *}
+{if isset($mollie_order_info_config)}
+<script type="text/javascript">
+  (function () {
+    var cfg = {$mollie_order_info_config nofilter};
+    window.ajax_url = cfg.ajax_url;
+    window.transaction_id = cfg.transaction_id;
+    window.resource = cfg.resource;
+    window.order_id = cfg.order_id;
+    window.trans = cfg.trans;
+  })();
+</script>
+<script type="text/javascript" src="{$mollie_order_info_js|escape:'html':'UTF-8'}"></script>
+{/if}


### PR DESCRIPTION
| Questions       | Answers
|-----------------| -------------------------------------------------------
| Branch?         | Master
| Description?    | Fixes the Mollie order-management actions (Refund / Capture / Ship / Cancel) doing nothing on the PS 1.7.7+ Symfony order page. See details below.
| Type?           | bug fix
| How to test?    | On PS 1.7.7+, open a paid Mollie order in the BO (`/sell/orders/{id}/view`). Before: clicking **Initiate Refund** does nothing and `typeof transaction_id` is `"undefined"` in the console. After: the confirmation modal opens and `transaction_id` is defined.
| Fixed issue ?   | #1428

### Problem

`views/js/admin/order_info.js` and its `Media::addJsDef` config (`transaction_id`, `resource`, `ajax_url`, `order_id`, `trans`) are enqueued only inside `mollie.php::hookActionAdminControllerSetMedia`, behind:

```php
if ('AdminOrders' === Tools::getValue('controller') && Tools::getValue('id_order')) { ... }
```

On the PS 1.7.7+ Symfony order route (`/sell/orders/{id}/view`), neither `controller` nor `id_order` is a GET parameter, so this block never runs. The script is never loaded, the globals are never defined, and the click handler throws a silent `ReferenceError`. The buttons (rendered by `hookDisplayAdminOrder`) therefore do nothing. Reproduced on `master` and `v6.4.4-beta`.

### Fix

Load `order_info.js` and its config from `hookDisplayAdminOrder`, which already receives `$params['id_order']` and runs on the Symfony order page. The config is emitted as safe JSON (`JSON_HEX_*`) into the template, which defines the globals and then loads the script. An idempotency guard in `order_info.js` prevents double-binding when the legacy media path also loads it.

This keeps the existing JS contract (bare globals) untouched and is the minimal change to make the actions work on Symfony-routed order pages.
