### PR TITLE
PIPRES-795 Fix free shipping voucher causing a Mollie 422 amount error

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 + Fixed "On backorder (paid)" status not being set when a product is ordered at exactly 0 stock, including instant-payment methods such as iDEAL and cards
 + Fixed payment method restriction diagnostics filling up the PrestaShop log table on every checkout page render
 + Fixed total_paid_real staying 0 on bank transfer orders after the payment is completed
++ Fixed free shipping vouchers causing a Mollie API 422 amount error at checkout, and wrong order line amounts when no payment fee is configured
 
 ## Changes in release 6.4.4
 + Added a "View in Mollie" link on the order page and in the Orders list to open a payment directly in the Mollie dashboard

--- a/src/Service/CartLinesService.php
+++ b/src/Service/CartLinesService.php
@@ -87,12 +87,10 @@ class CartLinesService
         $vatRatePrecision = Config::VAT_RATE_ROUNDING_PRECISION;
 
         $totalPrice = round($amount, $apiRoundingPrecision);
+        // A free-shipping cart rule is already carried by total_discounts, which is emitted as its
+        // own discount line below. Zeroing the shipping line as well subtracted the same amount
+        // twice and the lines no longer summed to the payment amount (PIPRES-795).
         $roundedShippingCost = round($shippingCost, $apiRoundingPrecision);
-        foreach ($cartSummary['discounts'] as $discount) {
-            if ($discount['free_shipping']) {
-                $roundedShippingCost = 0;
-            }
-        }
 
         $wrappingPrice = $psGiftWrapping ? round($cartSummary['total_wrapping'], $apiRoundingPrecision) : 0;
         $totalDiscounts = isset($cartSummary['total_discounts']) ? $cartSummary['total_discounts'] : 0;

--- a/tests/Unit/Service/CartLinesServiceTest.php
+++ b/tests/Unit/Service/CartLinesServiceTest.php
@@ -15,6 +15,7 @@ namespace Mollie\Tests\Unit\Service;
 use Mollie\Adapter\ConfigurationAdapter;
 use Mollie\Adapter\Context;
 use Mollie\Adapter\ToolsAdapter;
+use Mollie\Config\Config;
 use Mollie\DTO\Object\Amount;
 use Mollie\DTO\OrderLine;
 use Mollie\DTO\PaymentFeeData;
@@ -100,6 +101,7 @@ class CartLinesServiceTest extends TestCase
         $productName_2 = 'Hummingbird printed t-shirt';
         $productName_3 = 'The best is yet to come\' Framed poster';
         $shipping = 'Shipping';
+        $paymentFee = 'Payment fee';
         $giftWrapping = 'Gift wrapping';
         $currencyIsoCode = 'EUR';
 
@@ -501,6 +503,120 @@ class CartLinesServiceTest extends TestCase
                             ->setVatAmount(new Amount($currencyIsoCode, '0.84'))
                             ->setCategory(null)
                             ->setVatRate('21.00')
