### PR TITLE
PIPRES-807: applepay direct cart session binding

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@
 + Improved order description update logic and adjusted resource logging
 + Added diagnostic logging when a payment method is hidden by a restriction
 + Resolved PrestaShop Validator findings (errors, licenses, security)
++ Fixed Apple Pay Direct authorization so cart operations only affect the caller's own session cart
 
 ## Changes in release 6.4.3
 + Fixed Payment API race condition causing false "payment failed" errors

--- a/controllers/front/applePayDirectAjax.php
+++ b/controllers/front/applePayDirectAjax.php
@@ -21,9 +21,11 @@ use Mollie\Application\CommandHandler\UpdateApplePayShippingMethodHandler;
 use Mollie\Builder\ApplePayDirect\ApplePayOrderBuilder;
 use Mollie\Builder\ApplePayDirect\ApplePayProductBuilder;
 use Mollie\Controller\AbstractMollieController;
+use Mollie\Errors\Http\HttpStatusCode;
 use Mollie\Exception\FailedToProvidePaymentFeeException;
 use Mollie\Logger\Logger;
 use Mollie\Logger\LoggerInterface;
+use Mollie\Utility\ApplePayDirect\CartOwnershipUtility;
 use Mollie\Utility\ExceptionUtility;
 use Mollie\Utility\OrderRecoverUtility;
 
