### PR TITLE
PIPRES-794 Fix credit card 422 amount error with active payment surcharge

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
 + Fixed refund confirmation modal amount to reflect selected quantity for multi-unit order lines
 + Fixed payment method ordering mismatch between admin panel and checkout page
 + Fixed VAT amount being off by 1–2 cents on high-value order lines causing Mollie API 422 errors
++ Fixed credit card payments failing with a Mollie API 422 amount error when a payment surcharge is active and prices are rounded per line
 + Hid "Refund All" button for Klarna and other authorizable Orders API payments until at least one line is shipped
 + Disabled bulk Refund / Ship / Cancel buttons based on order state on the admin order page
 + Allowed shipping orders created on the Orders API while using the Payments API

--- a/src/Service/PaymentMethodService.php
+++ b/src/Service/PaymentMethodService.php
@@ -398,8 +398,11 @@ class PaymentMethodService
             }
 
             $paymentData->setLines(
+                // Pass the pre-fee amount; the fee is appended as its own line in getCartLines().
+                // Passing the fee-inclusive total left the rounding residual uncompensated (PIPRES-794).
+                // Mirrors the Orders API path below.
                 $this->cartLinesService->getCartLines(
-                    $totalAmount,
+                    $amount,
                     $paymentFeeData,
                     $currency,
                     $cart->getSummaryDetails(),


### PR DESCRIPTION
## Ticket
PIPRES-794 (GitHub #1437) - credit card payments failing with a Mollie 422 "amount is off".

## Cause
On the Payments API path, `PaymentMethodService::getPaymentData()` passed the surcharge-inclusive total (`$totalAmount`) into `CartLinesService::getCartLines()`. The payment fee is added there as its own line, so folding it into the amount left the per-line rounding residual conflated with the fee and never compensated. The order lines then summed to a cent more or less than the order amount, which Mollie rejects with a 422. Triggered when a payment surcharge is active and `PS_ROUND_TYPE` rounds per line (or on the total).

## Fix
Pass the pre-fee `$amount` into `getCartLines()`, matching the Orders API path. The surcharge is still added as its own line and the amount sent to Mollie is unchanged. One line (plus a comment).

## Testing
- Reproduced and verified before/after through a real storefront checkout under the merchant's confirmed settings (round on each line, round half up, percentage surcharge 2.9%).
- 136-scenario regression matrix (fixed vs unpatched): only surcharge + rounding-gap cases on the Payments path change and now pass; every other scenario is byte-identical, including a no-op when no surcharge is active.
- No regression to the 6.4.3 whole-number distribution or the 6.4.4 high-value VAT fix (PIPRES-781): the per-line VAT invariant holds with 0 violations.

## Note
An unrelated rounding bug (free-shipping voucher on a paid carrier) was found during this work and filed separately as PIPRES-795.
