### PR TITLE
PIPRES-777 Offer Billink as a consumer payment method

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 ## Changes in release 6.4.5
 + New payment method: Wero, available on the Payments API
++ New payment method: Billink, available on the Payments API for consumer purchases up to 2,500.00 EUR
 + Fixed inconsistent payment method label on orders, card payments showed the internal method id instead of the payment method name
 + Wallet payments are now labelled with the method that settled them and the wallet used, for example "Card (Apple Pay)"
 + Added shipping method exclusion list for Apple Pay Direct
@@ -57,7 +58,6 @@
 + Improved front office subscription tab handling
 + Improved company name validation by replacing special characters
 + Redirected bank transfer to order confirmation instead of custom page
-+ Added Billink payment method
 
 ## Changes in release 6.4.2
 + Multiple Apple Pay Direct improvements and stability fixes

--- a/src/Adapter/LegacyContext.php
+++ b/src/Adapter/LegacyContext.php
@@ -81,6 +81,19 @@ class LegacyContext
         return $invoiceAddress->id_country;
     }
 
+    public function getInvoiceCompany()
+    {
+        $cart = $this->getCart();
+
+        if (!$cart || !$cart->id_address_invoice) {
+            return '';
+        }
+
+        $invoiceAddress = new \Address((int) $cart->id_address_invoice);
+
+        return (string) $invoiceAddress->company;
+    }
+
     public function getCurrency()
     {
         return $this->getContext()->currency;

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -477,6 +477,11 @@ class Config
         self::BILLINK,
     ];
 
+    /* Mollie advertises the 10000.00 B2B ceiling in the methods endpoint, consumer orders are capped at 2500.00 */
+    public const BILLINK_B2C_MAXIMUM_AMOUNT = 2500.00;
+
+    public const BILLINK_CURRENCY = 'EUR';
+
     public const PS_CLOUDSYNC_CDC = 'https://assets.prestashop3.com/ext/cloudsync-merchant-sync-consent/latest/cloudsync-cdc.js';
 
     public const PS_EVENTBUS_CONTEXT = [

--- a/src/DTO/PaymentData.php
+++ b/src/DTO/PaymentData.php
@@ -15,6 +15,7 @@ namespace Mollie\DTO;
 use Address;
 use Country;
 use JsonSerializable;
+use Mollie\Config\Config;
 use Mollie\DTO\Object\Amount;
 use Mollie\Utility\MollieApiInputSanitizer;
 
@@ -464,7 +465,7 @@ class PaymentData implements JsonSerializable
                 'value' => (string) $this->getAmount()->getValue(),
             ],
             'billingAddress' => [
-                'organizationName' => $this->cleanUpInput($this->getBillingAddress()->company),
+                'organizationName' => $this->getOrganizationName(),
                 'givenName' => $this->cleanUpInput($this->getBillingAddress()->firstname),
                 'familyName' => $this->cleanUpInput($this->getBillingAddress()->lastname),
                 'email' => MollieApiInputSanitizer::sanitizeEmail($this->getEmail()),
@@ -516,5 +517,18 @@ class PaymentData implements JsonSerializable
     private function cleanUpInput($input, $defaultValue = 'N/A'): ?string
     {
         return MollieApiInputSanitizer::sanitize($input, $defaultValue);
+    }
+
+    /**
+     * Billink treats any organization name as a B2B order and then rejects the request,
+     * so the placeholder must be omitted for a consumer purchase.
+     */
+    private function getOrganizationName(): ?string
+    {
+        if (Config::BILLINK === $this->getMethod()) {
+            return $this->cleanUpInput($this->getBillingAddress()->company, null);
+        }
+
+        return $this->cleanUpInput($this->getBillingAddress()->company);
     }
 }

