### PR TITLE
PIPRES-785: multistore per-shop API keys + safe key transition (fallback)

### DIFF
--- a/controllers/admin/AdminMollieAuthenticationController.php
+++ b/controllers/admin/AdminMollieAuthenticationController.php
@@ -77,6 +77,12 @@ class AdminMollieAuthenticationController extends ModuleAdminController
                 'liveApiKey' => $this->module->l('Live API Key', self::FILE_NAME),
                 'apiKeyPlaceholder' => $this->module->l('Enter your API key here', self::FILE_NAME),
                 'apiKeyDescription' => $this->module->l('Required for connecting to the %s mode.', self::FILE_NAME),
+                'fallbackApiKey' => $this->module->l('Fallback API Key (optional)', self::FILE_NAME),
+                'fallbackApiKeyPlaceholder' => $this->module->l('Enter a fallback API key', self::FILE_NAME),
+                'fallbackApiKeyDescription' => $this->module->l('Used for existing orders when neither the order\'s original key nor the current key can access them (e.g. after rotating keys or migrating to per-store keys). Leave empty to disable.', self::FILE_NAME),
+                'saveFallbackKey' => $this->module->l('Save fallback key', self::FILE_NAME),
+                'fallbackKeySaved' => $this->module->l('Fallback key saved', self::FILE_NAME),
+                'fallbackKeyCleared' => $this->module->l('Fallback key removed', self::FILE_NAME),
                 'connect' => $this->module->l('Connect', self::FILE_NAME),
                 'connecting' => $this->module->l('Connecting...', self::FILE_NAME),
                 'connected' => $this->module->l('Connected', self::FILE_NAME),
@@ -215,6 +221,9 @@ class AdminMollieAuthenticationController extends ModuleAdminController
             case 'saveApiKey':
                 $this->ajaxSaveApiKey();
                 break;
+            case 'saveFallbackApiKey':
+                $this->ajaxSaveFallbackApiKey();
+                break;
             case 'switchEnvironment':
                 $this->ajaxSwitchEnvironment();
                 break;
@@ -273,6 +282,8 @@ class AdminMollieAuthenticationController extends ModuleAdminController
                 'data' => [
                     'test_api_key' => $testApiKey ?: '',
                     'live_api_key' => $liveApiKey ?: '',
+                    'test_fallback_api_key' => $this->configuration->get(Config::MOLLIE_API_KEY_FALLBACK_TEST) ?: '',
+                    'live_fallback_api_key' => $this->configuration->get(Config::MOLLIE_API_KEY_FALLBACK) ?: '',
                     'environment' => $environment ? 'live' : 'test',
                     'is_configured' => !empty($testApiKey) || !empty($liveApiKey),
                     'is_connected' => $isConnected,
@@ -343,6 +354,76 @@ class AdminMollieAuthenticationController extends ModuleAdminController
                     'is_connected' => true,
                     'methods' => $keyInfo['methods'] ?? [],
                 ],
