### PR TITLE
PIPRES-808: Harden webhook security token and subscription secure-key validation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,8 @@
 # Changelog #
 
 ## Changes in release 6.4.4
++ Hardened the payment webhook by validating the security token before processing a transaction
++ Hardened the subscription payment method update webhook by validating the secure key before applying changes
 + Added bank transfer due date configuration
 + Added Segment analytics tracking for module and payment events
 + Added Bulgarian translations

--- a/controllers/front/webhook.php
+++ b/controllers/front/webhook.php
@@ -21,6 +21,7 @@ use Mollie\Logger\Logger;
 use Mollie\Logger\LoggerInterface;
 use Mollie\Service\TransactionService;
 use Mollie\Utility\ExceptionUtility;
+use Mollie\Utility\HashUtility;
 use Mollie\Utility\TransactionUtility;
 
 if (!defined('_PS_VERSION_')) {
@@ -149,6 +150,30 @@ class MollieWebhookModuleFrontController extends AbstractMollieController
             ]);
 
             throw new \Exception(sprintf('Missing Cart ID. Transaction ID: [%s]', $transactionId), HttpStatusCode::HTTP_NOT_FOUND);
+        }
+
+        $cart = new Cart((int) $cartId);
+
+        if (!Validate::isLoadedObject($cart)) {
+            $logger->error(sprintf('%s - Cart not found', self::FILE_NAME), [
+                'transaction_id' => $transactionId,
+                'cart_id' => $cartId,
+            ]);
+
+            throw new TransactionException(sprintf('Cart not found. Transaction ID: [%s]', $transactionId), HttpStatusCode::HTTP_UNPROCESSABLE_ENTITY);
+        }
+
+        /** @var ToolsAdapter $tools */
+        $tools = $this->module->getService(ToolsAdapter::class);
+
+        $expectedToken = HashUtility::hash($cart->secure_key);
+
+        if (!hash_equals($expectedToken, (string) $tools->getValue('security_token'))) {
+            $logger->error(sprintf('%s - Invalid security token', self::FILE_NAME), [
+                'transaction_id' => $transactionId,
+            ]);
+
+            throw new TransactionException('Invalid security token.', HttpStatusCode::HTTP_UNAUTHORIZED);
         }
 
         $this->setContext($cartId);

--- a/subscription/Handler/SubscriptionPaymentMethodUpdateHandler.php
+++ b/subscription/Handler/SubscriptionPaymentMethodUpdateHandler.php
@@ -14,11 +14,16 @@ declare(strict_types=1);
 
 namespace Mollie\Subscription\Handler;
 
+use Mollie;
+use Mollie\Errors\Http\HttpStatusCode;
+use Mollie\Exception\TransactionException;
 use Mollie\Subscription\Api\PaymentApi;
 use Mollie\Subscription\Api\SubscriptionApi;
+use Mollie\Subscription\Factory\GetSubscriptionDataFactory;
 use Mollie\Subscription\Factory\UpdateSubscriptionDataFactory;
 use Mollie\Subscription\Repository\RecurringOrderRepositoryInterface;
 use Mollie\Subscription\Utility\ClockInterface;