@@ -34,6 +36,13 @@ if (!defined('_PS_VERSION_')) {
 class MollieApplePayDirectAjaxModuleFrontController extends AbstractMollieController
 {
     private const FILE_NAME = 'applePayDirectAjax';
+
+    /**
+     * Session cookie key holding the cart id the Apple Pay Direct flow is authorized to
+     * operate on. Bound server-side in getApplePaySession(); verified on every other action.
+     */
+    private const APPLE_PAY_CART_ID_COOKIE = 'mollie_apple_pay_cart_id';
+
     /** @var Mollie */
     public $module;
 
@@ -71,8 +80,12 @@ class MollieApplePayDirectAjaxModuleFrontController extends AbstractMollieContro
 
     private function getApplePaySession()
     {
-        $cartId = (int) Tools::getValue('cartId');
         $validationUrl = Tools::getValue('validationUrl');
+
+        $cartId = CartOwnershipUtility::resolveReusableCartId(
+            (int) Tools::getValue('cartId'),
+            (int) $this->context->cart->id
+        );
 
         /** @var RequestApplePayPaymentSessionHandler $handler */
         $handler = $this->module->getService(RequestApplePayPaymentSessionHandler::class);
@@ -103,11 +116,23 @@ class MollieApplePayDirectAjaxModuleFrontController extends AbstractMollieContro
             $this->ajaxRender('Unable to get apple pay session');
         }
 
+        // Bind the authorized cart id (session cart or freshly minted cart) to this session
+        // so every subsequent Apple Pay Direct action can verify ownership.
+        if (is_array($response) && !empty($response['success']) && !empty($response['cartId'])) {
+            $this->bindCartToSession((int) $response['cartId']);
+        }
+
         $this->ajaxRender(json_encode($response));
     }
 
     private function updateShippingMethod()
     {
+        if (!$this->isCartBoundToSession((int) Tools::getValue('cartId'))) {
+            $this->denyUnboundCart();
+
+            return;
+        }
+
         /** @var UpdateApplePayShippingMethodHandler $handler */
         $handler = $this->module->getService(UpdateApplePayShippingMethodHandler::class);
 
@@ -142,6 +167,12 @@ class MollieApplePayDirectAjaxModuleFrontController extends AbstractMollieContro
 
     private function updateAppleShippingContact()
     {
+        if (!$this->isCartBoundToSession((int) Tools::getValue('cartId'))) {
+            $this->denyUnboundCart();
+
+            return;
+        }
+
         $originalCartId = (int) $this->context->cookie->id_cart;
         $originalCustomerId = (int) $this->context->cookie->id_customer;
 
@@ -200,6 +231,13 @@ class MollieApplePayDirectAjaxModuleFrontController extends AbstractMollieContro
     private function createApplePayOrder()
     {
         $cartId = (int) Tools::getValue('cartId');
+
+        if (!$this->isCartBoundToSession($cartId)) {
+            $this->denyUnboundCart();
+
+            return;
+        }
+
         $cart = new Cart($cartId);
 
         $products = $this->getWantedCartProducts($cartId);
@@ -231,7 +269,14 @@ class MollieApplePayDirectAjaxModuleFrontController extends AbstractMollieContro
 
     private function getTotalApplePayCartPrice()
     {
-        $cartId = Tools::getValue('cartId');
+        $cartId = (int) Tools::getValue('cartId');
+
+        if (!$this->isCartBoundToSession($cartId)) {
+            $this->denyUnboundCart();
+
+            return;
+        }
+
         $cart = new Cart($cartId);
 
         $this->ajaxRender(json_encode(
@@ -244,6 +289,13 @@ class MollieApplePayDirectAjaxModuleFrontController extends AbstractMollieContro
     private function removeProductFromCart()
     {
         $cartId = (int) Tools::getValue('cartId');
+
+        if (!$this->isCartBoundToSession($cartId)) {
+            $this->denyUnboundCart();
+
+            return;
+        }
+
         $productId = (int) Tools::getValue('id_product');
         $productAttributeId = (int) Tools::getValue('id_product_attribute');
 
@@ -251,6 +303,41 @@ class MollieApplePayDirectAjaxModuleFrontController extends AbstractMollieContro
         $cart->deleteProduct($productId, $productAttributeId);
 
         $this->ajaxRender(json_encode(['success' => true]));
+    }
+
+    private function isCartBoundToSession(int $cartId): bool
+    {
+        return CartOwnershipUtility::isCartAuthorized(
+            $cartId,
+            (int) $this->context->cart->id,
+            (int) $this->context->cookie->{self::APPLE_PAY_CART_ID_COOKIE}
+        );
+    }
+
+    private function bindCartToSession(int $cartId): void
+    {
+        $this->context->cookie->{self::APPLE_PAY_CART_ID_COOKIE} = $cartId;
+        // Persist now: ajaxRender() outputs the body, after which cookie headers can no longer be sent.
+        $this->context->cookie->write();
+    }
+
+    private function denyUnboundCart(): void
+    {
+        /** @var Logger $logger */
+        $logger = $this->module->getService(LoggerInterface::class);
+
+        $logger->error(sprintf('%s - Rejected cart operation not bound to the session', self::FILE_NAME), [
+            'context' => [
+                'cartId' => (int) Tools::getValue('cartId'),
+                'action' => Tools::getValue('action'),
+            ],
+        ]);
+
+        $this->respond(
+            'error',
+            HttpStatusCode::HTTP_FORBIDDEN,
+            $this->module->l('You are not allowed to perform this action on this cart.', self::FILE_NAME)
+        );
     }
 
     private function getWantedCartProducts(int $cartId)

--- a/src/Utility/ApplePayDirect/CartOwnershipUtility.php
+++ b/src/Utility/ApplePayDirect/CartOwnershipUtility.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Mollie       https://www.mollie.nl
+ *
+ * @author      Mollie B.V. <info@mollie.nl>
+ * @copyright   Mollie B.V.
+ * @license     https://github.com/mollie/PrestaShop/blob/master/LICENSE.md
+ *
+ * @see        https://github.com/mollie/PrestaShop
+ * @codingStandardsIgnoreStart
+ */
+
+namespace Mollie\Utility\ApplePayDirect;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * Authorization rules that bind Apple Pay Direct cart operations to the caller's session.
+ *
+ * The product-page flow mints an anonymous cart server-side and the cart-page flow reuses
+ * the shopper's session cart, so there is no logged-in customer to bind against. These pure
+ * decisions keep the controller from ever trusting a raw, attacker-supplied cart id.
+ */
+class CartOwnershipUtility
+{
+    /**
+     * Decides which cart id the payment-session request may reuse.
+     *
+     * Only the shopper's own session cart may be reused (cart-page flow); any other supplied
+     * value yields 0, forcing a fresh empty cart to be minted (product-page flow). This stops
+     * an attacker from binding a foreign cart to their session.
+     */
+    public static function resolveReusableCartId(int $requestedCartId, int $sessionCartId): int
+    {
+        return $requestedCartId > 0 && $requestedCartId === $sessionCartId ? $sessionCartId : 0;
+    }
+
+    /**
+     * A cart id is authorized when it is either the caller's own session cart (cart-page flow)
+     * or the Apple Pay cart previously bound to this session (product-page flow).
+     */
+    public static function isCartAuthorized(int $cartId, int $sessionCartId, int $boundCartId): bool
+    {
+        if ($cartId <= 0) {
+            return false;
+        }
+
+        return $cartId === $sessionCartId || $cartId === $boundCartId;
+    }
+}

--- a/tests/Unit/Utility/ApplePayDirect/CartOwnershipUtilityTest.php
+++ b/tests/Unit/Utility/ApplePayDirect/CartOwnershipUtilityTest.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Mollie       https://www.mollie.nl
+ *
+ * @author      Mollie B.V. <info@mollie.nl>
+ * @copyright   Mollie B.V.
+ * @license     https://github.com/mollie/PrestaShop/blob/master/LICENSE.md
+ *
+ * @see        https://github.com/mollie/PrestaShop
+ * @codingStandardsIgnoreStart
+ */
+
+use Mollie\Utility\ApplePayDirect\CartOwnershipUtility;
+use PHPUnit\Framework\TestCase;
+
+class CartOwnershipUtilityTest extends TestCase
+{
+    /**
+     * @dataProvider resolveReusableCartIdDataProvider
+     */
+    public function testResolveReusableCartId(int $requestedCartId, int $sessionCartId, int $expected)
+    {
+        $this->assertSame($expected, CartOwnershipUtility::resolveReusableCartId($requestedCartId, $sessionCartId));
+    }
+
+    public function resolveReusableCartIdDataProvider(): array
+    {
+        return [
+            'cart-page flow reuses own session cart' => [
+                'requestedCartId' => 42,
+                'sessionCartId' => 42,
+                'expected' => 42,
+            ],
+            'product-page flow sends no cart, forces mint' => [
+                'requestedCartId' => 0,
+                'sessionCartId' => 55,
+                'expected' => 0,
+            ],
+            'foreign cart id is never reused, forces mint' => [
+                'requestedCartId' => 999,
+                'sessionCartId' => 42,
+                'expected' => 0,
+            ],
+            'no session cart yet, forces mint' => [
+                'requestedCartId' => 42,
+                'sessionCartId' => 0,
+                'expected' => 0,
+            ],
+            'negative requested id is rejected' => [
+                'requestedCartId' => -5,
+                'sessionCartId' => -5,
+                'expected' => 0,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider isCartAuthorizedDataProvider
+     */
+    public function testIsCartAuthorized(int $cartId, int $sessionCartId, int $boundCartId, bool $expected)
+    {
+        $this->assertSame($expected, CartOwnershipUtility::isCartAuthorized($cartId, $sessionCartId, $boundCartId));
+    }
+
+    public function isCartAuthorizedDataProvider(): array
+    {
+        return [
+            'matches session cart (cart-page flow)' => [
+                'cartId' => 42,
+                'sessionCartId' => 42,
+                'boundCartId' => 0,
+                'expected' => true,
+            ],
+            'matches bound cart (product-page flow)' => [
+                'cartId' => 77,
+                'sessionCartId' => 42,
+                'boundCartId' => 77,
+                'expected' => true,
+            ],
+            'foreign cart matching neither is rejected' => [
+                'cartId' => 999,
+                'sessionCartId' => 42,
+                'boundCartId' => 77,
+                'expected' => false,
+            ],
+            'attacker with no session cart nor binding is rejected' => [
+                'cartId' => 999,
+                'sessionCartId' => 0,
+                'boundCartId' => 0,
+                'expected' => false,
+            ],
+            'zero cart id is rejected' => [
+                'cartId' => 0,
+                'sessionCartId' => 0,
+                'boundCartId' => 0,
+                'expected' => false,
+            ],
+            'negative cart id is rejected even if it matches' => [
+                'cartId' => -1,
+                'sessionCartId' => -1,
+                'boundCartId' => -1,
+                'expected' => false,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
| Questions       | Answers
|-----------------| -------------------------------------------------------
| Branch?         | develop
| Description?    | Fix an Apple Pay Direct cart IDOR: bind the Apple Pay Direct AJAX cart operations to the current session's cart so a request cannot act on another customer's cart. Adds `CartOwnershipUtility` with a unit test.
| Type?           | bug fix
| How to test?    | Start an Apple Pay Direct payment from the product page and confirm the flow still completes for the session's own cart; a request referencing a cart that does not belong to the session is rejected.
| Fixed issue ?   | PIPRES-807

## Changes

- **`controllers/front/applePayDirectAjax.php`** — reject cart operations not bound to the current session.
- **`src/Utility/ApplePayDirect/CartOwnershipUtility.php`** — session/cart ownership check (+ unit test).
