### PR TITLE
PIPRES-783 Fix IDOR in recurring order detail controller

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@
 + Improved order description update logic and adjusted resource logging
 + Added diagnostic logging when a payment method is hidden by a restriction
 + Resolved PrestaShop Validator findings (errors, licenses, security)
++ Fixed subscription authorization so customers can only cancel or change the payment method of their own subscriptions
 
 ## Changes in release 6.4.3
 + Fixed Payment API race condition causing false "payment failed" errors

--- a/controllers/front/recurringOrderDetail.php
+++ b/controllers/front/recurringOrderDetail.php
@@ -144,6 +144,12 @@ class MollieRecurringOrderDetailModuleFrontController extends AbstractMollieCont
             return;
         }
 
+        if (!$this->customerOwnsRecurringOrder($recurringOrderId)) {
+            $this->errors[] = $this->module->l('You do not have permission to modify this subscription.', self::FILE_NAME);
+
+            return;
+        }
+
         /** @var FreeOrderCreationHandler $freeOrderCreationHandler */
         $freeOrderCreationHandler = $this->module->getService(FreeOrderCreationHandler::class);
         $checkoutUrl = $freeOrderCreationHandler->handle($recurringOrderId, $newMethod);
@@ -167,11 +173,44 @@ class MollieRecurringOrderDetailModuleFrontController extends AbstractMollieCont
             return;
         }
 
+        if (!$this->customerOwnsRecurringOrder($recurringOrderId)) {
+            $this->errors[] = $this->module->l('You do not have permission to modify this subscription.', self::FILE_NAME);
+
+            return;
+        }
+
         /** @var SubscriptionCancellationHandler $subscriptionCancellationHandler */
         $subscriptionCancellationHandler = $this->module->getService(SubscriptionCancellationHandler::class);
 
         $subscriptionCancellationHandler->handle($recurringOrderId);
         $this->success[] = $this->module->l('Successfully canceled subscription.', self::FILE_NAME);
+    }
+
+    private function customerOwnsRecurringOrder($recurringOrderId): bool
+    {
+        $recurringOrderId = (int) $recurringOrderId;
+
+        if (!Validate::isUnsignedId($recurringOrderId)) {
+            return false;
+        }
+
+        if (!Validate::isLoadedObject($this->context->customer)) {
+            return false;
+        }
+
+        /** @var RecurringOrderRepositoryInterface $recurringOrderRepository */
+        $recurringOrderRepository = $this->module->getService(RecurringOrderRepositoryInterface::class);
+
+        /** @var \MolRecurringOrder|null $recurringOrder */
+        $recurringOrder = $recurringOrderRepository->findOneBy([
+            'id_mol_recurring_order' => $recurringOrderId,
+        ]);
+
+        if (!$recurringOrder) {
+            return false;
+        }
+
+        return (int) $recurringOrder->id_customer === (int) $this->context->customer->id;
     }
 
     private function validateToken(): bool


### PR DESCRIPTION
## Summary

Fixes an IDOR (CWE-639) in `MollieRecurringOrderDetailModuleFrontController`. The subscription cancellation and payment-method update operations run in `postProcess()`, but the ownership check (subscription belongs to the authenticated customer) only ran later in `initContent()`. Since `postProcess()` executes before `initContent()`, an authenticated customer could cancel, or change the payment method of, any other customer's subscription by submitting that subscription's `recurring_order_id` - the CSRF token only validates the attacker's own session, not the target resource.

Ref: PIPRES-783 (CVSS 3.1 8.1, High).

## Fix

- Added `customerOwnsRecurringOrder()` and call it in both `updatePaymentMethod()` and `cancelSubscription()` **before** dispatching to the handlers.
- The check is bound to the exact parameter the operations consume (`recurring_order_id`), not the page's `id_mol_recurring_order`, so it cannot be bypassed by pairing an owned page ID with a victim's operation ID.
- Fails closed for invalid IDs, guests, and non-existent records.

The shared `SubscriptionCancellationHandler` is intentionally left unchanged: it is also used by the admin `SubscriptionController::cancelAction` (guarded by `@AdminSecurity`), where an employee legitimately cancels any customer's subscription. The correct authorization boundary for customer-facing requests is the front controller.

## Testing

Verified on PrestaShop 8.2.1 + Mollie 6.4.4, CSRF tokens enabled, with an authenticated attacker holding a valid token and two customers each owning a subscription:

| Scenario | Code | Result |
| --- | --- | --- |
| Attacker cancels victim's subscription | unfixed | request reaches the cancellation handler (vulnerable) |
| Attacker cancels victim's subscription | fixed | blocked at guard (302), handler never reached, victim unchanged |
| Attacker changes victim's payment method | fixed | blocked, no Mollie checkout URL returned |
| Customer cancels their own subscription | fixed | passes the guard (no regression) |

The token was valid in every request, confirming the block is the ownership check and not CSRF.

## Changelog

- Added entry under 6.4.4.