+                            ->setMetaData([]),
+                ],
+            ],
+            'free shipping voucher keeps the lines summing to the amount (PIPRES-795)' => [
+                'amount' => 14.28,
+                'paymentFee' => new PaymentFeeData(0.60, 0.50, 20.00, true),
+                'currencyIsoCode' => $currencyIsoCode,
+                'cartSummary' => [
+                    'gift_products' => [
+                        ],
+                    'discounts' => [
+                            0 => [
+                                'name' => 'Free shipping test',
+                                'free_shipping' => '1',
+                                'value_real' => 8.40,
+                                'value_tax_exc' => 8.40,
+                            ],
+                        ],
+                    'total_wrapping' => 0,
+                    'total_wrapping_tax_exc' => 0,
+                    'total_shipping' => 8.40,
+                    'total_shipping_tax_exc' => 8.40,
+                    'total_products_wt' => 14.28,
+                    'total_products' => 11.90,
+                    'total_price' => 14.28,
+                    'free_ship' => true,
+                    'total_discounts' => 8.40,
+                ],
+                8.40,
+                'cartItems' => [
+                    0 => [
+                            'total_wt' => 14.28,
+                            'cart_quantity' => '1',
+                            'price_wt' => 14.28,
+                            'id_product' => '6',
+                            'name' => $productName_3,
+                            'rate' => 20,
+                            'id_product_attribute' => '0',
+                            'id_customization' => null,
+                            'features' => [],
+                            'link_rewrite' => 'test-link',
+                            'id_image' => 'test-image-id',
+                        ],
+                ],
+                'psGiftWrapping' => false,
+                'selectedVoucherCategory' => 'null',
+                'translationMocks' => [
+                    0 => [
+                        'function' => 'lang',
+                        'expects' => $shipping,
+                        'return' => $shipping,
+                        'at' => 0,
+                    ],
+                    1 => [
+                        'function' => 'lang',
+                        'expects' => $paymentFee,
+                        'return' => $paymentFee,
+                        'at' => 1,
+                    ],
+                ],
+                'toolsMocks' => [
+                ],
+                'mocks' => [],
+                // 14.28 - 8.40 + 8.40 + 0.60 = 14.88, which is the amount plus the payment fee.
+                'result' => [
+                    0 => (new OrderLine())
+                            ->setType('physical')
+                            ->setName($productName_3)
+                            ->setQuantity(1)
+                            ->setSku('6¤0¤0')
+                            ->setDiscountAmount(null)
+                            ->setProductUrl('')
+                            ->setImageUrl('')
+                            ->setUnitPrice(new Amount($currencyIsoCode, '14.28'))
+                            ->setTotalPrice(new Amount($currencyIsoCode, '14.28'))
+                            ->setVatAmount(new Amount($currencyIsoCode, '2.38'))
+                            ->setCategory('')
+                            ->setVatRate('20.00')
+                            ->setMetaData(['idProduct' => '6']),
+                    1 => (new OrderLine())
+                            ->setType('discount')
+                            ->setName('Discount')
+                            ->setQuantity(1)
+                            ->setSku('DISCOUNT')
+                            ->setDiscountAmount(null)
+                            ->setUnitPrice(new Amount($currencyIsoCode, '-8.40'))
+                            ->setTotalPrice(new Amount($currencyIsoCode, '-8.40'))
+                            ->setVatAmount(new Amount($currencyIsoCode, '0.00'))
+                            ->setCategory('')
+                            ->setVatRate('0.00')
+                            ->setMetaData([]),
+                    2 => (new OrderLine())
+                            ->setType('shipping_fee')
+                            ->setName($shipping)
+                            ->setQuantity(1)
+                            ->setSku($shipping)
+                            ->setDiscountAmount(null)
+                            ->setUnitPrice(new Amount($currencyIsoCode, '8.40'))
+                            ->setTotalPrice(new Amount($currencyIsoCode, '8.40'))
+                            ->setVatAmount(new Amount($currencyIsoCode, '0.00'))
+                            ->setCategory(null)
+                            ->setVatRate('0.00')
+                            ->setMetaData([]),
+                    3 => (new OrderLine())
+                            ->setType('surcharge')
+                            ->setName($paymentFee)
+                            ->setQuantity(1)
+                            ->setSku(Config::PAYMENT_FEE_SKU)
+                            ->setDiscountAmount(null)
+                            ->setUnitPrice(new Amount($currencyIsoCode, '0.60'))
+                            ->setTotalPrice(new Amount($currencyIsoCode, '0.60'))
+                            ->setVatAmount(new Amount($currencyIsoCode, '0.10'))
+                            ->setCategory(null)
+                            ->setVatRate('20.00')
                             ->setMetaData([]),
                 ],
             ],


### PR DESCRIPTION
## Problem

A cart with a free shipping voucher and a paid carrier fails at checkout:

```
Error executing API call (422: Unprocessable Entity): The 'amount' field is off.
Expected to be EUR 6.48 (sum of the line items), got EUR 14.88.
```

No order is created. Lines sent for a 14.28 product, an 8.40 carrier and a 0.60 iDEAL fee:

| type | totalAmount |
|---|---|
| physical | 14.28 |
| discount | -8.40 |
| surcharge | 0.60 |