+use Mollie\Utility\SecureKeyUtility;
 
 if (!defined('_PS_VERSION_')) {
     exit;
@@ -36,19 +41,27 @@ class SubscriptionPaymentMethodUpdateHandler
     private $paymentApi;
     /** @var ClockInterface */
     private $clock;
+    /** @var GetSubscriptionDataFactory */
+    private $getSubscriptionDataFactory;
+    /** @var Mollie */
+    private $mollie;
 
     public function __construct(
         SubscriptionApi $subscriptionApi,
         RecurringOrderRepositoryInterface $recurringOrderRepository,
         UpdateSubscriptionDataFactory $subscriptionDataFactory,
         PaymentApi $paymentApi,
-        ClockInterface $clock
+        ClockInterface $clock,
+        GetSubscriptionDataFactory $getSubscriptionDataFactory,
+        Mollie $mollie
     ) {
         $this->subscriptionApi = $subscriptionApi;
         $this->recurringOrderRepository = $recurringOrderRepository;
         $this->subscriptionDataFactory = $subscriptionDataFactory;
         $this->paymentApi = $paymentApi;
         $this->clock = $clock;
+        $this->getSubscriptionDataFactory = $getSubscriptionDataFactory;
+        $this->mollie = $mollie;
     }
 
     /**
@@ -56,10 +69,23 @@ class SubscriptionPaymentMethodUpdateHandler
      */
     public function handle(string $transactionId, string $subscriptionId)
     {
-        $molPayment = $this->paymentApi->getPayment($transactionId);
-
         /** @var \MolRecurringOrder $recurringOrder */
         $recurringOrder = $this->recurringOrderRepository->findOrFail(['mollie_subscription_id' => $subscriptionId]);
+
+        $subscriptionData = $this->getSubscriptionDataFactory->build((int) $recurringOrder->id);
+        $subscription = $this->subscriptionApi->getSubscription($subscriptionData);
+
+        $key = SecureKeyUtility::generateReturnKey(
+            $recurringOrder->id_customer,
+            $recurringOrder->id_cart,
+            $this->mollie->name
+        );
+
+        if ($key !== $subscription->metadata->secure_key) {
+            throw new TransactionException('Security key is incorrect.', HttpStatusCode::HTTP_UNAUTHORIZED);
+        }
+
+        $molPayment = $this->paymentApi->getPayment($transactionId);
 
         $subscriptionUpdateData = $this->subscriptionDataFactory->build($recurringOrder, $molPayment->mandateId);
         $newSubscription = $this->subscriptionApi->updateSubscription($subscriptionUpdateData);

--- a/tests/Unit/Subscription/Handler/SubscriptionPaymentMethodUpdateHandlerTest.php
+++ b/tests/Unit/Subscription/Handler/SubscriptionPaymentMethodUpdateHandlerTest.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * Mollie       https://www.mollie.nl
+ *
+ * @author      Mollie B.V. <info@mollie.nl>
+ * @copyright   Mollie B.V.
+ * @license     https://github.com/mollie/PrestaShop/blob/master/LICENSE.md
+ *
+ * @see        https://github.com/mollie/PrestaShop
+ * @codingStandardsIgnoreStart
+ */
+
+namespace Mollie\Tests\Unit\Subscription\Handler;
+
+use Mollie\Api\Resources\Payment;
+use Mollie\Api\Resources\Subscription;
+use Mollie\Errors\Http\HttpStatusCode;
+use Mollie\Exception\TransactionException;
+use Mollie\Subscription\Api\PaymentApi;
+use Mollie\Subscription\Api\Request\UpdateSubscriptionRequest;
+use Mollie\Subscription\Api\SubscriptionApi;
+use Mollie\Subscription\DTO\GetSubscriptionData;
+use Mollie\Subscription\Factory\GetSubscriptionDataFactory;
+use Mollie\Subscription\Factory\UpdateSubscriptionDataFactory;
+use Mollie\Subscription\Handler\SubscriptionPaymentMethodUpdateHandler;
+use Mollie\Subscription\Repository\RecurringOrderRepositoryInterface;
+use Mollie\Subscription\Utility\ClockInterface;
+use Mollie\Tests\Unit\BaseTestCase;
+use Mollie\Utility\SecureKeyUtility;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class SubscriptionPaymentMethodUpdateHandlerTest extends BaseTestCase
+{
+    private const CUSTOMER_ID = 1;
+    private const CART_ID = 2;
+    private const MODULE_NAME = 'mollie';
+    private const TRANSACTION_ID = 'tr_test';
+    private const SUBSCRIPTION_ID = 'sub_test';
+
+    /** @var SubscriptionApi|MockObject */
+    private $subscriptionApi;
+    /** @var RecurringOrderRepositoryInterface|MockObject */
+    private $recurringOrderRepository;
+    /** @var UpdateSubscriptionDataFactory|MockObject */
+    private $updateSubscriptionDataFactory;
+    /** @var PaymentApi|MockObject */
+    private $paymentApi;
+    /** @var ClockInterface|MockObject */
+    private $clock;
+    /** @var GetSubscriptionDataFactory|MockObject */
+    private $getSubscriptionDataFactory;
+    /** @var \Mollie|MockObject */
+    private $module;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->subscriptionApi = $this->mock(SubscriptionApi::class);
+        $this->recurringOrderRepository = $this->mock(RecurringOrderRepositoryInterface::class);
+        $this->updateSubscriptionDataFactory = $this->mock(UpdateSubscriptionDataFactory::class);
+        $this->paymentApi = $this->mock(PaymentApi::class);
+        $this->clock = $this->mock(ClockInterface::class);
+        $this->getSubscriptionDataFactory = $this->mock(GetSubscriptionDataFactory::class);
+        $this->module = $this->mock(\Mollie::class);
+        $this->module->name = self::MODULE_NAME;
+    }
+
+    public function testItThrowsWhenSecureKeyDoesNotMatch(): void
+    {
+        $recurringOrder = $this->buildRecurringOrder();
+        $recurringOrder->expects($this->never())->method('update');
+
+        $this->recurringOrderRepository
+            ->expects($this->once())
+            ->method('findOrFail')
+            ->with(['mollie_subscription_id' => self::SUBSCRIPTION_ID])
+            ->willReturn($recurringOrder);
+
+        $this->getSubscriptionDataFactory
+            ->expects($this->once())
+            ->method('build')
+            ->willReturn($this->mock(GetSubscriptionData::class));
+
+        $this->subscriptionApi
+            ->expects($this->once())
+            ->method('getSubscription')
+            ->willReturn($this->buildSubscription('some-other-secure-key'));
+
+        // Nothing beyond the security check should run.
+        $this->paymentApi->expects($this->never())->method('getPayment');
+        $this->updateSubscriptionDataFactory->expects($this->never())->method('build');
+        $this->subscriptionApi->expects($this->never())->method('updateSubscription');
+
+        $this->expectException(TransactionException::class);
+        $this->expectExceptionCode(HttpStatusCode::HTTP_UNAUTHORIZED);
+
+        $this->createHandler()->handle(self::TRANSACTION_ID, self::SUBSCRIPTION_ID);
+    }
+
+    public function testItUpdatesPaymentMethodWhenSecureKeyMatches(): void
+    {
+        $recurringOrder = $this->buildRecurringOrder();
+        $recurringOrder->expects($this->once())->method('update');
+
+        $this->recurringOrderRepository
+            ->expects($this->once())
+            ->method('findOrFail')
+            ->with(['mollie_subscription_id' => self::SUBSCRIPTION_ID])
+            ->willReturn($recurringOrder);
+
+        $this->getSubscriptionDataFactory
+            ->expects($this->once())
+            ->method('build')
+            ->willReturn($this->mock(GetSubscriptionData::class));
+
+        $expectedKey = SecureKeyUtility::generateReturnKey(self::CUSTOMER_ID, self::CART_ID, self::MODULE_NAME);
+
+        $this->subscriptionApi
+            ->expects($this->once())
+            ->method('getSubscription')
+            ->willReturn($this->buildSubscription($expectedKey));
+
+        /** @var Payment|MockObject $payment */
+        $payment = $this->mock(Payment::class);
+        $payment->mandateId = 'mdt_test';
+        $payment->method = 'creditcard';
+
+        $this->paymentApi
+            ->expects($this->once())
+            ->method('getPayment')
+            ->with(self::TRANSACTION_ID)
+            ->willReturn($payment);
+
+        $this->updateSubscriptionDataFactory
+            ->expects($this->once())
+            ->method('build')
+            ->with($recurringOrder, 'mdt_test')
+            ->willReturn($this->mock(UpdateSubscriptionRequest::class));
+
+        $this->subscriptionApi
+            ->expects($this->exactly(2))
+            ->method('updateSubscription')
+            ->willReturn($this->buildSubscription($expectedKey, 'sub_new'));
+
+        $this->clock->expects($this->once())->method('getCurrentDate')->willReturn('2024-01-01 00:00:00');
+
+        $this->createHandler()->handle(self::TRANSACTION_ID, self::SUBSCRIPTION_ID);
+
+        self::assertSame('creditcard', $recurringOrder->payment_method);
+        self::assertSame('sub_new', $recurringOrder->mollie_subscription_id);
+    }
+
+    private function createHandler(): SubscriptionPaymentMethodUpdateHandler
+    {
+        return new SubscriptionPaymentMethodUpdateHandler(
+            $this->subscriptionApi,
+            $this->recurringOrderRepository,
+            $this->updateSubscriptionDataFactory,
+            $this->paymentApi,
+            $this->clock,
+            $this->getSubscriptionDataFactory,
+            $this->module
+        );
+    }
+
+    /**
+     * @return \MolRecurringOrder|MockObject
+     */
+    private function buildRecurringOrder()
+    {
+        /** @var \MolRecurringOrder|MockObject $recurringOrder */
+        $recurringOrder = $this->mock(\MolRecurringOrder::class);
+        $recurringOrder->id = 10;
+        $recurringOrder->id_customer = self::CUSTOMER_ID;
+        $recurringOrder->id_cart = self::CART_ID;
+        $recurringOrder->mollie_customer_id = 'cst_test';
+        $recurringOrder->mollie_subscription_id = self::SUBSCRIPTION_ID;
+
+        return $recurringOrder;
+    }
+
+    /**
+     * @return Subscription|MockObject
+     */
+    private function buildSubscription(string $secureKey, string $id = 'sub_test')
+    {
+        /** @var Subscription|MockObject $subscription */
+        $subscription = $this->mock(Subscription::class);
+        $subscription->id = $id;
+
+        $metadata = new \stdClass();
+        $metadata->secure_key = $secureKey;
+        $subscription->metadata = $metadata;
+
+        return $subscription;
+    }
+}


### PR DESCRIPTION
| Questions       | Answers
|-----------------| -------------------------------------------------------
| Branch?         | develop
| Description?    | Security-review follow-up (PIPRES-792): reject a forged/missing token or secure key before processing on two webhook paths.
| Type?           | bug fix
| How to test?    | Call the payment webhook with a wrong `security_token` -> `401`, no processing; correct token still processes. Trigger the subscription payment-method update webhook with a mismatched secure key -> `401`; a valid Mollie callback still applies.
| Fixed issue ?   | PIPRES-808

## Changes

- **`controllers/front/webhook.php`** — validate the URL `security_token` against `HashUtility::hash($cart->secure_key)` and reject before `processTransaction`.
- **`subscription/Handler/SubscriptionPaymentMethodUpdateHandler.php`** — validate the subscription `secure_key` before applying the update, matching the sibling `RecurringOrderHandler`.
- Unit test added for the subscription handler; full Unit suite green.

Confidence: 95%
