### PR TITLE
Fix duplicate SEGMENT_API_KEY line in packaged .env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,8 @@ jobs:
           rm -rf vendor/segmentio/analytics-php/.github
 
           cp .env.dist .env
+          # Replace the placeholder from .env.dist with the real key (avoid a duplicate SEGMENT_API_KEY line)
+          sed -i "/^SEGMENT_API_KEY=/d" .env
           echo "SEGMENT_API_KEY='${{ secrets.SEGMENT_API_KEY }}'" >> .env
 
           # Create module directory structure


### PR DESCRIPTION
## Problem
During zip creation the packaged module's `.env` ends up with **two** `SEGMENT_API_KEY` lines — one empty, one with the value:

```
SEGMENT_API_KEY=''            # copied from .env.dist
SEGMENT_API_KEY='<secret>'    # appended by the release workflow
```

The release job runs `cp .env.dist .env` (`.env.dist` already declares `SEGMENT_API_KEY=''`) and then `echo "SEGMENT_API_KEY='...'" >> .env`, which appends a second line instead of replacing the placeholder.

## Fix
Strip any existing `SEGMENT_API_KEY` line before appending, so the packaged `.env` contains exactly one entry with the real value.

## Verification
Simulated the build steps locally against the current `.env.dist`: the resulting `.env` has a single `SEGMENT_API_KEY` line with the value and no empty duplicate.