### PR TITLE
PIPRES-809 Stop payment method restriction logging from flooding ps_log

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 # Changelog #
 
+## Changes in release 6.4.5
++ Fixed payment method restriction diagnostics filling up the PrestaShop log table on every checkout page render
+
 ## Changes in release 6.4.4
 + Added bank transfer due date configuration
 + Added Segment analytics tracking for module and payment events

--- a/src/Service/PaymentMethod/PaymentMethodRestrictionValidation.php
+++ b/src/Service/PaymentMethod/PaymentMethodRestrictionValidation.php
@@ -36,10 +36,9 @@
 
 namespace Mollie\Service\PaymentMethod;
 
-use Mollie\Config\Config;
+use Mollie\Logger\LoggerInterface;
 use Mollie\Service\PaymentMethod\PaymentMethodRestrictionValidation\PaymentMethodRestrictionValidatorInterface;
 use MolPaymentMethod;
-use PrestaShopLogger;
 use Throwable;
 
 if (!defined('_PS_VERSION_')) {
@@ -55,9 +54,15 @@ class PaymentMethodRestrictionValidation implements PaymentMethodRestrictionVali
      */
     private $paymentRestrictionValidators;
 
-    public function __construct(array $paymentRestrictionValidators)
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(array $paymentRestrictionValidators, LoggerInterface $logger)
     {
         $this->paymentRestrictionValidators = $paymentRestrictionValidators;
+        $this->logger = $logger;
     }
 
     /**
@@ -76,31 +81,21 @@ class PaymentMethodRestrictionValidation implements PaymentMethodRestrictionVali
                     $success = $paymentRestrictionValidator->isValid($paymentMethod);
 
                     if (!$success) {
-                        PrestaShopLogger::addLog(
+                        $this->logger->debug(
                             sprintf(
                                 '%s: payment method "%s" was hidden by %s',
                                 self::FILE_NAME,
                                 $paymentMethod->getPaymentMethodName(),
                                 get_class($paymentRestrictionValidator)
-                            ),
-                            Config::WARNING,
-                            null,
-                            null,
-                            null,
-                            true
+                            )
                         );
 
                         return false;
                     }
                 }
             } catch (Throwable $exception) {
-                PrestaShopLogger::addLog(
-                    sprintf('%s has caught error: %s', self::FILE_NAME, $exception->getMessage()),
-                    Config::ERROR,
-                    null,
-                    null,
-                    null,
-                    true
+                $this->logger->error(
+                    sprintf('%s has caught error: %s', self::FILE_NAME, $exception->getMessage())
                 );
 
                 return false;

--- a/src/Service/PaymentMethod/PaymentMethodRestrictionValidation/ApplePayPaymentMethodRestrictionValidator.php
+++ b/src/Service/PaymentMethod/PaymentMethodRestrictionValidation/ApplePayPaymentMethodRestrictionValidator.php
@@ -38,10 +38,9 @@ namespace Mollie\Service\PaymentMethod\PaymentMethodRestrictionValidation;
 
 use Mollie\Adapter\ConfigurationAdapter;
 use Mollie\Api\Types\PaymentMethod;
-use Mollie\Config\Config;
+use Mollie\Logger\LoggerInterface;
 use Mollie\Utility\VersionUtility;
 use MolPaymentMethod;
-use PrestaShopLogger;
 
 if (!defined('_PS_VERSION_')) {
     exit;
@@ -56,9 +55,15 @@ class ApplePayPaymentMethodRestrictionValidator implements PaymentMethodRestrict
      */
     private $configurationAdapter;
 
-    public function __construct(ConfigurationAdapter $configurationAdapter)
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(ConfigurationAdapter $configurationAdapter, LoggerInterface $logger)
     {
         $this->configurationAdapter = $configurationAdapter;
+        $this->logger = $logger;
     }
 
     /**
@@ -83,13 +88,8 @@ class ApplePayPaymentMethodRestrictionValidator implements PaymentMethodRestrict
 
     private function logHidden(string $reason): void
     {
-        PrestaShopLogger::addLog(
-            sprintf('%s: Apple Pay hidden because %s', self::FILE_NAME, $reason),
-            Config::WARNING,
-            null,
-            null,
-            null,
-            true
+        $this->logger->debug(
+            sprintf('%s: Apple Pay hidden because %s', self::FILE_NAME, $reason)
         );
     }
 

--- a/src/ServiceProvider/BaseServiceProvider.php
+++ b/src/ServiceProvider/BaseServiceProvider.php
@@ -268,6 +268,10 @@ final class BaseServiceProvider
         $this->addService($container, PaymentMethodSortProviderInterface::class, PaymentMethodSortProvider::class);
         $this->addService($container, PhoneNumberProviderInterface::class, PhoneNumberProvider::class);
 
+        $service = $this->addService($container, ApplePayPaymentMethodRestrictionValidator::class, ApplePayPaymentMethodRestrictionValidator::class);
+        $this->addServiceArgument($service, ConfigurationAdapter::class);
+        $this->addServiceArgument($service, LoggerInterface::class);
+
         $this->addService($container, PaymentMethodRestrictionValidationInterface::class, function () use ($container) {
             return new PaymentMethodRestrictionValidation([
                 $container->get(BasePaymentMethodRestrictionValidator::class),
@@ -277,7 +281,7 @@ final class BaseServiceProvider
                 $container->get(AmountPaymentMethodRestrictionValidator::class),
                 $container->get(B2bPaymentMethodRestrictionValidator::class),
                 $container->get(CustomerGroupPaymentMethodRestrictionValidator::class),
-            ]);
+            ], $container->get(LoggerInterface::class));
         });
 
         $this->addService($container, CustomLogoProviderInterface::class, $container->get(CreditCardLogoProvider::class));

--- a/tests/Unit/Service/PaymentMethod/PaymentMethodRestrictionValidation/ApplePayPaymentRestrictionValidationTest.php
+++ b/tests/Unit/Service/PaymentMethod/PaymentMethodRestrictionValidation/ApplePayPaymentRestrictionValidationTest.php
@@ -11,6 +11,7 @@
  */
 
 use Mollie\Config\Config;
+use Mollie\Logger\LoggerInterface;
 use Mollie\Service\PaymentMethod\PaymentMethodRestrictionValidation\ApplePayPaymentMethodRestrictionValidator;
 use Mollie\Tests\Unit\Tools\UnitTestCase;
 
@@ -24,7 +25,8 @@ class ApplePayPaymentRestrictionValidationTest extends UnitTestCase
         $_COOKIE['isApplePayMethod'] = $isApple;
 
         $applePayValidation = new ApplePayPaymentMethodRestrictionValidator(
-            $configurationAdapter
+            $configurationAdapter,
+            $this->createMock(LoggerInterface::class)
         );
 
         $isValid = $applePayValidation->isValid(
@@ -69,7 +71,8 @@ class ApplePayPaymentRestrictionValidationTest extends UnitTestCase
         $applePayValidation = new ApplePayPaymentMethodRestrictionValidator(
             $this->mockConfigurationAdapter([
                 'PS_SSL_ENABLED_EVERYWHERE' => true,
-            ])
+            ]),
+            $this->createMock(LoggerInterface::class)
         );
 
         $this->assertEquals($expectedResult, $applePayValidation->supports($paymentName));


