### PR TITLE
PIPRES-793 Fix total_paid_real not updated on bank transfer orders

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 # Changelog #
 
 ## Changes in release 6.4.3
++ Fixed total_paid_real staying 0 on bank transfer orders after the payment is completed
 + Fixed Payment API race condition causing false "payment failed" errors
 + Fixed rounding distribution for whole-number differences in order line amounts
 + Fixed Apple Pay Direct payment when country is not active in shop

--- a/src/Service/TransactionService.php
+++ b/src/Service/TransactionService.php
@@ -46,6 +46,7 @@ use Order;
 use OrderPayment;
 use PrestaShopDatabaseException;
 use PrestaShopException;
+use Validate;
 
 if (!defined('_PS_VERSION_')) {
     exit;
@@ -385,6 +386,31 @@ class TransactionService
                 $orderPayment->update();
             }
         }
+
+        $this->updateOrderTotalPaidReal(new Order($orderId));
+    }
+
+    private function updateOrderTotalPaidReal(Order $order): void
+    {
+        if (!Validate::isLoadedObject($order)) {
+            return;
+        }
+
+        $totalPaidReal = 0.0;
+        /** @var OrderPayment $orderPayment */
+        foreach ($order->getOrderPaymentCollection() as $orderPayment) {
+            if ((int) $orderPayment->id_currency !== (int) $order->id_currency) {
+                continue;
+            }
+            $totalPaidReal += (float) $orderPayment->amount;
+        }
+
+        if ((float) $order->total_paid_real === $totalPaidReal) {
+            return;
+        }
+
+        $order->total_paid_real = $totalPaidReal;
+        $order->update();
     }
 
     /**


### PR DESCRIPTION
## Problem
For bank transfer orders, `total_paid_real` stays `0.0` even after the payment is completed and the order is marked as paid. iDEAL is unaffected. This surfaces when reading orders via the PrestaShop Orders API (webservice). Reported in #1434 (PIPRES-793).

## Root cause
Bank transfer orders are created in a non-logable "awaiting" state, so PrestaShop core does not record an order payment at creation and `total_paid_real` starts at 0. When the payment is later completed on the webhook, `TransactionService::updateTransaction()` records the payment but never maintains `total_paid_real`, so the paid order keeps `total_paid_real = 0`. This happens regardless of the shop "Enable invoices" setting.

## Fix
Recompute `total_paid_real` from the order's own order payments (currency-matched) at the end of `updateTransaction()`, so it is always maintained no matter how the payment was recorded. The recompute is guarded to be idempotent and does not change orders that are already correct (e.g. iDEAL, created directly in a paid state).

## Testing
Verified end-to-end on PrestaShop 8.2.1 + Mollie test mode with "Enable invoices" ON:

| Method | Before fix | After fix |
|---|---|---|
| Bank transfer | total_paid_real = 0.00 | total_paid_real = 22.94 ✅ |
| iDEAL (regression) | 22.94 | 22.94 ✅ (unchanged) |