Sum 6.48, short by exactly the waived 8.40. There is no shipping line.

## Root cause

PrestaShop does not remove the shipping cost for a free shipping cart rule. It charges the carrier and puts the waived amount into `total_discounts`, so the order total already nets them out. Straight from `Cart::getSummaryDetails()` on the reproducing cart:

```
total_products_wt   14.28
total_shipping       8.40
total_discounts      8.40
total_price         14.28   (= 14.28 + 8.40 - 8.40)
```

`CartLinesService::getCartLines()` emitted the `-8.40` discount line from `total_discounts` and *also* zeroed the shipping line, so the same amount was subtracted twice.

The payment fee is what makes it visible. `compositeRoundingInaccuracies()` normally absorbs a leftover `$remaining` into a product line, but it returns early when a fee is active and `feeTaxIncl - remaining < 0.1`. With `$remaining` = 8.40 and a 0.60 fee that is -7.80, so the compensation never runs and the lines undershoot by the full shipping cost.

Without a fee the compensation does run, so the payment is accepted with a product line inflated from 14.28 to 22.68. That is a second, silent defect: the line items in the Mollie checkout and dashboard do not match the shop.

## Solution

Stop zeroing the shipping line. `total_discounts` already carries the waived shipping and is emitted as its own discount line.

```
remaining = 14.28 - 8.40         =  5.88
product lines  -14.28            = -8.40
discount line  +8.40             =  0.00   nothing left to compensate
lines: 14.28 - 8.40 + 8.40 + 0.60 = 14.88 = amount + payment fee
```

The line set is now consistent by construction rather than relying on the rounding compensation, and the product lines keep their real catalogue price.

Deliberately not touched: the `compositeRoundingInaccuracies()` early return is also wrong for payment fees below about 0.11, but that is a separate defect and changing it risks regressing PIPRES-794.

## How to test

1. Cart rule with **Free shipping** enabled, no other reduction.
2. Mollie > Payment Methods > iDEAL > Payment fees: fixed fee, 0.50 tax excl, 20% tax rules group.
3. Add one product, apply the voucher, and at the delivery step pick a **paid** carrier. With the voucher applied PrestaShop labels every carrier "Free", so selecting a genuinely free carrier such as pick up in-store does not reproduce it: `total_discounts` stays 0.
4. Pay with iDEAL.

Before: 422 and no order. After: Mollie accepts the payment and the order is created.

## Testing done

- Unit suite `OK (357 tests, 729 assertions)`, including a new regression case in `CartLinesServiceTest` that fails without the fix. Full suite unchanged against develop (33 pre-existing Integration autoload errors on both sides).
- Scenario matrix over the real `CartLinesService`, 23 cart shapes x both call sites (Payments API and Orders API), asserting the invariants Mollie enforces: lines sum to `amount + fee`, `unitPrice * quantity == totalAmount`, `vatAmount` consistent with `vatRate`, physical lines equal `total_products_wt`, shipping line present when shipping is charged. Axes: no voucher / free shipping / percent / fixed amount / free shipping combined with a reduction / two rules at once; single, multi-product, zero-tax and mixed 20-5-0% tax carts; shipping 0, 0.99, 7.13, 8.40, 24.95; fee off, 0.05, 0.60, 1.00.
  - develop: 16 pass, 30 fail
  - this branch: 46 pass, 0 fail
- Diffing every line before and after across those scenarios: 8 identical, 15 changed. The 15 are exactly the free shipping carts on a paid carrier. Nothing else in the module reads the zeroed value; the other `free_shipping` uses (`PendingOrderCartRuleRepository`, `MolPendingOrderCartRule`, `MailService`) work on PrestaShop order values after payment.
- End to end on PS 1.7.8.9 / PHP 7.4 with a Mollie test key: payment accepted at 14.88, lines physical 14.28 + discount -8.40 + shipping_fee 8.40 + surcharge 0.60 = 14.88, order created with `total_paid` 14.88 in state Payment accepted.

## Note on the ticket description

The ticket says the problem is independent of the payment fee. It is not: the fee is the gate for the 422. Without a fee the same cart is accepted with inflated product lines instead.
