### PR TITLE
PIPRES-782 Lock Wero to the Payments API

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 # Changelog #
 
 ## Changes in release 6.4.5
++ New payment method: Wero, available on the Payments API
 + Fixed inconsistent payment method label on orders, card payments showed the internal method id instead of the payment method name
 + Wallet payments are now labelled with the method that settled them and the wallet used, for example "Card (Apple Pay)"
 + Added shipping method exclusion list for Apple Pay Direct

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -335,6 +335,7 @@ class Config
     const RIVERTY = 'riverty';
     const BILLINK = 'billink';
     const PAY_BY_BANK = 'paybybank';
+    const WERO = 'wero';
 
     const MOLLIE_VOUCHER_CATEGORY_NULL = 'null';
     const MOLLIE_VOUCHER_CATEGORY_MEAL = 'meal';
@@ -367,6 +368,7 @@ class Config
 
     const PAYMENT_API_ONLY_METHODS = [
         self::BILLINK,
+        self::WERO,
     ];
 
     const MOLLIE_MANUAL_CAPTURE_ELIGIBLE_METHODS = [

--- a/src/Handler/PaymentMethod/PaymentMethodSettingsHandler.php
+++ b/src/Handler/PaymentMethod/PaymentMethodSettingsHandler.php
@@ -180,7 +180,10 @@ class PaymentMethodSettingsHandler
         $paymentMethod->id_method = $methodId;
         $paymentMethod->method_name = $this->resolveMethodName($paymentMethod, $methodId, $apiMethodData);
         $paymentMethod->enabled = (bool) ($settings['enabled'] ?? false);
-        $paymentMethod->method = $settings['apiSelection'] ?? 'payments';
+        $paymentMethod->method = $this->resolveApiSelection(
+            $methodId,
+            (string) ($settings['apiSelection'] ?? Config::MOLLIE_PAYMENTS_API)
+        );
         $paymentMethod->description = $settings['transactionDescription'] ?? '';
 
         $paymentMethod->min_amount = (float) ($settings['orderRestrictions']['minAmount'] ?? 0);
@@ -198,6 +201,19 @@ class PaymentMethodSettingsHandler
         if (in_array($methodId, Config::MOLLIE_MANUAL_CAPTURE_ELIGIBLE_METHODS)) {
             $paymentMethod->is_manual_capture = ($settings['captureMode'] ?? 'automatic') === 'manual';
         }
+    }
+
+    /**
+     * Methods that Mollie only supports on the Payments API are locked to it. The UI already
+     * hides the Orders button, this keeps a stale or crafted selection from being stored.
+     */
+    private function resolveApiSelection(string $methodId, string $apiSelection): string
+    {
+        if (in_array($methodId, Config::PAYMENT_API_ONLY_METHODS, true)) {
+            return Config::MOLLIE_PAYMENTS_API;
+        }
+
+        return $apiSelection;
     }
 
     /**


### PR DESCRIPTION
## What

Mollie only supports **Wero** on the Payments API, so the method is now locked to it.

- `Config::WERO` added and appended to `PAYMENT_API_ONLY_METHODS`. That constant is already fed to the admin React app as `onlyPaymentsMethods`, so the Orders API button and the "Payments API is the recommended option" disclaimer disappear for Wero.
- `PaymentMethodSettingsHandler::resolveApiSelection()` coerces the stored value on save. The UI hide alone is not enforcement, so a stale or crafted payload can no longer persist `orders`.
- Changelog entry added to the unreleased 6.4.5 section. Wero itself landed in `e2549147c` without one.

## Why the server-side coercion

`assignSettings()` writes `$settings['apiSelection']` straight to the entity, so hiding the button in React was the only thing standing between a POST and an unsupported API selection. `controllers/front/payment.php:107` already does the same kind of runtime forcing for subscription orders, so this follows existing precedent.

## Testing

| Check | Result |
|---|---|
| PHPUnit Unit suite | OK, 356 tests / 727 assertions |
| PHPStan (`phpstan_base.neon`) | 2 errors, both pre-existing on `develop` (`OrderStateInstaller.php:183`, `NumberUtility.php:244`). 0 new. |
| php-cs-fixer | clean |
| Functional probe | 34 assertions, 34 passed |

Verified live on PS 1.7.8.9 / PHP 7.4 with Mollie 6.4.5:

- BO renders a single "Payments" button for Wero, iDEAL keeps both plus the disclaimer.
- Saving Wero with `apiSelection: orders` stores `payments`. Tampering the DB row to `orders` and re-saving restores `payments`. Billink stays coerced, iDEAL / creditcard / swish still switch freely both ways.
- End-to-end payment: order `VZBRWHXTV`, EUR 200.00, `total_paid_real` 200.00, state **Payment accepted**, `ps_order_payment.payment_method` = `Wero`, transaction `tr_2mYfEYCrGQZbmaDKzz3VJ`. The `tr_` prefix confirms the Payments API was used.

No regressions: title / description / min-max / surcharge / translations / position / id_shop survive the save, creditcard manual capture still toggles, unsupported method ids still throw, country restrictions still enforce (11 cases), and the checkout listing is unchanged.

## Notes

The coercion runs on write, not on read, so a pre-existing row holding `method = 'orders'` would keep it until re-saved. Traced every write path to that column and no merchant-reachable one can produce such a row: the settings handler is the only live writer, `PaymentMethodService::savePaymentMethod()` is only reachable through the `refreshMethods` ajax action which nothing in the admin bundle calls, the two remaining writers are in-memory and already force `payments`, and no install or upgrade script touches the column. No upgrade script needed.