### PR TITLE
PIPRES-796 Fix order status webhook leaving orders half-updated on database deadlock

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
 + Added shipping method exclusion list for Apple Pay Direct
 + Fixed "On backorder (paid)" status not being set when a product is ordered at exactly 0 stock, including instant-payment methods such as iDEAL and cards
 + Fixed payment method restriction diagnostics filling up the PrestaShop log table on every checkout page render
++ Fixed order status webhook leaving orders half-updated (empty invoice, missing paid status) when a database deadlock or lock timeout interrupted the transition; the transition now runs atomically and retries transient database errors
++ Fixed webhook retries silently skipping orders whose previous status transition was interrupted; the module now detects and completes the interrupted transition, including relinking the invoice
 
 ## Changes in release 6.4.4
 + Added a "View in Mollie" link on the order page and in the Orders list to open a payment directly in the Mollie dashboard

--- a/src/Service/OrderStatusService.php
+++ b/src/Service/OrderStatusService.php
@@ -124,7 +124,7 @@ class OrderStatusService
             return;
         }
 
-        if ($matchesCurrentState && !$currentStateApplied) {
+        if ($matchesCurrentState) {
             $this->logger->error(sprintf('%s - Completing interrupted status transition', self::FILE_NAME), [
                 'order_id' => (int) $order->id,
                 'status_id' => (int) $statusId,
@@ -266,7 +266,7 @@ class OrderStatusService
 
             if (!$order->invoice_number && $invoice->number) {
                 $order->invoice_number = (int) $invoice->number;
-                $order->invoice_date = $invoice->date_add;
+                $order->invoice_date = (string) $invoice->date_add;
                 $order->update();
             }
         }

--- a/src/Service/OrderStatusService.php
+++ b/src/Service/OrderStatusService.php
@@ -13,9 +13,11 @@
 namespace Mollie\Service;
 
 use Configuration;
+use Db;
 use Mollie\Api\Types\OrderStatus;
 use Mollie\Api\Types\PaymentStatus;
 use Mollie\Config\Config;
+use Mollie\Logger\PrestaLoggerInterface;
 use Mollie\Repository\OrderRepository;
 use Mollie\Utility\OrderStatusUtility;
 use Order;
@@ -32,6 +34,11 @@ if (!defined('_PS_VERSION_')) {
 
 class OrderStatusService
 {
+    private const FILE_NAME = 'OrderStatusService';
+
+    private const TRANSITION_MAX_ATTEMPTS = 3;
+    private const TRANSITION_RETRY_DELAY_MS = 250;
+
     /**
      * @var MailService
      */
@@ -39,10 +46,14 @@ class OrderStatusService
 
     private $orderRepository;
 
-    public function __construct(MailService $mailService, OrderRepository $orderRepository)
+    /** @var PrestaLoggerInterface */
+    private $logger;
+
+    public function __construct(MailService $mailService, OrderRepository $orderRepository, PrestaLoggerInterface $logger)
     {
         $this->mailService = $mailService;
         $this->orderRepository = $orderRepository;
+        $this->logger = $logger;
     }
 
     /**
@@ -96,18 +107,32 @@ class OrderStatusService
             return;
         }
 
-        if ((int) $order->current_state === (int) $statusId) {
-            return;
-        }
-        if ($this->isStatusPaid($statusId) && $this->isStatusPaid($order->current_state)) {
+        /*
+         * current_state is committed before the history entry during a status transition,
+         * so a matching current_state without a matching history entry means a previous
+         * transition was interrupted mid-way and must be completed instead of skipped.
+         */
+        $currentStateApplied = !empty($order->getHistory($order->id_lang, (int) $order->current_state));
+        $matchesCurrentState = (int) $order->current_state === (int) $statusId
+            || ($this->isStatusPaid($statusId) && $this->isStatusPaid($order->current_state));
+
+        if ($matchesCurrentState && $currentStateApplied) {
             return;
         }
 
-        if (!Validate::isLoadedObject($order)
-            || !$status
-        ) {
+        if (!$status) {
             return;
         }
+
+        if ($matchesCurrentState && !$currentStateApplied) {
+            $this->logger->error(sprintf('%s - Completing interrupted status transition', self::FILE_NAME), [
+                'order_id' => (int) $order->id,
+                'status_id' => (int) $statusId,
+            ]);
+
+            $this->repairInterruptedTransition($order);
+        }
+
         if (null === $useExistingPayment) {
             $useExistingPayment = !$order->hasInvoice();
         }
@@ -115,37 +140,134 @@ class OrderStatusService
         $orders = $this->orderRepository->findAllByCartId($order->id_cart);
         if (count($orders) > 1) {
             foreach ($orders as $subOrder) {
-                $history = new OrderHistory();
-                $history->id_order = $subOrder->id;
-                $history->changeIdOrderState($statusId, $subOrder->id, $useExistingPayment);
-
-                $status = OrderStatusUtility::transformPaymentStatusToPaid($status, Config::STATUS_PAID_ON_BACKORDER);
-
-                if ($this->checkIfOrderConfNeedsToBeSend($statusId)) {
-                    $this->mailService->sendOrderConfMail($subOrder, $statusId);
-                }
-
-                if ('0' === Configuration::get('MOLLIE_MAIL_WHEN_' . Tools::strtoupper($status))) {
-                    $history->add();
-                } else {
-                    $history->addWithemail(true, $templateVars);
-                }
+                $this->applyOrderStatus((int) $subOrder->id, (int) $statusId, $useExistingPayment, $status, $templateVars);
             }
-        } else {
+
+            return;
+        }
+
+        $this->applyOrderStatus((int) $order->id, (int) $statusId, $useExistingPayment, $status, $templateVars);
+    }
+
+    private function applyOrderStatus(int $orderId, int $statusId, $useExistingPayment, string $status, array $templateVars): void
+    {
+        $history = null;
+
+        $this->runTransitionWithRetry(function () use (&$history, $statusId, $orderId, $useExistingPayment) {
             $history = new OrderHistory();
-            $history->id_order = $order->id;
+            $history->id_order = $orderId;
             $history->changeIdOrderState($statusId, $orderId, $useExistingPayment);
 
-            $status = OrderStatusUtility::transformPaymentStatusToPaid($status, Config::STATUS_PAID_ON_BACKORDER);
+            if (!$history->add()) {
+                throw new PrestaShopException('Could not add order history entry');
+            }
+        }, $orderId, $statusId);
 
-            if ($this->checkIfOrderConfNeedsToBeSend($statusId)) {
-                $this->mailService->sendOrderConfMail($order, $statusId);
+        $status = OrderStatusUtility::transformPaymentStatusToPaid($status, Config::STATUS_PAID_ON_BACKORDER);
+
+        $order = new Order($orderId);
+
+        if ($this->checkIfOrderConfNeedsToBeSend($statusId)) {
+            $this->mailService->sendOrderConfMail($order, $statusId);
+        }
+
+        if ('0' !== Configuration::get('MOLLIE_MAIL_WHEN_' . Tools::strtoupper($status))) {
+            $history->sendEmail($order, $templateVars);
+        }
+    }
+
+    /**
+     * Runs the state transition inside a database transaction so an interruption
+     * (deadlock, lock timeout, fatal) cannot leave the order half-updated, and
+     * retries transient database errors instead of failing the webhook.
+     */
+    private function runTransitionWithRetry(callable $transition, int $orderId, int $statusId): void
+    {
+        $db = Db::getInstance();
+        $attempt = 1;
+
+        while (true) {
+            $db->execute('START TRANSACTION');
+
+            try {
+                $transition();
+                $db->execute('COMMIT');
+
+                return;
+            } catch (\Throwable $exception) {
+                try {
+                    $db->execute('ROLLBACK');
+                } catch (\Throwable $rollbackException) {
+                }
+
+                if ($attempt >= self::TRANSITION_MAX_ATTEMPTS || !$this->isTransientDatabaseError($exception)) {
+                    throw $exception;
+                }
+
+                $this->logger->error(sprintf('%s - Transient database error during status transition, retrying', self::FILE_NAME), [
+                    'order_id' => $orderId,
+                    'status_id' => $statusId,
+                    'attempt' => $attempt,
+                    'exception_message' => $exception->getMessage(),
+                ]);
+
+                usleep(self::TRANSITION_RETRY_DELAY_MS * 1000 * $attempt);
+                ++$attempt;
+            }
+        }
+    }
+
+    private function isTransientDatabaseError(\Throwable $exception): bool
+    {
+        while ($exception !== null) {
+            $message = $exception->getMessage();
+
+            if (stripos($message, 'Deadlock found') !== false
+                || stripos($message, 'Lock wait timeout') !== false
+                || stripos($message, 'SQLSTATE[40001]') !== false
+            ) {
+                return true;
             }
 
-            if ('0' === Configuration::get('MOLLIE_MAIL_WHEN_' . Tools::strtoupper($status))) {
-                $history->add();
-            } else {
-                $history->addWithemail(true, $templateVars);
+            $exception = $exception->getPrevious();
+        }
+
+        return false;
+    }
+
+    /**
+     * Completes what an interrupted transition left behind: an invoice without
+     * linked order lines, payments and order invoice fields.
+     */
+    private function repairInterruptedTransition(Order $order): void
+    {
+        foreach ($order->getInvoicesCollection() as $invoice) {
+            /** @var \OrderInvoice $invoice */
+            $linkedDetails = (int) Db::getInstance()->getValue(
+                'SELECT COUNT(*) FROM `' . _DB_PREFIX_ . 'order_detail` WHERE `id_order_invoice` = ' . (int) $invoice->id
+            );
+
+            if ($linkedDetails > 0) {
+                continue;
+            }
+
+            Db::getInstance()->execute(
+                'UPDATE `' . _DB_PREFIX_ . 'order_detail` SET `id_order_invoice` = ' . (int) $invoice->id
+                . ' WHERE `id_order` = ' . (int) $order->id . ' AND `id_order_invoice` = 0'
+            );
+
+            Db::getInstance()->execute(
+                'INSERT INTO `' . _DB_PREFIX_ . 'order_invoice_payment` (`id_order_invoice`, `id_order_payment`, `id_order`)'
+                . ' SELECT ' . (int) $invoice->id . ', op.`id_order_payment`, ' . (int) $order->id
+                . ' FROM `' . _DB_PREFIX_ . 'order_payment` op'
+                . ' LEFT JOIN `' . _DB_PREFIX_ . 'order_invoice_payment` oip ON oip.`id_order_payment` = op.`id_order_payment`'
+                . ' WHERE op.`order_reference` = \'' . pSQL($order->reference) . '\' AND oip.`id_order_payment` IS NULL'
+            );
+
+            if (!$order->invoice_number && $invoice->number) {
+                $order->invoice_number = (int) $invoice->number;
+                $order->invoice_date = $invoice->date_add;
+                $order->update();
             }
         }
     }


### PR DESCRIPTION
## Problem

When a MySQL deadlock or lock wait timeout interrupts the order status transition mid-way (e.g. the paid webhook colliding with a scheduled ERP sync), the order is left permanently half-updated:

- `current_state` is committed to paid but no history entry exists
- the invoice is created with a number but no order lines linked ("invoice has no positions")
- Mollie's webhook retry responds 200 but repairs nothing, because the `current_state` guard in `OrderStatusService` treats the half-applied state as already done
- a later manual status change auto-creates a duplicate payment (false overpayment warning)

Confirmed on merchant production (8 affected orders, each matching a logged deadlock to the second) and reproduced deterministically on PS 8.2.3 by holding a row lock on the order's `order_detail` rows while the paid webhook arrives. Related reports: #1025 (timeout variant), #387 (duplicate payments). Bank transfer is the most exposed flow (order exists before payment), but the code path is shared by all payment methods, including refund, chargeback and Klarna shipment transitions.

## Fix

- Run the state transition (`changeIdOrderState` + history entry) inside a database transaction; roll back and retry up to 3 times on transient database errors (deadlock 1213, lock wait timeout 1205). A final failure rolls back cleanly so the next webhook retry finds an untouched order.
- The `current_state` guard now also checks the order history: a matching `current_state` without a history entry is an interrupted transition, which gets logged, repaired (relink invoice order lines, link payments to the invoice, set order invoice number and date) and completed instead of skipped.
- Status emails are sent after commit, so a mail failure can no longer break or block a transition; a failed history insert now throws instead of being silently ignored.

## Validation

Tested against a reproduction harness on PS 8.2.3 with real Mollie test webhooks (bank transfer):

1. Order broken by the old code is healed by a single webhook retry: paid history added, invoice relinked, invoice number and date set, no duplicate payment
2. 30s lock collision: two transient failures logged, third attempt succeeds in the same request, fully consistent result
3. 60s lock (outlasts all attempts): webhook responds 400 but the rollback is pristine, no orphan invoice, order still awaiting
4. Subsequent webhook retry after the failure: clean full transition
5. No collision: normal flow unchanged

## Release

- Changelog updated (6.4.5 section)

## Note for reviewers

Hooks fired by `changeIdOrderState` now run inside the transaction: their database writes roll back together with the transition (consistent), but external side effects could fire once per retry attempt. Retries only happen on transient database errors, which previously produced a permanently broken order.