### PR TITLE
PIPRES-782 Add Wero payment method

### DIFF
--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -153,6 +153,7 @@ class Config
         'swish' => ['se'],
         'bizum' => ['es', 'ad'],
         'vippsmobilepay' => ['no', 'dk', 'fi'],
+        'wero' => ['de', 'be', 'fr', 'lu'],
     ];
 
     const SUPPORTED_PHP_VERSION = '5.6';
@@ -421,6 +422,7 @@ class Config
         'bizum' => 'Bizum',
         'vipps' => 'Vipps',
         'mobilepay' => 'Mobile Pay',
+        'wero' => 'Wero',
     ];
 
     public const LOG_SEVERITY_LEVEL_INFORMATIVE = 1;


### PR DESCRIPTION
## What
Adds the new Mollie **Wero** payment method (product code `wero`) to the module.

The module is API-driven, so the only code change is registering `wero` in `Config`:
- `Config::$methods` gains `'wero' => 'Wero'` (required - it is accessed by direct array key when creating orders, so a missing entry throws an undefined-index).
- `Config::$defaultMethodAvailability` gains `'wero' => ['de', 'be', 'fr', 'lu']` for consistency.

Icon, min/max amount, currency (EUR) and per-country availability are all supplied by the Mollie API at runtime; the method defaults to the Payments API. The async `pending` -> `paid` flow is handled by the existing generic status pipeline, so no extra handling was needed.

## Testing
Verified end-to-end on a PS 8.2.3 test environment with Wero enabled on the Mollie test profile:
- Shows in admin Payment Methods and at checkout (EUR, DE address) with the correct Wero icon.
- Immediate `paid` and async `pending` both create orders in the correct states.
- Partial and full refunds work on both the Payments API and the Orders API (confirmed against the Mollie API).

## Note
Mollie has rebranded the iDEAL method's API description to "iDEAL | Wero", so the existing iDEAL option now displays as "iDEAL | Wero" at checkout - separate from the standalone Wero method added here.

Jira: PIPRES-782