### PR DESCRIPTION
## What

Country-restricted (and otherwise hidden) payment methods wrote a `WARNING` row into `ps_log` on **every checkout page render**, with PrestaShop's duplicate suppression explicitly disabled and no way for a merchant to switch it off.

Both call sites now log through the injected `Mollie\Logger\LoggerInterface` instead of calling `PrestaShopLogger::addLog()` statically.

## Why it mattered

- One row per hidden method per render, linear and unbounded. `ps_log` has no automatic pruning in PrestaShop. A merchant with 4 excluded methods generated 12+ rows just walking one cart to the payment step.
- `MOLLIE_DEBUG_LOG` was bypassed, so setting Mollie logs to "Nothing" did not silence it.
- Severity 2 also meant `PrestaShopLogger::sendByMail()` fired (it runs *before* the dedup check), so shops with `PS_LOGS_BY_EMAIL` at severity <= 2 got an email per hidden method per render.
- The rows were invisible in the module's own Logs tab, because `AdminMollieLogsController` inner-joins `mol_logs` on `object_type = 'mollieLog'` and these calls passed `null`. Merchants only saw them under Advanced Parameters > Logs.

Nothing was functionally broken: methods were hidden correctly. This was debug instrumentation that shipped to production.

## Regression window

Introduced in `527423b72` ("PIPRES-780 Fix Apple Pay not shown at checkout on PrestaShop 9", 2026-06-04). Absent from `release-6.4.2` and `release-6.4.3`, present in `release-6.4.4`. Not PS-version specific.