--- a/src/Service/PaymentMethod/PaymentMethodRestrictionValidation/BillinkPaymentMethodRestrictionValidator.php
+++ b/src/Service/PaymentMethod/PaymentMethodRestrictionValidation/BillinkPaymentMethodRestrictionValidator.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Mollie       https://www.mollie.nl
+ *
+ * @author      Mollie B.V. <info@mollie.nl>
+ * @copyright   Mollie B.V.
+ * @license     https://github.com/mollie/PrestaShop/blob/master/LICENSE.md
+ *
+ * @see        https://github.com/mollie/PrestaShop
+ * @codingStandardsIgnoreStart
+ */
+
+namespace Mollie\Service\PaymentMethod\PaymentMethodRestrictionValidation;
+
+use Mollie\Adapter\LegacyContext;
+use Mollie\Config\Config;
+use MolPaymentMethod;
+use PrestaShop\Decimal\Number;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/** Validator to keep Billink within the consumer purchase conditions Mollie accepts */
+class BillinkPaymentMethodRestrictionValidator implements PaymentMethodRestrictionValidatorInterface
+{
+    /** @var LegacyContext */
+    private $context;
+
+    public function __construct(
+        LegacyContext $context
+    ) {
+        $this->context = $context;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isValid(MolPaymentMethod $paymentMethod): bool
+    {
+        if (Config::BILLINK_CURRENCY !== $this->context->getCurrencyIsoCode()) {
+            return false;
+        }
+
+        if (!empty($this->context->getInvoiceCompany())) {
+            return false;
+        }
+
+        $cartTotal = new Number((string) $this->context->getCart()->getOrderTotal());
+        $maximumAmount = new Number((string) Config::BILLINK_B2C_MAXIMUM_AMOUNT);
+
+        if ($maximumAmount->isLowerThan($cartTotal)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function supports(MolPaymentMethod $paymentMethod): bool
+    {
+        return Config::BILLINK === $paymentMethod->getPaymentMethodName();
+    }
+}

--- a/src/ServiceProvider/BaseServiceProvider.php
+++ b/src/ServiceProvider/BaseServiceProvider.php
@@ -126,6 +126,7 @@ use Mollie\Service\PaymentMethod\PaymentMethodRestrictionValidation\AmountPaymen
 use Mollie\Service\PaymentMethod\PaymentMethodRestrictionValidation\ApplePayPaymentMethodRestrictionValidator;
 use Mollie\Service\PaymentMethod\PaymentMethodRestrictionValidation\B2bPaymentMethodRestrictionValidator;
 use Mollie\Service\PaymentMethod\PaymentMethodRestrictionValidation\BasePaymentMethodRestrictionValidator;
+use Mollie\Service\PaymentMethod\PaymentMethodRestrictionValidation\BillinkPaymentMethodRestrictionValidator;
 use Mollie\Service\PaymentMethod\PaymentMethodRestrictionValidation\CustomerGroupPaymentMethodRestrictionValidator;
 use Mollie\Service\PaymentMethod\PaymentMethodRestrictionValidation\EnvironmentVersionSpecificPaymentMethodRestrictionValidator;
 use Mollie\Service\PaymentMethod\PaymentMethodRestrictionValidation\VoucherPaymentMethodRestrictionValidator;
@@ -281,6 +282,7 @@ final class BaseServiceProvider
                 $container->get(ApplePayPaymentMethodRestrictionValidator::class),
                 $container->get(AmountPaymentMethodRestrictionValidator::class),
                 $container->get(B2bPaymentMethodRestrictionValidator::class),
+                $container->get(BillinkPaymentMethodRestrictionValidator::class),
                 $container->get(CustomerGroupPaymentMethodRestrictionValidator::class),
             ], $container->get(LoggerInterface::class));
         });