+            ]));
+        } catch (MollieException $e) {
+            $this->ajaxRender(json_encode([
+                'success' => false,
+                'message' => $e->getMessage(),
+            ]));
+        } catch (Exception $e) {
+            $this->ajaxRender(json_encode([
+                'success' => false,
+                'message' => $this->module->l('Failed to save API key', self::FILE_NAME),
+            ]));
+        }
+    }
+
+    private function ajaxSaveFallbackApiKey(): void
+    {
+        try {
+            $apiKey = trim((string) $this->tools->getValue('api_key'));
+            $environment = $this->tools->getValue('environment');
+
+            if (!$environment) {
+                throw new MollieException($this->module->l('Missing required parameters', self::FILE_NAME));
+            }
+
+            $configKey = ($environment === 'live')
+                ? Config::MOLLIE_API_KEY_FALLBACK
+                : Config::MOLLIE_API_KEY_FALLBACK_TEST;
+
+            // Empty value clears the fallback key.
+            if ('' === $apiKey) {
+                $this->configuration->updateValue($configKey, '');
+
+                $this->ajaxRender(json_encode([
+                    'success' => true,
+                    'message' => $this->module->l('Fallback key removed', self::FILE_NAME),
+                    'data' => ['cleared' => true],
+                ]));
+
+                return;
+            }
+
+            $isTestKey = ($environment === 'test');
+            $apiTestFeedbackBuilder = $this->module->getService(ApiTestFeedbackBuilder::class);
+            $keyInfo = $apiTestFeedbackBuilder->getApiKeyInfo($apiKey, $isTestKey);
+
+            if (!$keyInfo['status']) {
+                $this->ajaxRender(json_encode([
+                    'success' => false,
+                    'message' => 'API key validation failed: Key does not exist or is invalid',
+                ]));
+
+                return;
+            }
+
+            if ($keyInfo['warning']) {
+                $expectedPrefix = $isTestKey ? 'test_' : 'live_';
+                $this->ajaxRender(json_encode([
+                    'success' => false,
+                    'message' => "API key validation failed: Key must start with '{$expectedPrefix}'",
+                ]));
+
+                return;
+            }
+
+            $this->configuration->updateValue($configKey, $apiKey);
+
+            $this->ajaxRender(json_encode([
+                'success' => true,
+                'message' => $this->module->l('Fallback key saved', self::FILE_NAME),
+                'data' => ['cleared' => false],
             ]));
         } catch (MollieException $e) {
             $this->ajaxRender(json_encode([

--- a/controllers/admin/AdminMollieAuthenticationController.php
+++ b/controllers/admin/AdminMollieAuthenticationController.php
@@ -402,7 +402,7 @@ class AdminMollieAuthenticationController extends ModuleAdminController
             if (!$keyInfo['status']) {
                 $this->ajaxRender(json_encode([
                     'success' => false,
-                    'message' => 'API key validation failed: Key does not exist or is invalid',
+                    'message' => $this->module->l('API key validation failed: Key does not exist or is invalid', self::FILE_NAME),
                 ]));
 
                 return;
@@ -412,7 +412,10 @@ class AdminMollieAuthenticationController extends ModuleAdminController
                 $expectedPrefix = $isTestKey ? 'test_' : 'live_';
                 $this->ajaxRender(json_encode([
                     'success' => false,
-                    'message' => "API key validation failed: Key must start with '{$expectedPrefix}'",
+                    'message' => sprintf(
+                        $this->module->l('API key validation failed: Key must start with \'%s\'', self::FILE_NAME),
+                        $expectedPrefix
+                    ),
                 ]));
 
                 return;

--- a/controllers/admin/AdminMollieAuthenticationController.php
+++ b/controllers/admin/AdminMollieAuthenticationController.php
@@ -282,8 +282,7 @@ class AdminMollieAuthenticationController extends ModuleAdminController
                 'data' => [
                     'test_api_key' => $testApiKey ?: '',
                     'live_api_key' => $liveApiKey ?: '',
-                    'test_fallback_api_key' => $this->configuration->get(Config::MOLLIE_API_KEY_FALLBACK_TEST) ?: '',
-                    'live_fallback_api_key' => $this->configuration->get(Config::MOLLIE_API_KEY_FALLBACK) ?: '',
+                    'fallback_api_key' => $this->configuration->get(Config::MOLLIE_API_KEY_FALLBACK) ?: '',
                     'environment' => $environment ? 'live' : 'test',
                     'is_configured' => !empty($testApiKey) || !empty($liveApiKey),
                     'is_connected' => $isConnected,
@@ -372,19 +371,11 @@ class AdminMollieAuthenticationController extends ModuleAdminController
     {
         try {
             $apiKey = trim((string) $this->tools->getValue('api_key'));
-            $environment = $this->tools->getValue('environment');
 
-            if (!$environment) {
-                throw new MollieException($this->module->l('Missing required parameters', self::FILE_NAME));
-            }
-
-            $configKey = ($environment === 'live')
-                ? Config::MOLLIE_API_KEY_FALLBACK
-                : Config::MOLLIE_API_KEY_FALLBACK_TEST;
-
-            // Empty value clears the fallback key.
+            // A single fallback key is stored regardless of environment - whichever
+            // key is entered is used. Empty value clears it.
             if ('' === $apiKey) {
-                $this->configuration->updateValue($configKey, '');
+                $this->configuration->updateValue(Config::MOLLIE_API_KEY_FALLBACK, '');
 
                 $this->ajaxRender(json_encode([
                     'success' => true,
@@ -395,7 +386,8 @@ class AdminMollieAuthenticationController extends ModuleAdminController
                 return;
             }
 
-            $isTestKey = ($environment === 'test');
+            // Validate the key against its own prefix (test_ / live_), not the shop environment.
+            $isTestKey = 0 === strpos($apiKey, 'test_');
             $apiTestFeedbackBuilder = $this->module->getService(ApiTestFeedbackBuilder::class);
             $keyInfo = $apiTestFeedbackBuilder->getApiKeyInfo($apiKey, $isTestKey);
 
@@ -421,7 +413,7 @@ class AdminMollieAuthenticationController extends ModuleAdminController
                 return;
             }
 
-            $this->configuration->updateValue($configKey, $apiKey);
+            $this->configuration->updateValue(Config::MOLLIE_API_KEY_FALLBACK, $apiKey);
 
             $this->ajaxRender(json_encode([
                 'success' => true,

--- a/controllers/front/payment.php
+++ b/controllers/front/payment.php
@@ -168,12 +168,18 @@ class MolliePaymentModuleFrontController extends ModuleFrontController
             if ($method === PaymentMethod::BANKTRANSFER) {
                 $orderId = Order::getIdByCartId($cart->id);
                 $order = new Order($orderId);
+
+                /** @var \Mollie\Service\Api\MollieApiClientProvider $clientProvider */
+                $clientProvider = $this->module->getService(\Mollie\Service\Api\MollieApiClientProvider::class);
+                $apiKeyRef = $clientProvider->resolveApiKeyRefForShop((int) $order->id_shop);
+
                 $paymentMethodRepository->addOpenStatusPayment(
                     $cart->id,
                     $apiPayment->method,
                     $apiPayment->id,
                     $order->id,
-                    $order->reference
+                    $order->reference,
+                    $apiKeyRef
                 );
 
                 $orderPayments = $order->getOrderPayments();

--- a/controllers/front/return.php
+++ b/controllers/front/return.php
@@ -319,6 +319,10 @@ class MollieReturnModuleFrontController extends AbstractMollieController
             $_GET['module'] = $this->module->name;
         }
 
+        // Use the key that owns this transaction's order (its shop's key, with
+        // fallback) so the lookup succeeds in multistore and after key migrations.
+        $this->module->setApiClientForTransaction($transactionId);
+
         $isOrder = TransactionUtility::isOrderTransaction($transactionId);
         if ($isOrder) {
             $transaction = $this->module->getApiClient()->orders->get($transactionId, ['embed' => 'payments']);

--- a/controllers/front/subscriptionUpdateWebhook.php
+++ b/controllers/front/subscriptionUpdateWebhook.php
@@ -109,7 +109,7 @@ class MollieSubscriptionUpdateWebhookModuleFrontController extends AbstractMolli
 
         // Point the client at the key that owns this transaction's order (with
         // fallback) so subscription webhooks resolve correctly in multistore.
-        $this->module->setApiClientForTransaction($transactionId);
+        $this->module->setApiClientForTransaction($transactionId, true);
 
         /** @var SubscriptionPaymentMethodUpdateHandler $subscriptionPaymentMethodUpdateHandler */
         $subscriptionPaymentMethodUpdateHandler = $this->module->getService(SubscriptionPaymentMethodUpdateHandler::class);

--- a/controllers/front/subscriptionUpdateWebhook.php
+++ b/controllers/front/subscriptionUpdateWebhook.php
@@ -107,6 +107,10 @@ class MollieSubscriptionUpdateWebhookModuleFrontController extends AbstractMolli
             ));
         }
 
+        // Point the client at the key that owns this transaction's order (with
+        // fallback) so subscription webhooks resolve correctly in multistore.
+        $this->module->setApiClientForTransaction($transactionId);
+
         /** @var SubscriptionPaymentMethodUpdateHandler $subscriptionPaymentMethodUpdateHandler */
         $subscriptionPaymentMethodUpdateHandler = $this->module->getService(SubscriptionPaymentMethodUpdateHandler::class);
 

--- a/controllers/front/subscriptionWebhook.php
+++ b/controllers/front/subscriptionWebhook.php
@@ -97,7 +97,7 @@ class MollieSubscriptionWebhookModuleFrontController extends AbstractMollieContr
 
         // Point the client at the key that owns this transaction's order (with
         // fallback) so subscription webhooks resolve correctly in multistore.
-        $this->module->setApiClientForTransaction($transactionId);
+        $this->module->setApiClientForTransaction($transactionId, true);
 
         /** @var RecurringOrderHandler $recurringOrderHandler */
         $recurringOrderHandler = $this->module->getService(RecurringOrderHandler::class);

--- a/controllers/front/subscriptionWebhook.php
+++ b/controllers/front/subscriptionWebhook.php
@@ -95,6 +95,10 @@ class MollieSubscriptionWebhookModuleFrontController extends AbstractMollieContr
             ));
         }
 
+        // Point the client at the key that owns this transaction's order (with
+        // fallback) so subscription webhooks resolve correctly in multistore.
+        $this->module->setApiClientForTransaction($transactionId);
+
         /** @var RecurringOrderHandler $recurringOrderHandler */
         $recurringOrderHandler = $this->module->getService(RecurringOrderHandler::class);
 

--- a/controllers/front/webhook.php
+++ b/controllers/front/webhook.php
@@ -131,6 +131,11 @@ class MollieWebhookModuleFrontController extends AbstractMollieController
         /** @var Logger $logger * */
         $logger = $this->module->getService(LoggerInterface::class);
 
+        // Point the API client at the key that owns this transaction's order
+        // (its shop's key, with fallback) so webhooks keep working in multistore
+        // and after key migrations, regardless of which shop's context is current.
+        $this->module->setApiClientForTransaction($transactionId);
+
         if (TransactionUtility::isOrderTransaction($transactionId)) {
             $transaction = $this->module->getApiClient()->orders->get($transactionId, ['embed' => 'payments']);
         } else {
@@ -159,6 +164,14 @@ class MollieWebhookModuleFrontController extends AbstractMollieController
     private function setContext(int $cartId): void
     {
         $cart = new Cart($cartId);
+
+        // Align the shop context with the cart's shop so that, in multistore,
+        // per-shop configuration (order statuses, keys, etc.) resolves against
+        // the shop that owns the order rather than the default shop.
+        if (Validate::isLoadedObject($cart) && $cart->id_shop) {
+            Shop::setContext(Shop::CONTEXT_SHOP, (int) $cart->id_shop);
+            $this->context->shop = new Shop((int) $cart->id_shop);
+        }
 
         $this->context->currency = new Currency($cart->id_currency);
         $this->context->customer = new Customer($cart->id_customer);

--- a/mollie.php
+++ b/mollie.php
@@ -143,6 +143,24 @@ class Mollie extends PaymentModule
         return $this->api;
     }
 
+    /**
+     * Point the API client at the key that owns a given transaction's payment
+     * (the shop that created it). Used before acting on existing orders so that,
+     * in a multistore setup, refunds/captures/shipments use the correct key
+     * instead of whatever shop is the current context.
+     */
+    public function setApiClientForTransaction(string $transactionId, bool $subscriptionOrder = false): void
+    {
+        /** @var \Mollie\Service\Api\MollieApiClientProvider $clientProvider */
+        $clientProvider = $this->getService(\Mollie\Service\Api\MollieApiClientProvider::class);
+
+        $client = $clientProvider->getForTransaction($transactionId, $subscriptionOrder);
+
+        if ($client) {
+            $this->api = $client;
+        }
+    }
+
     private function loadEnv()
     {
         if (!class_exists('\Symfony\Component\Dotenv\Dotenv')) {

--- a/mollie.php
+++ b/mollie.php
@@ -104,7 +104,7 @@ class Mollie extends PaymentModule
     {
         $this->name = 'mollie';
         $this->tab = 'payments_gateways';
-        $this->version = '6.4.4';
+        $this->version = '6.5.0';
         $this->author = 'Mollie B.V.';
         $this->need_instance = 1;
         $this->bootstrap = true;
@@ -1446,12 +1446,17 @@ class Mollie extends PaymentModule
             /** @var PaymentMethodRepositoryInterface $paymentMethodRepository */
             $paymentMethodRepository = $this->getService(PaymentMethodRepositoryInterface::class);
 
+            /** @var \Mollie\Service\Api\MollieApiClientProvider $clientProvider */
+            $clientProvider = $this->getService(\Mollie\Service\Api\MollieApiClientProvider::class);
+            $apiKeyRef = $clientProvider->resolveApiKeyRefForShop((int) $params['order']->id_shop);
+
             $paymentMethodRepository->addOpenStatusPayment(
                 $cartId,
                 $orderPayment,
                 $newPayment->id,
                 $orderId,
-                $orderReference
+                $orderReference,
+                $apiKeyRef
             );
 
             $sendMolliePaymentMail = Tools::getValue('mollie-email-send');

--- a/mollie.php
+++ b/mollie.php
@@ -154,7 +154,21 @@ class Mollie extends PaymentModule
         /** @var \Mollie\Service\Api\MollieApiClientProvider $clientProvider */
         $clientProvider = $this->getService(\Mollie\Service\Api\MollieApiClientProvider::class);
 
-        $client = $clientProvider->getForTransaction($transactionId, $subscriptionOrder);
+        try {
+            $client = $clientProvider->getForTransaction($transactionId, $subscriptionOrder);
+        } catch (\Mollie\Api\Exceptions\IncompatiblePlatform $e) {
+            // Mirror setApiKey(): keep whatever client is already set and let the
+            // caller proceed rather than surfacing a fatal from client creation.
+            $errorHandler = \Mollie\Handler\ErrorHandler\ErrorHandler::getInstance();
+            $errorHandler->handle($e, $e->getCode(), false);
+
+            return;
+        } catch (\Exception $e) {
+            $errorHandler = \Mollie\Handler\ErrorHandler\ErrorHandler::getInstance();
+            $errorHandler->handle($e, $e->getCode(), false);
+
+            return;
+        }
 
         if ($client) {
             $this->api = $client;

--- a/mollie.php
+++ b/mollie.php
@@ -1665,21 +1665,15 @@ class Mollie extends PaymentModule
             return;
         }
 
-        /** @var \Mollie\Service\ApiKeyService $apiKeyService */
-        $apiKeyService = $this->getService(\Mollie\Service\ApiKeyService::class);
+        /** @var \Mollie\Service\Api\MollieApiClientProvider $clientProvider */
+        $clientProvider = $this->getService(\Mollie\Service\Api\MollieApiClientProvider::class);
 
         $environment = (int) Configuration::get(Mollie\Config\Config::MOLLIE_ENVIRONMENT);
-        $apiKeyConfig = \Mollie\Config\Config::ENVIRONMENT_LIVE === (int) $environment ?
-            Mollie\Config\Config::MOLLIE_API_KEY : Mollie\Config\Config::MOLLIE_API_KEY_TEST;
-
-        $apiKey = Configuration::get($apiKeyConfig, null, null, $shopId);
-
-        if (!$apiKey) {
-            return;
-        }
 
         try {
-            $this->api = $apiKeyService->setApiKey($apiKey, $this->version, $subscriptionOrder, $environment);
+            // Key selection is centralised in the provider (multistore per-shop
+            // resolution today; per-order key + fallback added in later steps).
+            $this->api = $clientProvider->getForShop($shopId, $subscriptionOrder);
         } catch (\Mollie\Api\Exceptions\IncompatiblePlatform $e) {
             $errorHandler = \Mollie\Handler\ErrorHandler\ErrorHandler::getInstance();
             $errorHandler->handle($e, $e->getCode(), false);

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -184,10 +184,10 @@ class Config
     const MOLLIE_ENVIRONMENT = 'MOLLIE_ENVIRONMENT';
     const MOLLIE_API_KEY = 'MOLLIE_API_KEY';
     const MOLLIE_API_KEY_TEST = 'MOLLIE_API_KEY_TEST';
-    // Optional manually-entered fallback keys, tried when neither the order's
-    // stored key nor the shop's current key can access a transaction.
+    // Optional manually-entered fallback key, tried when neither the order's
+    // stored key nor the shop's current key can access a transaction. A single
+    // key is used regardless of environment - whichever key is entered is used.
     const MOLLIE_API_KEY_FALLBACK = 'MOLLIE_API_KEY_FALLBACK';
-    const MOLLIE_API_KEY_FALLBACK_TEST = 'MOLLIE_API_KEY_FALLBACK_TEST';
     // MOLLIE_API_KEY_TESTING_BUTTON removed - functionality moved to AdminMollieAuthentication
     const MOLLIE_FORM_PAYMENT_OPTION_POSITION = 'payment_option_position';
     const MOLLIE_ACCOUNT_SWITCH = 'MOLLIE_ACCOUNT_SWITCH';

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -184,6 +184,10 @@ class Config
     const MOLLIE_ENVIRONMENT = 'MOLLIE_ENVIRONMENT';
     const MOLLIE_API_KEY = 'MOLLIE_API_KEY';
     const MOLLIE_API_KEY_TEST = 'MOLLIE_API_KEY_TEST';
+    // Optional manually-entered fallback keys, tried when neither the order's
+    // stored key nor the shop's current key can access a transaction.
+    const MOLLIE_API_KEY_FALLBACK = 'MOLLIE_API_KEY_FALLBACK';
+    const MOLLIE_API_KEY_FALLBACK_TEST = 'MOLLIE_API_KEY_FALLBACK_TEST';
     // MOLLIE_API_KEY_TESTING_BUTTON removed - functionality moved to AdminMollieAuthentication
     const MOLLIE_FORM_PAYMENT_OPTION_POSITION = 'payment_option_position';
     const MOLLIE_ACCOUNT_SWITCH = 'MOLLIE_ACCOUNT_SWITCH';

--- a/src/Install/DatabaseTableInstaller.php
+++ b/src/Install/DatabaseTableInstaller.php
@@ -46,6 +46,7 @@ final class DatabaseTableInstaller implements InstallerInterface
 				`order_id`        INT(64),
 				`order_reference` VARCHAR(191),
 				`mandate_id`      VARCHAR(64),
+				`api_key_ref`     VARCHAR(32),
 				`method`          VARCHAR(128) NOT NULL,
 				`bank_status`     VARCHAR(64)  NOT NULL,
 				`reason`          VARCHAR(64),

--- a/src/Install/Uninstall.php
+++ b/src/Install/Uninstall.php
@@ -69,6 +69,8 @@ class Uninstall
     {
         $configurations = [
             Config::MOLLIE_API_KEY,
+            Config::MOLLIE_API_KEY_FALLBACK,
+            Config::MOLLIE_API_KEY_FALLBACK_TEST,
             Config::MOLLIE_PAYMENTSCREEN_LOCALE,
             Config::MOLLIE_SEND_ORDER_CONFIRMATION,
             Config::MOLLIE_IFRAME,

--- a/src/Install/Uninstall.php
+++ b/src/Install/Uninstall.php
@@ -70,7 +70,6 @@ class Uninstall
         $configurations = [
             Config::MOLLIE_API_KEY,
             Config::MOLLIE_API_KEY_FALLBACK,
-            Config::MOLLIE_API_KEY_FALLBACK_TEST,
             Config::MOLLIE_PAYMENTSCREEN_LOCALE,
             Config::MOLLIE_SEND_ORDER_CONFIRMATION,
             Config::MOLLIE_IFRAME,

--- a/src/Repository/PaymentMethodRepository.php
+++ b/src/Repository/PaymentMethodRepository.php
@@ -195,20 +195,23 @@ class PaymentMethodRepository extends AbstractRepository implements PaymentMetho
         }
     }
 
-    public function addOpenStatusPayment($cartId, $orderPayment, $transactionId, $orderId, $orderReference)
+    public function addOpenStatusPayment($cartId, $orderPayment, $transactionId, $orderId, $orderReference, $apiKeyRef = null)
     {
-        return Db::getInstance()->insert(
-            'mollie_payments',
-            [
-                'cart_id' => (int) $cartId,
-                'method' => pSQL($orderPayment),
-                'transaction_id' => pSQL($transactionId),
-                'bank_status' => PaymentStatus::STATUS_OPEN,
-                'order_id' => (int) $orderId,
-                'order_reference' => pSQL($orderReference),
-                'created_at' => ['type' => 'sql', 'value' => 'NOW()'],
-            ]
-        );
+        $data = [
+            'cart_id' => (int) $cartId,
+            'method' => pSQL($orderPayment),
+            'transaction_id' => pSQL($transactionId),
+            'bank_status' => PaymentStatus::STATUS_OPEN,
+            'order_id' => (int) $orderId,
+            'order_reference' => pSQL($orderReference),
+            'created_at' => ['type' => 'sql', 'value' => 'NOW()'],
+        ];
+
+        if ($apiKeyRef) {
+            $data['api_key_ref'] = pSQL($apiKeyRef);
+        }
+
+        return Db::getInstance()->insert('mollie_payments', $data);
     }
 
     public function updatePaymentReason($transactionId, $reason)

--- a/src/Repository/PaymentMethodRepositoryInterface.php
+++ b/src/Repository/PaymentMethodRepositoryInterface.php
@@ -34,7 +34,7 @@ interface PaymentMethodRepositoryInterface extends ReadOnlyRepositoryInterface
 
     public function savePaymentStatus($transactionId, $status, $orderId, $paymentMethod);
 
-    public function addOpenStatusPayment($cartId, $orderPayment, $transactionId, $orderId, $orderReference);
+    public function addOpenStatusPayment($cartId, $orderPayment, $transactionId, $orderId, $orderReference, $apiKeyRef = null);
 
     public function updatePaymentReason($transactionId, $reason);
 

--- a/src/Service/Api/MollieApiClientProvider.php
+++ b/src/Service/Api/MollieApiClientProvider.php
@@ -107,6 +107,15 @@ class MollieApiClientProvider
             return $this->getForApiKey($candidateKeys[0], $subscriptionOrder);
         }
 
+        // If the order carries a stored key reference and the top candidate's
+        // fingerprint matches it, that key created the order: trust it and skip
+        // the verification round-trip (buildCandidateKeys puts the matching key
+        // first). Only fall through to probing when the owning key is unknown
+        // (no stored ref, e.g. legacy orders) or no longer configured.
+        if (null !== $storedRef && $this->getApiKeyReference($candidateKeys[0]) === $storedRef) {
+            return $this->getForApiKey($candidateKeys[0], $subscriptionOrder);
+        }
+
         $isOrderTransaction = TransactionUtility::isOrderTransaction($transactionId);
         $firstUsableClient = null;
 
@@ -146,13 +155,21 @@ class MollieApiClientProvider
             }
         }
 
-        if ($storedRef) {
-            usort($keys, function (string $a, string $b) use ($storedRef): int {
-                $aMatches = $this->getApiKeyReference($a) === $storedRef ? 0 : 1;
-                $bMatches = $this->getApiKeyReference($b) === $storedRef ? 0 : 1;
-
-                return $aMatches <=> $bMatches;
-            });
+        // Put the key whose fingerprint matches the order's stored reference
+        // first. A partition (not usort) keeps this deterministic and preserves
+        // the shop-key-before-fallback order among the rest - PHP < 8.0 sort is
+        // not stable, so an equal-comparator usort could otherwise reorder them.
+        if (null !== $storedRef) {
+            $matching = [];
+            $rest = [];
+            foreach ($keys as $key) {
+                if ($this->getApiKeyReference($key) === $storedRef) {
+                    $matching[] = $key;
+                } else {
+                    $rest[] = $key;
+                }
+            }
+            $keys = array_merge($matching, $rest);
         }
 
         return $keys;

--- a/src/Service/Api/MollieApiClientProvider.php
+++ b/src/Service/Api/MollieApiClientProvider.php
@@ -196,15 +196,12 @@ class MollieApiClientProvider
     }
 
     /**
-     * The manually-entered fallback key for the current environment, or null.
+     * The manually-entered fallback key, or null. A single key is used
+     * regardless of environment - whichever key is entered is used.
      */
     public function getConfiguredFallbackApiKey(?int $shopId = null): ?string
     {
-        $keyConfig = $this->isLiveEnvironment()
-            ? Config::MOLLIE_API_KEY_FALLBACK
-            : Config::MOLLIE_API_KEY_FALLBACK_TEST;
-
-        $key = $this->configuration->get($keyConfig, $shopId);
+        $key = $this->configuration->get(Config::MOLLIE_API_KEY_FALLBACK, $shopId);
 
         return $key ?: null;
     }

--- a/src/Service/Api/MollieApiClientProvider.php
+++ b/src/Service/Api/MollieApiClientProvider.php
@@ -153,6 +153,31 @@ class MollieApiClientProvider
         );
     }
 
+    /**
+     * A stable, non-reversible reference for an API key. Stored against an order
+     * so we can later tell which of the known keys (order shop, current shop,
+     * configured fallback) created it, without ever persisting the secret itself.
+     */
+    public function getApiKeyReference(string $apiKey): string
+    {
+        return substr(hash('sha256', $apiKey), 0, 16);
+    }
+
+    /**
+     * The reference of the key currently configured on the given shop, or null
+     * when no key is configured.
+     */
+    public function resolveApiKeyRefForShop(?int $shopId = null): ?string
+    {
+        $apiKey = $this->resolveApiKeyForShop($shopId);
+
+        if (!$apiKey) {
+            return null;
+        }
+
+        return $this->getApiKeyReference($apiKey);
+    }
+
     private function getEnvironment(): int
     {
         return (int) $this->configuration->get(Config::MOLLIE_ENVIRONMENT);

--- a/src/Service/Api/MollieApiClientProvider.php
+++ b/src/Service/Api/MollieApiClientProvider.php
@@ -18,6 +18,7 @@ use Mollie\Adapter\ConfigurationAdapter;
 use Mollie\Api\MollieApiClient;
 use Mollie\Config\Config;
 use Mollie\Factory\ModuleFactory;
+use Mollie\Repository\PaymentMethodRepositoryInterface;
 use Mollie\Service\ApiKeyService;
 
 if (!defined('_PS_VERSION_')) {
@@ -45,17 +46,61 @@ class MollieApiClientProvider
     /** @var ModuleFactory */
     private $moduleFactory;
 
+    /** @var PaymentMethodRepositoryInterface */
+    private $paymentMethodRepository;
+
     /** @var array<string, MollieApiClient|null> clients cached per API key */
     private $clientCache = [];
 
     public function __construct(
         ConfigurationAdapter $configuration,
         ApiKeyService $apiKeyService,
-        ModuleFactory $moduleFactory
+        ModuleFactory $moduleFactory,
+        PaymentMethodRepositoryInterface $paymentMethodRepository
     ) {
         $this->configuration = $configuration;
         $this->apiKeyService = $apiKeyService;
         $this->moduleFactory = $moduleFactory;
+        $this->paymentMethodRepository = $paymentMethodRepository;
+    }
+
+    /**
+     * Build the API client to use for an existing transaction. Resolves the
+     * shop that owns the payment (multistore) and uses that shop's key, instead
+     * of relying on whatever shop happens to be the current context. Falls back
+     * to the current shop when the transaction cannot be located.
+     */
+    public function getForTransaction(string $transactionId, bool $subscriptionOrder = false): ?MollieApiClient
+    {
+        return $this->getForShop($this->resolveShopIdForTransaction($transactionId), $subscriptionOrder);
+    }
+
+    /**
+     * Find which shop created a transaction, via its stored payment row.
+     */
+    private function resolveShopIdForTransaction(string $transactionId): ?int
+    {
+        $payment = $this->paymentMethodRepository->getPaymentBy('transaction_id', $transactionId);
+
+        if (empty($payment)) {
+            return null;
+        }
+
+        if (!empty($payment['order_id'])) {
+            $order = new \Order((int) $payment['order_id']);
+            if (\Validate::isLoadedObject($order)) {
+                return (int) $order->id_shop;
+            }
+        }
+
+        if (!empty($payment['cart_id'])) {
+            $cart = new \Cart((int) $payment['cart_id']);
+            if (\Validate::isLoadedObject($cart)) {
+                return (int) $cart->id_shop;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/src/Service/Api/MollieApiClientProvider.php
+++ b/src/Service/Api/MollieApiClientProvider.php
@@ -15,11 +15,13 @@ declare(strict_types=1);
 namespace Mollie\Service\Api;
 
 use Mollie\Adapter\ConfigurationAdapter;
+use Mollie\Api\Exceptions\ApiException;
 use Mollie\Api\MollieApiClient;
 use Mollie\Config\Config;
 use Mollie\Factory\ModuleFactory;
 use Mollie\Repository\PaymentMethodRepositoryInterface;
 use Mollie\Service\ApiKeyService;
+use Mollie\Utility\TransactionUtility;
 
 if (!defined('_PS_VERSION_')) {
     exit;
@@ -65,23 +67,124 @@ class MollieApiClientProvider
     }
 
     /**
-     * Build the API client to use for an existing transaction. Resolves the
-     * shop that owns the payment (multistore) and uses that shop's key, instead
-     * of relying on whatever shop happens to be the current context. Falls back
-     * to the current shop when the transaction cannot be located.
+     * Build the API client to use for an existing transaction.
+     *
+     * Tries, in order, the candidate keys most likely to own the payment and
+     * returns the first one that can actually access the transaction on Mollie:
+     *   1. the key whose stored reference matches the order (its original key),
+     *   2. the key currently configured on the order's shop,
+     *   3. the manually-entered fallback key.
+     *
+     * This keeps refunds/captures/webhooks working in multistore and after a key
+     * migration, where the shop's current key may no longer own older orders.
+     * When no candidate can be verified (e.g. transaction not found on any key),
+     * the first usable client is returned so behaviour degrades to the previous
+     * single-key attempt rather than failing to build a client at all.
      */
     public function getForTransaction(string $transactionId, bool $subscriptionOrder = false): ?MollieApiClient
     {
-        return $this->getForShop($this->resolveShopIdForTransaction($transactionId), $subscriptionOrder);
+        $payment = $this->paymentMethodRepository->getPaymentBy('transaction_id', $transactionId);
+        $payment = is_array($payment) ? $payment : [];
+
+        $shopId = $this->resolveShopIdFromPayment($payment);
+        $storedRef = !empty($payment['api_key_ref']) ? (string) $payment['api_key_ref'] : null;
+
+        $candidateKeys = $this->buildCandidateKeys($shopId, $storedRef);
+
+        if (empty($candidateKeys)) {
+            return $this->getForShop($shopId, $subscriptionOrder);
+        }
+
+        $isOrderTransaction = TransactionUtility::isOrderTransaction($transactionId);
+        $firstUsableClient = null;
+
+        foreach ($candidateKeys as $apiKey) {
+            $client = $this->getForApiKey($apiKey, $subscriptionOrder);
+
+            if (!$client) {
+                continue;
+            }
+
+            if (null === $firstUsableClient) {
+                $firstUsableClient = $client;
+            }
+
+            if ($this->clientCanAccessTransaction($client, $transactionId, $isOrderTransaction)) {
+                return $client;
+            }
+        }
+
+        return $firstUsableClient;
     }
 
     /**
-     * Find which shop created a transaction, via its stored payment row.
+     * Ordered, de-duplicated list of API keys to try for a transaction: the key
+     * matching the order's stored reference first (its original key), then the
+     * order shop's current key, then the manually-entered fallback key.
+     *
+     * @return string[]
      */
-    private function resolveShopIdForTransaction(string $transactionId): ?int
+    private function buildCandidateKeys(?int $shopId, ?string $storedRef): array
     {
-        $payment = $this->paymentMethodRepository->getPaymentBy('transaction_id', $transactionId);
+        $keys = [];
 
+        foreach ([$this->resolveApiKeyForShop($shopId), $this->getConfiguredFallbackApiKey($shopId)] as $key) {
+            if ($key && !in_array($key, $keys, true)) {
+                $keys[] = $key;
+            }
+        }
+
+        if ($storedRef) {
+            usort($keys, function (string $a, string $b) use ($storedRef): int {
+                $aMatches = $this->getApiKeyReference($a) === $storedRef ? 0 : 1;
+                $bMatches = $this->getApiKeyReference($b) === $storedRef ? 0 : 1;
+
+                return $aMatches <=> $bMatches;
+            });
+        }
+
+        return $keys;
+    }
+
+    /**
+     * Whether a client can fetch the given transaction (i.e. its key owns it).
+     */
+    private function clientCanAccessTransaction(MollieApiClient $client, string $transactionId, bool $isOrderTransaction): bool
+    {
+        try {
+            if ($isOrderTransaction) {
+                $client->orders->get($transactionId);
+            } else {
+                $client->payments->get($transactionId);
+            }
+
+            return true;
+        } catch (ApiException $e) {
+            return false;
+        } catch (\Throwable $e) {
+            return false;
+        }
+    }
+
+    /**
+     * The manually-entered fallback key for the current environment, or null.
+     */
+    public function getConfiguredFallbackApiKey(?int $shopId = null): ?string
+    {
+        $keyConfig = $this->isLiveEnvironment()
+            ? Config::MOLLIE_API_KEY_FALLBACK
+            : Config::MOLLIE_API_KEY_FALLBACK_TEST;
+
+        $key = $this->configuration->get($keyConfig, $shopId);
+
+        return $key ?: null;
+    }
+
+    /**
+     * Find which shop created a transaction, from its stored payment row.
+     */
+    private function resolveShopIdFromPayment(array $payment): ?int
+    {
         if (empty($payment)) {
             return null;
         }

--- a/src/Service/Api/MollieApiClientProvider.php
+++ b/src/Service/Api/MollieApiClientProvider.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Mollie       https://www.mollie.nl
+ *
+ * @author      Mollie B.V. <info@mollie.nl>
+ * @copyright   Mollie B.V.
+ * @license     https://github.com/mollie/PrestaShop/blob/master/LICENSE.md
+ *
+ * @see        https://github.com/mollie/PrestaShop
+ * @codingStandardsIgnoreStart
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Service\Api;
+
+use Mollie\Adapter\ConfigurationAdapter;
+use Mollie\Api\MollieApiClient;
+use Mollie\Config\Config;
+use Mollie\Factory\ModuleFactory;
+use Mollie\Service\ApiKeyService;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * Central place that builds Mollie API clients.
+ *
+ * All API key selection lives here so that, in multistore setups and after key
+ * migrations, actions on an order can be pointed at the key that owns the
+ * payment instead of whatever key happens to be configured on the current shop.
+ * Previously every caller resolved the key itself and called
+ * `$module->getApiClient()` directly (~60 call sites), which made that
+ * impossible to do consistently.
+ */
+class MollieApiClientProvider
+{
+    /** @var ConfigurationAdapter */
+    private $configuration;
+
+    /** @var ApiKeyService */
+    private $apiKeyService;
+
+    /** @var ModuleFactory */
+    private $moduleFactory;
+
+    /** @var array<string, MollieApiClient|null> clients cached per API key */
+    private $clientCache = [];
+
+    public function __construct(
+        ConfigurationAdapter $configuration,
+        ApiKeyService $apiKeyService,
+        ModuleFactory $moduleFactory
+    ) {
+        $this->configuration = $configuration;
+        $this->apiKeyService = $apiKeyService;
+        $this->moduleFactory = $moduleFactory;
+    }
+
+    /**
+     * Resolve the API key configured for a given shop (multistore aware).
+     * When $shopId is null the current shop context is used.
+     */
+    public function resolveApiKeyForShop(?int $shopId = null): ?string
+    {
+        $keyConfig = $this->isLiveEnvironment()
+            ? Config::MOLLIE_API_KEY
+            : Config::MOLLIE_API_KEY_TEST;
+
+        return $this->configuration->get($keyConfig, $shopId);
+    }
+
+    /**
+     * Build (and cache) an API client for the key configured on the given shop.
+     */
+    public function getForShop(?int $shopId = null, bool $subscriptionOrder = false): ?MollieApiClient
+    {
+        $apiKey = $this->resolveApiKeyForShop($shopId);
+
+        if (!$apiKey) {
+            return null;
+        }
+
+        return $this->getForApiKey($apiKey, $subscriptionOrder);
+    }
+
+    /**
+     * Build (and cache) an API client for an explicit API key. This is the single
+     * point of client creation; key-selection strategies (per shop, per order,
+     * fallback) resolve to a key and then call through here.
+     */
+    public function getForApiKey(string $apiKey, bool $subscriptionOrder = false): ?MollieApiClient
+    {
+        $cacheKey = md5($apiKey) . ($subscriptionOrder ? ':sub' : '');
+
+        if (array_key_exists($cacheKey, $this->clientCache)) {
+            return $this->clientCache[$cacheKey];
+        }
+
+        $moduleVersion = (string) $this->moduleFactory->getModuleVersion();
+
+        return $this->clientCache[$cacheKey] = $this->apiKeyService->setApiKey(
+            $apiKey,
+            $moduleVersion,
+            $subscriptionOrder,
+            $this->getEnvironment()
+        );
+    }
+
+    private function getEnvironment(): int
+    {
+        return (int) $this->configuration->get(Config::MOLLIE_ENVIRONMENT);
+    }
+
+    private function isLiveEnvironment(): bool
+    {
+        return Config::ENVIRONMENT_LIVE === $this->getEnvironment();
+    }
+}

--- a/src/Service/Api/MollieApiClientProvider.php
+++ b/src/Service/Api/MollieApiClientProvider.php
@@ -69,14 +69,20 @@ class MollieApiClientProvider
     /**
      * Build the API client to use for an existing transaction.
      *
-     * Tries, in order, the candidate keys most likely to own the payment and
-     * returns the first one that can actually access the transaction on Mollie:
-     *   1. the key whose stored reference matches the order (its original key),
-     *   2. the key currently configured on the order's shop,
-     *   3. the manually-entered fallback key.
+     * Considers the keys that are currently configured and could own the
+     * payment - the order shop's key and the manually-entered fallback key -
+     * and returns the first one that can actually access the transaction on
+     * Mollie. When the order carries a stored key reference, the configured key
+     * whose fingerprint matches it is tried first (it is the key that created
+     * the order, so it is the most likely to succeed and avoids a wasted probe).
      *
-     * This keeps refunds/captures/webhooks working in multistore and after a key
-     * migration, where the shop's current key may no longer own older orders.
+     * Note: the stored reference is a one-way fingerprint, so it cannot recover
+     * a key that is no longer configured anywhere. Recovering access to orders
+     * created with a rotated/removed key therefore requires that key to be
+     * present as the shop key or the fallback key. This keeps refunds/captures/
+     * webhooks working in multistore and after a key migration, as long as the
+     * owning key is still configured in one of those slots.
+     *
      * When no candidate can be verified (e.g. transaction not found on any key),
      * the first usable client is returned so behaviour degrades to the previous
      * single-key attempt rather than failing to build a client at all.
@@ -93,6 +99,12 @@ class MollieApiClientProvider
 
         if (empty($candidateKeys)) {
             return $this->getForShop($shopId, $subscriptionOrder);
+        }
+
+        // With a single candidate there is no choice to make: return it directly
+        // and skip the verification round-trip (the common single-store case).
+        if (1 === count($candidateKeys)) {
+            return $this->getForApiKey($candidateKeys[0], $subscriptionOrder);
         }
 
         $isOrderTransaction = TransactionUtility::isOrderTransaction($transactionId);

--- a/src/Service/Api/index.php
+++ b/src/Service/Api/index.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Mollie       https://www.mollie.nl
+ *
+ * @author      Mollie B.V. <info@mollie.nl>
+ * @copyright   Mollie B.V.
+ * @license     https://github.com/mollie/PrestaShop/blob/master/LICENSE.md
+ *
+ * @see        https://github.com/mollie/PrestaShop
+ * @codingStandardsIgnoreStart
+ */
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/src/Service/CancelService.php
+++ b/src/Service/CancelService.php
@@ -37,6 +37,8 @@ class CancelService
 
     public function handleCancel($transactionId, $orderlineId = null, $quantity = null)
     {
+        $this->module->setApiClientForTransaction($transactionId);
+
         try {
             $order = $this->module->getApiClient()->orders->get($transactionId, ['embed' => 'payments']);
 

--- a/src/Service/CaptureService.php
+++ b/src/Service/CaptureService.php
@@ -43,6 +43,8 @@ class CaptureService
      */
     public function handleCapture($transactionId, $amount = null, $orderId = null)
     {
+        $this->module->setApiClientForTransaction($transactionId);
+
         try {
             if (TransactionUtility::isOrderTransaction($transactionId)) {
                 $this->captureOrderTransaction($transactionId);

--- a/src/Service/MollieOrderCreationService.php
+++ b/src/Service/MollieOrderCreationService.php
@@ -12,6 +12,7 @@
 
 namespace Mollie\Service;
 
+use Cart;
 use Db;
 use Exception;
 use Mollie;
@@ -24,8 +25,10 @@ use Mollie\DTO\PaymentData;
 use Mollie\Exception\OrderCreationException;
 use Mollie\Handler\ErrorHandler\ErrorHandler;
 use Mollie\Handler\Exception\OrderExceptionHandler;
+use Mollie\Service\Api\MollieApiClientProvider;
 use MolPaymentMethod;
 use PrestaShopException;
+use Validate;
 
 if (!defined('_PS_VERSION_')) {
     exit;
@@ -42,10 +45,16 @@ class MollieOrderCreationService
      */
     private $module;
 
-    public function __construct(OrderExceptionHandler $exceptionHandler, Mollie $module)
+    /**
+     * @var MollieApiClientProvider
+     */
+    private $apiClientProvider;
+
+    public function __construct(OrderExceptionHandler $exceptionHandler, Mollie $module, MollieApiClientProvider $apiClientProvider)
     {
         $this->exceptionHandler = $exceptionHandler;
         $this->module = $module;
+        $this->apiClientProvider = $apiClientProvider;
     }
 
     /**
@@ -113,19 +122,40 @@ class MollieOrderCreationService
             $mandateId = $apiPayment->mandateId;
         }
 
-        Db::getInstance()->insert(
-            'mollie_payments',
-            [
-                'cart_id' => (int) $cartId,
-                'order_id' => (int) $orderId,
-                'method' => pSQL($apiPayment->method),
-                'transaction_id' => pSQL($apiPayment->id),
-                'order_reference' => pSQL($orderReference),
-                'bank_status' => $status,
-                'mandate_id' => $mandateId,
-                'created_at' => ['type' => 'sql', 'value' => 'NOW()'],
-            ]
-        );
+        $data = [
+            'cart_id' => (int) $cartId,
+            'order_id' => (int) $orderId,
+            'method' => pSQL($apiPayment->method),
+            'transaction_id' => pSQL($apiPayment->id),
+            'order_reference' => pSQL($orderReference),
+            'bank_status' => $status,
+            'mandate_id' => $mandateId,
+            'created_at' => ['type' => 'sql', 'value' => 'NOW()'],
+        ];
+
+        $apiKeyRef = $this->resolveApiKeyRefForCart((int) $cartId);
+        if ($apiKeyRef) {
+            $data['api_key_ref'] = pSQL($apiKeyRef);
+        }
+
+        Db::getInstance()->insert('mollie_payments', $data);
+    }
+
+    /**
+     * Reference of the API key that created a cart's payment. Resolved from the
+     * cart's own shop so it stays correct even when the order is created outside
+     * that shop's context (e.g. subscription renewals).
+     */
+    private function resolveApiKeyRefForCart(int $cartId): ?string
+    {
+        $shopId = null;
+
+        $cart = new Cart($cartId);
+        if (Validate::isLoadedObject($cart)) {
+            $shopId = (int) $cart->id_shop;
+        }
+
+        return $this->apiClientProvider->resolveApiKeyRefForShop($shopId);
     }
 
     public function updateMolliePaymentReference(string $transactionId, string $orderReference)

--- a/src/Service/PayByBankCancellationService.php
+++ b/src/Service/PayByBankCancellationService.php
@@ -69,6 +69,8 @@ class PayByBankCancellationService
      */
     public function getActualMollieStatus($transactionId)
     {
+        $this->module->setApiClientForTransaction($transactionId);
+
         try {
             $isOrder = TransactionUtility::isOrderTransaction($transactionId);
 

--- a/src/Service/RefundService.php
+++ b/src/Service/RefundService.php
@@ -52,6 +52,8 @@ class RefundService
      */
     public function handleRefund(string $transactionId, ?float $amount = null, ?string $orderLineId = null, ?int $quantity = null, ?int $orderId = null, ?string $refundType = null)
     {
+        $this->module->setApiClientForTransaction($transactionId);
+
         try {
             $payment = TransactionUtility::isOrderTransaction($transactionId)
                 ? $this->module->getApiClient()->orders->get($transactionId, ['embed' => 'payments,refunds'])

--- a/src/Service/ShipService.php
+++ b/src/Service/ShipService.php
@@ -48,6 +48,8 @@ class ShipService
      */
     public function handleShip($transactionId, $orderlineId = null, $tracking = null, $quantity = null)
     {
+        $this->module->setApiClientForTransaction($transactionId);
+
         try {
             /** @var MollieOrderAlias $payment */
             $order = $this->module->getApiClient()->orders->get($transactionId, ['embed' => 'payments']);

--- a/upgrade/Upgrade-6.5.0.php
+++ b/upgrade/Upgrade-6.5.0.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Mollie       https://www.mollie.nl
+ *
+ * @author      Mollie B.V. <info@mollie.nl>
+ * @copyright   Mollie B.V.
+ * @license     https://github.com/mollie/PrestaShop/blob/master/LICENSE.md
+ *
+ * @see        https://github.com/mollie/PrestaShop
+ * @codingStandardsIgnoreStart
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * Add the api_key_ref column to mollie_payments so each order records a
+ * reference of the API key that created it (multistore / key-migration safe).
+ *
+ * @param Mollie $module
+ *
+ * @return bool
+ */
+function upgrade_module_6_5_0($module)
+{
+    try {
+        $columnExists = (bool) Db::getInstance()->getValue(
+            'SELECT COUNT(*) > 0
+             FROM information_schema.columns
+             WHERE TABLE_SCHEMA = "' . _DB_NAME_ . '"
+               AND table_name = "' . _DB_PREFIX_ . 'mollie_payments"
+               AND column_name = "api_key_ref";'
+        );
+
+        if ($columnExists) {
+            return true;
+        }
+
+        return (bool) Db::getInstance()->execute(
+            'ALTER TABLE `' . _DB_PREFIX_ . 'mollie_payments`
+             ADD COLUMN `api_key_ref` VARCHAR(32) DEFAULT NULL AFTER `mandate_id`;'
+        );
+    } catch (Exception $e) {
+        PrestaShopLogger::addLog(
+            'Mollie module upgrade to 6.5.0 failed: ' . $e->getMessage(),
+            3,
+            $e->getCode(),
+            'Module',
+            $module->id,
+            true
+        );
+
+        return false;
+    }
+}

--- a/views/js/admin/library/src/pages/authorization/components/authorization-form.tsx
+++ b/views/js/admin/library/src/pages/authorization/components/authorization-form.tsx
@@ -78,6 +78,13 @@ export default function AuthorizationForm() {
   const [initialLoading, setInitialLoading] = useState(true)
   const [showConfirmDialog, setShowConfirmDialog] = useState(false)
   const [pendingMode, setPendingMode] = useState<"live" | "test" | null>(null)
+  const [testFallbackApiKey, setTestFallbackApiKey] = useState("")
+  const [liveFallbackApiKey, setLiveFallbackApiKey] = useState("")
+  const [fallbackApiKey, setFallbackApiKey] = useState("")
+  const [showFallbackKey, setShowFallbackKey] = useState(false)
+  const [isSavingFallback, setIsSavingFallback] = useState(false)
+  const [fallbackMessage, setFallbackMessage] = useState("")
+  const [fallbackError, setFallbackError] = useState("")
 
   // Load current settings on component mount
   useEffect(() => {
@@ -92,8 +99,13 @@ export default function AuthorizationForm() {
         setLiveApiKey(response.data.live_api_key || "")
         setMode(response.data.environment as "live" | "test")
         setApiKey(response.data.environment === "live" ? response.data.live_api_key : response.data.test_api_key)
+        setTestFallbackApiKey(response.data.test_fallback_api_key || "")
+        setLiveFallbackApiKey(response.data.live_fallback_api_key || "")
+        setFallbackApiKey(response.data.environment === "live" ? (response.data.live_fallback_api_key || "") : (response.data.test_fallback_api_key || ""))
         setIsConnected(response.data.is_connected || false)
         setErrorMessage("")
+        setFallbackMessage("")
+        setFallbackError("")
         setJustConnected(false) // Reset the "just connected" state on load
       }
     } catch (error) {
@@ -136,6 +148,32 @@ export default function AuthorizationForm() {
     }
   }
 
+  const handleSaveFallback = async () => {
+    setIsSavingFallback(true)
+    setFallbackMessage("")
+    setFallbackError("")
+
+    try {
+      const response = await authApiService.saveFallbackApiKey(fallbackApiKey.trim(), mode)
+      if (response.success) {
+        const savedKey = fallbackApiKey.trim()
+        if (mode === "live") {
+          setLiveFallbackApiKey(savedKey)
+        } else {
+          setTestFallbackApiKey(savedKey)
+        }
+        setFallbackMessage(savedKey ? t('fallbackKeySaved') : t('fallbackKeyCleared'))
+      } else {
+        setFallbackError(response.message || t('connectionFailed'))
+      }
+    } catch (error) {
+      console.error('Failed to save fallback key:', error)
+      setFallbackError(t('connectionFailed'))
+    } finally {
+      setIsSavingFallback(false)
+    }
+  }
+
   const handleModeChange = (newMode: "live" | "test") => {
     // If it's the same mode, do nothing
     if (newMode === mode) return
@@ -160,6 +198,9 @@ export default function AuthorizationForm() {
         setMode(pendingMode)
         setIsConnected(switchResponse.data.is_connected || false)
         setApiKey(switchResponse.data.api_key || "")
+        setFallbackApiKey(pendingMode === "live" ? liveFallbackApiKey : testFallbackApiKey)
+        setFallbackMessage("")
+        setFallbackError("")
 
         // Update the stored keys based on the response
         if (pendingMode === "live") {
@@ -307,6 +348,62 @@ export default function AuthorizationForm() {
 
                 {!isConnected && (
                   <p className="text-sm text-black mt-2">{t('apiKeyDescription', mode)}</p>
+                )}
+              </div>
+            )}
+
+            {/* Fallback API Key Input */}
+            {initialLoading ? (
+              <SkeletonApiKeyInput />
+            ) : (
+              <div>
+                <div className="flex items-center gap-2 mb-2">
+                  <label className="text-sm font-medium text-black">
+                    {t('fallbackApiKey')}
+                  </label>
+                </div>
+
+                <div className="relative">
+                  <Input
+                    type={showFallbackKey ? "text" : "password"}
+                    value={fallbackApiKey}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => setFallbackApiKey(e.target.value)}
+                    placeholder={t('fallbackApiKeyPlaceholder')}
+                    className="pr-20 h-12 text-base border-gray-300"
+                  />
+                  {fallbackApiKey && (
+                    <button
+                      type="button"
+                      onClick={() => setShowFallbackKey(!showFallbackKey)}
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-gray-500 hover:text-gray-700"
+                    >
+                      {showFallbackKey ? t('hide') : t('show')}
+                    </button>
+                  )}
+                </div>
+
+                <p className="text-sm text-black mt-2">{t('fallbackApiKeyDescription')}</p>
+
+                <Button
+                  onClick={handleSaveFallback}
+                  disabled={isSavingFallback}
+                  className="mt-3 h-10 text-sm font-medium text-white hover:opacity-90"
+                  style={{backgroundColor: 'rgba(0, 64, 255, 1)'}}
+                >
+                  {isSavingFallback ? t('connecting') : t('saveFallbackKey')}
+                </Button>
+
+                {fallbackMessage && (
+                  <div className="mt-3 flex items-center gap-2 text-green-700">
+                    <CheckCircle className="h-4 w-4" />
+                    <span className="text-sm font-medium">{fallbackMessage}</span>
+                  </div>
+                )}
+
+                {fallbackError && (
+                  <div className="mt-3 p-3 bg-red-50 border border-red-200 rounded-md">
+                    <span className="text-red-800 text-sm">{fallbackError}</span>
+                  </div>
                 )}
               </div>
             )}

--- a/views/js/admin/library/src/pages/authorization/components/authorization-form.tsx
+++ b/views/js/admin/library/src/pages/authorization/components/authorization-form.tsx
@@ -78,8 +78,6 @@ export default function AuthorizationForm() {
   const [initialLoading, setInitialLoading] = useState(true)
   const [showConfirmDialog, setShowConfirmDialog] = useState(false)
   const [pendingMode, setPendingMode] = useState<"live" | "test" | null>(null)
-  const [testFallbackApiKey, setTestFallbackApiKey] = useState("")
-  const [liveFallbackApiKey, setLiveFallbackApiKey] = useState("")
   const [fallbackApiKey, setFallbackApiKey] = useState("")
   const [showFallbackKey, setShowFallbackKey] = useState(false)
   const [isSavingFallback, setIsSavingFallback] = useState(false)
@@ -99,9 +97,7 @@ export default function AuthorizationForm() {
         setLiveApiKey(response.data.live_api_key || "")
         setMode(response.data.environment as "live" | "test")
         setApiKey(response.data.environment === "live" ? response.data.live_api_key : response.data.test_api_key)
-        setTestFallbackApiKey(response.data.test_fallback_api_key || "")
-        setLiveFallbackApiKey(response.data.live_fallback_api_key || "")
-        setFallbackApiKey(response.data.environment === "live" ? (response.data.live_fallback_api_key || "") : (response.data.test_fallback_api_key || ""))
+        setFallbackApiKey(response.data.fallback_api_key || "")
         setIsConnected(response.data.is_connected || false)
         setErrorMessage("")
         setFallbackMessage("")
@@ -154,14 +150,9 @@ export default function AuthorizationForm() {
     setFallbackError("")
 
     try {
-      const response = await authApiService.saveFallbackApiKey(fallbackApiKey.trim(), mode)
+      const response = await authApiService.saveFallbackApiKey(fallbackApiKey.trim())
       if (response.success) {
         const savedKey = fallbackApiKey.trim()
-        if (mode === "live") {
-          setLiveFallbackApiKey(savedKey)
-        } else {
-          setTestFallbackApiKey(savedKey)
-        }
         setFallbackMessage(savedKey ? t('fallbackKeySaved') : t('fallbackKeyCleared'))
       } else {
         setFallbackError(response.message || t('connectionFailed'))
@@ -198,7 +189,7 @@ export default function AuthorizationForm() {
         setMode(pendingMode)
         setIsConnected(switchResponse.data.is_connected || false)
         setApiKey(switchResponse.data.api_key || "")
-        setFallbackApiKey(pendingMode === "live" ? liveFallbackApiKey : testFallbackApiKey)
+        // Fallback key is a single value independent of environment; leave it as-is.
         setFallbackMessage("")
         setFallbackError("")
 

--- a/views/js/admin/library/src/services/AuthenticationApiService.ts
+++ b/views/js/admin/library/src/services/AuthenticationApiService.ts
@@ -61,14 +61,13 @@ export class AuthenticationApiService {
   /**
    * Save (or clear, when empty) the manually-entered fallback API key
    */
-  async saveFallbackApiKey(apiKey: string, environment: string) {
+  async saveFallbackApiKey(apiKey: string) {
     const url = new URL(this.baseUrl, window.location.origin);
 
     const formData = new FormData();
     formData.append('ajax', '1');
     formData.append('action', 'saveFallbackApiKey');
     formData.append('api_key', apiKey);
-    formData.append('environment', environment);
 
     const response = await fetch(url.toString(), {
       method: 'POST',

--- a/views/js/admin/library/src/services/AuthenticationApiService.ts
+++ b/views/js/admin/library/src/services/AuthenticationApiService.ts
@@ -59,6 +59,25 @@ export class AuthenticationApiService {
   }
 
   /**
+   * Save (or clear, when empty) the manually-entered fallback API key
+   */
+  async saveFallbackApiKey(apiKey: string, environment: string) {
+    const url = new URL(this.baseUrl, window.location.origin);
+
+    const formData = new FormData();
+    formData.append('ajax', '1');
+    formData.append('action', 'saveFallbackApiKey');
+    formData.append('api_key', apiKey);
+    formData.append('environment', environment);
+
+    const response = await fetch(url.toString(), {
+      method: 'POST',
+      body: formData
+    });
+    return response.json();
+  }
+
+  /**
    * Switch environment between test and live
    */
   async switchEnvironment(environment: string) {

--- a/views/js/admin/library/src/shared/types/index.ts
+++ b/views/js/admin/library/src/shared/types/index.ts
@@ -20,6 +20,12 @@ export interface MollieAuthTranslations {
   liveApiKey: string;
   apiKeyPlaceholder: string;
   apiKeyDescription: string;
+  fallbackApiKey: string;
+  fallbackApiKeyPlaceholder: string;
+  fallbackApiKeyDescription: string;
+  saveFallbackKey: string;
+  fallbackKeySaved: string;
+  fallbackKeyCleared: string;
   connect: string;
   connecting: string;
   connected: string;


### PR DESCRIPTION
| Questions | Answers |
|---|---|
| Branch? | develop |
| Description? | Multistore per-shop Mollie API keys: resolve the key by the order's shop, attach a key reference to each order, use the owning key when firing/handling webhooks, and add a fallback-key mechanism — plus a small client-creation abstraction so key selection lives in one place. Directly addresses the merchant migration concern in PIPRES-785. |
| Type? | improvement |
| How to test? | See "How to test" below. |
| Fixed issue? | PIPRES-785 |

## Why

A merchant with 14 stores must move from one shared live key to a dedicated key per store and is worried about **legacy orders** (refunds/captures/shipments/webhooks) after the switch, and about **webhooks firing mid-transition**. Previously every caller resolved the key itself and called `$module->getApiClient()` directly (~60 sites), so there was no single place to make key selection order-aware or add a fallback.

## What changed (6 commits)

1. **`MollieApiClientProvider`** — a single wrapper that builds/caches API clients. All key-selection strategies resolve to a key and go through one method.
2. **Resolve the key by the order's shop** for existing-transaction actions (refund/capture/ship/cancel, pay-by-bank) via `Mollie::setApiClientForTransaction()`, so multistore actions use the correct shop's key instead of whatever shop is the current context.
3. **Attach an API-key reference to each order** — new `api_key_ref` column on `mollie_payments` (fresh install + a 6.5.0 upgrade), storing a **non-reversible fingerprint** (never the secret) of the key that created the order.
4. **Webhooks/returns use the order's key** and switch the PrestaShop shop context to the cart's shop, so lookups succeed in multistore and after a key migration.
5. **Fallback resolution** — when building the client for a transaction, try the candidate keys and use the first that can access it: the key matching the order's stored reference, then the order shop's current key, then a manually-entered fallback key.
6. **Configurable fallback key** — optional per-environment field on the API Configuration page (React + controller save/validate/clear).

## How to test

1. Multistore with two shops, each a different Mollie key. Save a key under each shop (BO shop selector) → each persists to that shop only.
2. Refund/ship/capture an order belonging to shop B while the BO context is shop A → succeeds using shop B's key.
3. Rotate a shop's key to a new one and set the old key as the **Fallback API Key** → refunds/webhooks on legacy orders still succeed.
4. Switch a method (e.g. Klarna) from Orders API to Payments API → legacy orders still process (the module branches on each order's stored transaction id, not the global setting).

## Verification done

- Unit (PHPUnit) 310/310, PHPStan 0.12 (PS 1.7.7.0) clean, php-cs-fixer clean, ESLint clean, admin bundle builds.
- Live E2E on a real Mollie test profile: real refund recovered via the fallback key; multistore per-shop save + per-shop key selection + per-shop fallback isolation all verified end-to-end.

## Notes for reviewer

- Bumps module version 6.4.4 → 6.5.0 to run the `api_key_ref` upgrade — confirm this suits the intended release/base branch.
- The stored reference is a one-way fingerprint: it optimizes key selection and audits which key owns an order, but recovering access to an order created with a rotated/removed key still requires that key to be present as the shop key or the fallback key (by design — the secret is never persisted).

Confidence: 90%