## Changes

- `PaymentMethodRestrictionValidation`: takes `LoggerInterface`; "was hidden by" goes through `debug()`, the `catch (Throwable)` branch through `error()`. `$allow_duplicate = true` dropped from both.
- `ApplePayPaymentMethodRestrictionValidator::logHidden()`: same change, injected `LoggerInterface`.
- `BaseServiceProvider`: passes `LoggerInterface` into the aggregate, and registers `ApplePayPaymentMethodRestrictionValidator` explicitly with its two arguments rather than relying on `ReflectionContainer` to autowire an interface.
- `ApplePayPaymentRestrictionValidationTest`: `LoggerInterface` mock.
- Changelog entry under 6.4.5.

These two were the only `$allow_duplicate = true` call sites in the module. All remaining `PrestaShopLogger::addLog` calls live inside `Logger` and `PrestaLogger` themselves.

## Testing

Reproduced and verified on PS 8.2.3 + Mollie 6.4.4, 4 methods with France excluded plus Bank transfer as an unrestricted control.

| Check | Result |
|---|---|
| 8 checkout renders, logs "Nothing" | 0 restriction rows (was 4 per render) |
| Filtering still correct | only Bank transfer offered, 4 excluded methods hidden |
| Restrictions removed | all 5 methods offered again, 0 log rows |
| 1 render, logs "Everything" | 4 rows at severity 1, `object_type = mollieLog`, now visible in the Mollie Logs tab |
| Log gating, `debug()` / `error()` | Nothing: 0/1, Errors: 0/1, Everything: 1/1 |
| Container | all 7 validators + aggregate + `PaymentMethodService` + both loggers resolve, 13/13 |
| BO | Payment Methods page and Logs page render, no container errors |
| End-to-end | bank transfer order `EBUYFOZNJ` reached Payment accepted |
| Unit suite | 310 tests OK, 642 assertions |
| php-cs-fixer | clean |

Render counts corroborated by an unrelated module on the same env that logs one row per checkout render: 8 renders produced 8 of its rows and 0 Mollie rows.

## Reviewer notes

- **Genuine errors are not silenced.** `Logger::error()` writes at every log level including "Nothing", so the `catch (Throwable)` branch stays visible to support. Only the hidden-by-restriction diagnostic is gated.
- `Logger::debug()` only writes at "Everything", so merchants who want the diagnostic must raise the log level. That is the intended trade-off.
- At "Everything" each diagnostic also writes a `mol_logs` context row, which is how every other module log already behaves. With logs off, the whole path is one cached `Configuration::get` and no writes, so it is cheaper than before.
- Not exercised live: the Apple Pay `logHidden()` path, which needs a live API key to enable the method. The change there is identical in shape and covered by the unit test.
- A validator throwing on every render would still write one error row per render, since `Logger::log()` stamps a unique `object_id` so PrestaShop cannot dedup it. Left as is: that signals a real fault, not a normal configuration.

Jira: https://mollie.atlassian.net/browse/PIPRES-809