--- a/tests/Unit/Service/PaymentMethod/PaymentMethodRestrictionValidation/BillinkPaymentRestrictionValidationTest.php
+++ b/tests/Unit/Service/PaymentMethod/PaymentMethodRestrictionValidation/BillinkPaymentRestrictionValidationTest.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Mollie       https://www.mollie.nl
+ *
+ * @author      Mollie B.V. <info@mollie.nl>
+ * @copyright   Mollie B.V.
+ * @license     https://github.com/mollie/PrestaShop/blob/master/LICENSE.md
+ *
+ * @see        https://github.com/mollie/PrestaShop
+ * @codingStandardsIgnoreStart
+ */
+
+use Mollie\Config\Config;
+use Mollie\Service\PaymentMethod\PaymentMethodRestrictionValidation\BillinkPaymentMethodRestrictionValidator;
+use Mollie\Tests\Unit\Tools\UnitTestCase;
+
+class BillinkPaymentRestrictionValidationTest extends UnitTestCase
+{
+    /**
+     * @var MolPaymentMethod|PHPUnit_Framework_MockObject_MockObject
+     */
+    private $paymentMethod;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->paymentMethod = $this->mockPaymentMethod(Config::BILLINK, true);
+    }
+
+    /**
+     * @dataProvider getBillinkPaymentRestrictionValidationDataProvider
+     */
+    public function testIsValid(float $totalOrderAmount, string $currencyIso, string $company, bool $expectedResult)
+    {
+        $context = $this->mockContext('NL', $currencyIso);
+
+        $context
+            ->method('getCart')
+            ->willReturn($this->mockCart($totalOrderAmount))
+        ;
+
+        $context
+            ->method('getInvoiceCompany')
+            ->willReturn($company)
+        ;
+
+        $validator = new BillinkPaymentMethodRestrictionValidator($context);
+
+        $this->assertEquals($expectedResult, $validator->isValid($this->paymentMethod));
+    }
+
+    public function getBillinkPaymentRestrictionValidationDataProvider()
+    {
+        return [
+            'Consumer purchase within the maximum amount' => [
+                'totalOrderAmount' => 100.00,
+                'currencyIso' => 'EUR',
+                'company' => '',
+                'expectedResult' => true,
+            ],
+            'Consumer purchase at the maximum amount' => [
+                'totalOrderAmount' => 2500.00,
+                'currencyIso' => 'EUR',
+                'company' => '',
+                'expectedResult' => true,
+            ],
+            'Consumer purchase one cent above the maximum amount' => [
+                'totalOrderAmount' => 2500.01,
+                'currencyIso' => 'EUR',
+                'company' => '',
+                'expectedResult' => false,
+            ],
+            'Business purchase is not supported' => [
+                'totalOrderAmount' => 100.00,
+                'currencyIso' => 'EUR',
+                'company' => 'Mollie B.V.',
+                'expectedResult' => false,
+            ],
+            'Unsupported currency' => [
+                'totalOrderAmount' => 100.00,
+                'currencyIso' => 'SEK',
+                'company' => '',
+                'expectedResult' => false,
+            ],
+        ];
+    }
+
+    public function testSupportsOnlyBillink()
+    {
+        $validator = new BillinkPaymentMethodRestrictionValidator($this->mockContext('NL', 'EUR'));
+
+        $this->assertTrue($validator->supports($this->paymentMethod));
+        $this->assertFalse($validator->supports($this->mockPaymentMethod(Config::MOLLIE_METHOD_ID_KLARNA_PAY_LATER, true)));
+    }
+}


### PR DESCRIPTION
## What

Billink is offered at checkout as a consumer payment method only.

Mollie does not support business purchases for Billink yet ([PIPRES-777 comment](https://mollie.atlassian.net/browse/PIPRES-777)), so the module keeps Billink inside the conditions Mollie accepts today. PIPRES-812 tracks lifting the restriction once Mollie is ready.

## Changes

- New `BillinkPaymentMethodRestrictionValidator`: hides Billink when the currency is not EUR, when the invoice address has a company filled, or when the cart total is above 2500.00
- `PaymentData` no longer sends the `organizationName` placeholder for Billink. Any value puts the payment on the business path, which Mollie rejects with `422 The company entity type is invalid`. Other methods keep the existing behaviour
- `LegacyContext::getInvoiceCompany()` to read the company from the invoice address
- `Config::BILLINK_B2C_MAXIMUM_AMOUNT` and `Config::BILLINK_CURRENCY`
- Unit test covering the amount boundary, company, currency and method matching
- Changelog entry moved to 6.4.5, the stale 6.4.3 line was removed

## Why the 2500 limit

The `methods` endpoint advertises a 10000.00 maximum, which is the business figure. The consumer maximum is 2500.00, confirmed against the API: 2500.00 is accepted, 2500.01 returns `The amount is higher than the maximum`. Without the cap, carts between 2500.01 and 10000 are offered Billink and then fail at payment creation.

## Testing

Live on PS 1.7.8.9 with the Payments API and a test key:

- Billink order 100.00 EUR, NL consumer, authorized with `captureMode: manual` and no `organizationName` in the payload, then captured from the back office and the payment moved to paid
- Wero order with company "Mollie B.V." still sends `organizationName`, confirming the change is Billink only
- Visibility: 2500.00 shows Billink, 2600.00 hides it, a filled company hides it, GBP hides it. iDEAL, card and Wero are unaffected in every case
- 363 unit tests green, php-cs-fixer and PHPStan clean on the touched files

## Not covered

Billink's hosted credit check always approves in test mode, so the decline path that falls back to another method could not be exercised. Only NL consumers were tested, not BE or DE.