### PR TITLE
PIPRES-790 Fix Apple Pay Direct guest payments failing after authorization

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 + Fixed payment method restriction diagnostics filling up the PrestaShop log table on every checkout page render
 + Fixed total_paid_real staying 0 on bank transfer orders after the payment is completed
 + Fixed free shipping vouchers causing a Mollie API 422 amount error at checkout, and wrong order line amounts when no payment fee is configured
++ Fixed Apple Pay Direct failing to complete guest payments, the shipping address selected in the Apple Pay sheet was dropped from the cart before the order was created
 
 ## Changes in release 6.4.4
 + Added a "View in Mollie" link on the order page and in the Orders list to open a payment directly in the Mollie dashboard

--- a/controllers/front/applePayDirectAjax.php
+++ b/controllers/front/applePayDirectAjax.php
@@ -247,16 +247,45 @@ class MollieApplePayDirectAjaxModuleFrontController extends AbstractMollieContro
         /** @var ApplePayOrderBuilder $applePayProductBuilder */
         $applePayProductBuilder = $this->module->getService(ApplePayOrderBuilder::class);
 
-        $shippingContent = Tools::getValue('shippingContact');
-        $billingContent = Tools::getValue('billingContact');
-        $applePayOrderBuilder = $applePayProductBuilder->build($products, $shippingContent, $billingContent);
+        /** @var Logger $logger */
+        $logger = $this->module->getService(LoggerInterface::class);
 
-        $command = new CreateApplePayOrder(
-            $cartId,
-            $applePayOrderBuilder,
-            json_encode(Tools::getValue('token'))
-        );
-        $response = $handler->handle($command);
+        try {
+            $shippingContent = Tools::getValue('shippingContact');
+            $billingContent = Tools::getValue('billingContact');
+            $applePayOrderBuilder = $applePayProductBuilder->build($products, $shippingContent, $billingContent);
+
+            $command = new CreateApplePayOrder(
+                $cartId,
+                $applePayOrderBuilder,
+                json_encode(Tools::getValue('token'))
+            );
+            $response = $handler->handle($command);
+        } catch (\Throwable $exception) {
+            $logger->error(sprintf('%s - Failed to create apple pay order.', self::FILE_NAME), [
+                'context' => [
+                    'cartId' => $cartId,
+                ],
+                'exceptions' => ExceptionUtility::getExceptions($exception),
+            ]);
+
+            // Apple Pay only understands a JSON payload here. Letting the exception escape returns an
+            // HTML error page, which the sheet reports to the shopper as an opaque parsing failure.
+            $this->ajaxRender(json_encode([
+                'success' => false,
+                'status' => 'STATUS_FAILURE',
+                'errors' => [
+                    [
+                        'code' => 'unknown',
+                        'contactField' => null,
+                        'message' => $this->module->l('Failed to create the order. Please try again.', self::FILE_NAME),
+                    ],
+                ],
+            ]));
+
+            return;
+        }
+
         if (!$response['success']) {
             $this->ajaxRender(json_encode($response));
         }

--- a/src/Application/CommandHandler/UpdateApplePayShippingContactHandler.php
+++ b/src/Application/CommandHandler/UpdateApplePayShippingContactHandler.php
@@ -177,6 +177,32 @@ final class UpdateApplePayShippingContactHandler
     {
         $context = \Context::getContext();
         $context->cart = $cart;
-        \Context::getContext()->updateCustomer($customer);
+
+        $deliveryAddressId = (int) $cart->id_address_delivery;
+        $invoiceAddressId = (int) $cart->id_address_invoice;
+
+        $context->updateCustomer($customer);
+
+        $this->restoreCartAddresses($cart, $deliveryAddressId, $invoiceAddressId);
+    }
+
+    /**
+     * Context::updateCustomer() reassigns both cart addresses to Address::getFirstCustomerAddressId(),
+     * which ignores soft-deleted rows and therefore never returns the temporary Apple Pay address:
+     * 0 for the throwaway guest, the customer's oldest saved address for a logged-in shopper.
+     * Put back the addresses the Apple Pay sheet is being quoted against.
+     */
+    private function restoreCartAddresses(Cart $cart, int $deliveryAddressId, int $invoiceAddressId): void
+    {
+        if ((int) $cart->id_address_delivery === $deliveryAddressId && (int) $cart->id_address_invoice === $invoiceAddressId) {
+            return;
+        }
+
+        // Remaps ps_cart_product rows away from the address the core call just forced onto the cart.
+        $cart->updateAddressId((int) $cart->id_address_delivery, $deliveryAddressId);
+
+        $cart->id_address_delivery = $deliveryAddressId;
+        $cart->id_address_invoice = $invoiceAddressId;
+        $cart->update();
     }
 }


### PR DESCRIPTION
## Problem

Apple Pay Direct returns HTTP 500 on `mollie_apple_pay_create_order` for guest shoppers, right after the shopper authorizes with Touch ID. The sheet reports it as `SyntaxError: JSON Parse error: Unrecognized token '<'`, because the JS error handler `JSON.parse`s what is actually PrestaShop's HTML error page.

Regression from PIPRES-790 (commit e523d6acd). Present on `develop`, not on `master`.

## Root cause

PIPRES-790 made the temporary Apple Pay address `deleted = true` so abandoned sheets stop leaking placeholder addresses into the customer's address book.

`UpdateApplePayShippingContactHandler::updateContext()` calls `Context::updateCustomer()`, and PS core unconditionally reassigns both cart addresses to `Address::getFirstCustomerAddressId()`, which filters `deleted = 0`. So the temporary address is never returned:

- guest: both cart addresses become `0`
- logged in: both become the customer's oldest saved address

`CreateApplePayOrderHandler::handle()` then sees `id_address_delivery == id_address_invoice` and calls `duplicateAddress(0)`, which throws `PrestaShopException: Property Address->id_country is empty`.

Verified as the same core behaviour on PS 1.7.8.9, 8.2.3 and 9.1.0.

## Fix

1. `updateContext()` captures both cart address ids before the core call and restores them after, remapping `ps_cart_product` rows with `Cart::updateAddressId()`.
2. `createApplePayOrder()` in the controller is wrapped so any exception is logged and returned as a JSON Apple Pay error, instead of an HTML error page the sheet cannot parse.

Side effect worth noting: registered customers no longer get their oldest saved address silently overwritten with the Apple Pay contact.

## Verification

Empirical before/after probe on PS 9.1.0:

```
WITHOUT FIX | expected delivery=30 invoice=31
  before updateCustomer : cart.delivery=30 cart.invoice=31 cart_product.delivery=30
  after  updateCustomer : cart.delivery=0  cart.invoice=0  cart_product.delivery=30
  duplicateAddress()    : PrestaShopException: Property Address->id_country is empty.  <== 500

WITH FIX    | expected delivery=32 invoice=33
  before updateCustomer : cart.delivery=32 cart.invoice=33 cart_product.delivery=32
  after  updateCustomer : cart.delivery=32 cart.invoice=33 cart_product.delivery=32
  duplicateAddress()    : not reached (delivery != invoice, as intended)
```

Live guest Apple Pay payment on PS 9.1.0 with the fix deployed: order `IOCJQDSTD` created, state Payment accepted, cart keeps delivery and invoice as two distinct addresses. PIPRES-790 behaviour intact: the guest customer is restored to `deleted = 0` on order creation, the throwaway guest from an abandoned sheet stays hidden.

Unit suite green (357 tests, 729 assertions), php-cs-fixer clean.
