### PR TITLE
Make the upgrade-check job boot its shop and actually test the upgrade

### DIFF
--- a/.docker/upgrade-module.php
+++ b/.docker/upgrade-module.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Runs a module's own upgrade/Upgrade-*.php files against the version the shop has
+ * registered, the way PrestaShop does once a merchant has replaced the module files.
+ *
+ * `bin/console prestashop:module upgrade` cannot be used for this. ModuleManager::upgrade()
+ * calls setModuleOnDiskFromAddons() whenever the marketplace advertises a newer version,
+ * which unpacks the released module over modules/<name> - here a bind mount of the
+ * checkout - so the code under test is thrown away before a single upgrade file runs.
+ *
+ * Usage: php .docker/upgrade-module.php <module>
+ */
+
+if (php_sapi_name() !== 'cli') {
+    exit(1);
+}
+
+$moduleName = isset($argv[1]) ? $argv[1] : '';
+
+if ($moduleName === '') {
+    fwrite(STDERR, "usage: php .docker/upgrade-module.php <module>\n");
+    exit(1);
+}
+
+require_once __DIR__ . '/../../../config/config.inc.php';
+
+$context = Context::getContext();
+
+if (!$context->employee) {
+    $context->employee = new Employee(1);
+}
+
+$query = new DbQuery();
+$query->select('version')
+    ->from('module')
+    ->where('name = "' . pSQL($moduleName) . '"');
+
+$registeredVersion = Db::getInstance()->getValue($query);
+
+if (!$registeredVersion) {
+    fwrite(STDERR, sprintf("The shop has no %s module installed.\n", $moduleName));
+    exit(1);
+}
+
+$module = Module::getInstanceByName($moduleName);
+
+if (!$module instanceof Module) {
+    fwrite(STDERR, sprintf("Could not instantiate the %s module.\n", $moduleName));
+    exit(1);
+}
+
+$module->installed = true;
+$module->database_version = $registeredVersion;
+
+if (!Module::initUpgradeModule($module)) {
+    fwrite(STDERR, sprintf(
+        "Nothing to upgrade: the shop reports %s %s and the files ship %s.\n",
+        $moduleName,
+        $registeredVersion,
+        $module->version
+    ));
+    exit(1);
+}
+
+$upgrade = $module->runUpgradeModule();
+
+foreach ($module->getErrors() as $error) {
+    fwrite(STDERR, strip_tags($error) . "\n");
+}
+
+if (!$upgrade['success'] || $upgrade['number_upgrade_left'] > 0) {
+    fwrite(STDERR, sprintf(
+        "Upgrading %s from %s failed on version %s, %d file(s) left.\n",
+        $moduleName,
+        $registeredVersion,
+        $upgrade['version_fail'],
+        $upgrade['number_upgrade_left']
+    ));
+    exit(1);
+}
+
+// runUpgradeModule() only records the last upgrade file it ran, so a module whose
+// newest upgrade file predates its current version stays behind. PrestaShop closes
+// that gap on the next request, when loadUpgradeVersionList() finds nothing left to
+// run; do it here so the shop ends up where a merchant's would.
+Module::upgradeModuleVersion($moduleName, $module->version);
+
+printf(
+    "Upgraded %s from %s to %s, %d upgrade file(s) applied.\n",
+    $moduleName,
+    $registeredVersion,
+    $module->version,
+    $upgrade['number_upgraded']
+);

--- a/.docker/upgrade-module.php
+++ b/.docker/upgrade-module.php
@@ -68,7 +68,20 @@ if (!Module::initUpgradeModule($module)) {
     exit(1);
 }
 
-$upgrade = $module->runUpgradeModule();
+try {
+    $upgrade = $module->runUpgradeModule();
+} catch (Throwable $exception) {
+    fwrite(STDERR, sprintf(
+        "Upgrading %s from %s threw %s: %s\n  in %s line %d\n",
+        $moduleName,
+        $registeredVersion,
+        get_class($exception),
+        $exception->getMessage(),
+        $exception->getFile(),
+        $exception->getLine()
+    ));
+    exit(1);
+}
 
 foreach ($module->getErrors() as $error) {
     fwrite(STDERR, strip_tags($error) . "\n");

--- a/.docker/upgrade-module.php
+++ b/.docker/upgrade-module.php
@@ -3,14 +3,13 @@
  * Runs a module's own upgrade/Upgrade-*.php files against the version the shop has
  * registered, the way PrestaShop does once a merchant has replaced the module files.
  *
- * `bin/console prestashop:module upgrade` cannot be used for this. ModuleManager::upgrade()
- * calls setModuleOnDiskFromAddons() whenever the marketplace advertises a newer version,
- * which unpacks the released module over modules/<name> - here a bind mount of the
- * checkout - so the code under test is thrown away before a single upgrade file runs.
+ * `bin/console prestashop:module upgrade` cannot be used: ModuleManager::upgrade()
+ * calls setModuleOnDiskFromAddons() first, which unpacks the released module over
+ * modules/<name> - here a bind mount of the checkout - so the code under test is
+ * thrown away before a single upgrade file runs.
  *
  * Usage: php .docker/upgrade-module.php <module>
  */
-
 if (php_sapi_name() !== 'cli') {
     exit(1);
 }
@@ -24,9 +23,8 @@ if ($moduleName === '') {
 
 require_once __DIR__ . '/../../../config/config.inc.php';
 
-// Same bootstrap as bin/console. Upgrade files reach for Symfony services such as
-// prestashop.adapter.module.tab.register, and SymfonyContainer::getInstance() only
-// hands one back when the global $kernel is booted.
+// Same bootstrap as bin/console: upgrade files reach for Symfony services, and
+// SymfonyContainer::getInstance() only hands one back when the global $kernel is booted.
 $kernel = new AppKernel(getenv('SYMFONY_ENV') ?: 'dev', false);
 $kernel->boot();
 
@@ -98,10 +96,9 @@ if (!$upgrade['success'] || $upgrade['number_upgrade_left'] > 0) {
     exit(1);
 }
 
-// runUpgradeModule() only records the last upgrade file it ran, so a module whose
-// newest upgrade file predates its current version stays behind. PrestaShop closes
-// that gap on the next request, when loadUpgradeVersionList() finds nothing left to
-// run; do it here so the shop ends up where a merchant's would.
+// runUpgradeModule() records the last upgrade file it ran, so a module whose newest
+// upgrade file predates its current version stays behind. PrestaShop closes that gap
+// on the next request; do it here so the shop ends up where a merchant's would.
 Module::upgradeModuleVersion($moduleName, $module->version);
 
 printf(

--- a/.docker/upgrade-module.php
+++ b/.docker/upgrade-module.php
@@ -24,6 +24,12 @@ if ($moduleName === '') {
 
 require_once __DIR__ . '/../../../config/config.inc.php';
 
+// Same bootstrap as bin/console. Upgrade files reach for Symfony services such as
+// prestashop.adapter.module.tab.register, and SymfonyContainer::getInstance() only
+// hands one back when the global $kernel is booted.
+$kernel = new AppKernel(getenv('SYMFONY_ENV') ?: 'dev', false);
+$kernel->boot();
+
 $context = Context::getContext();
 
 if (!$context->employee) {

--- a/.docker/upgrading-module-test.sh
+++ b/.docker/upgrading-module-test.sh
@@ -1,22 +1,17 @@
 #!/bin/bash
 # Usage: upgrading-module-test.sh <module> <ps-version> [base-tag]
 #
-# Installs the oldest supported release of the module into an already running shop,
-# checks the tree back out to the commit under test, runs that commit's own
-# upgrade/*.php files, and asserts the shop's recorded version at both ends.
-#
-# Expects a shop built by `make VERSION=<ps-version> e2eh<ps-version>`, so run it
-# after that target and not on its own.
-#
-# The tree round trip happens in place because the PrestaShop container bind mounts
-# the checkout as modules/<module>; there is no second copy to point it at.
+# Installs the oldest supported release of the module into a shop already built by
+# `make VERSION=<ps-version> e2eh<ps-version>`, checks the tree back out to the commit
+# under test, runs that commit's own upgrade/*.php files, and asserts the shop's
+# recorded version at both ends. The tree round trip happens in place because the
+# container bind mounts the checkout as modules/<module>.
 
 set -euo pipefail
 
 # bash reads a script file in chunks as it executes, and the tag checkout below
-# replaces this very file with the tag's tree, which does not contain it. Re-exec
-# from a copy held in memory so the rest of the run cannot be pulled out from
-# under the interpreter.
+# replaces this very file with a tree that does not contain it. Re-exec from a copy
+# held in memory.
 if [ -n "${BASH_SOURCE[0]:-}" ]; then
     source_text="$(cat "${BASH_SOURCE[0]}")"
     exec bash -c "$source_text" "$0" "$@"
@@ -24,9 +19,7 @@ fi
 
 MODULE="${1:-mollie}"
 PS_VERSION="${2:-1785}"
-# The oldest release in the supported window: Mollie's compatibility table pairs
-# PS 1.7.6 - 9.0.0 with Mollie 6, and there is no v6.0.0 tag, only betas. Bump this
-# when Mollie 6 leaves support.
+# Oldest release in the supported window; bump when Mollie 6 leaves support.
 BASE_TAG="${3:-v6.0.1}"
 
 PS_CONTAINER="prestashop-${MODULE}-${PS_VERSION}"
@@ -34,15 +27,13 @@ DB_CONTAINER="mysql-${MODULE}-${PS_VERSION}"
 
 cd "$(git rev-parse --show-toplevel)"
 
-# Everything read from the tree has to be read now, while the commit under test is
-# still checked out. A branch name when there is one, so a local run ends where it
-# started; CI checks out a detached HEAD and only has the sha.
+# Read while the commit under test is still checked out. A branch name when there is
+# one, so a local run ends where it started; CI only has the sha.
 HEAD_REF="$(git symbolic-ref --quiet --short HEAD || git rev-parse HEAD)"
 HEAD_VERSION="$(awk -F"'" '/this->version = /{print $2; exit}' "${MODULE}.php")"
 BASE_VERSION="${BASE_TAG#v}"
 # composer.lock is gitignored on the branch and tracked in the old tags, so the round
-# trip would delete the one CI resolved for the head. Keep it outside the checkout,
-# where no checkout can touch it.
+# trip would delete the one CI resolved for the head. Park it outside the checkout.
 LOCK_BACKUP="$(cd .. && pwd)/composer.lock.${MODULE}-upgrading-module-test"
 
 step() {
@@ -50,10 +41,6 @@ step() {
     echo "==> $*"
 }
 
-# Everything below needs a shop already built by e2eh<ps-version> and the lock that
-# built it. Checked up front because otherwise the target dies on a raw "No such
-# container" or a bare cp error from whichever step ran first, neither of which says
-# what is actually missing - and by then the module has already been uninstalled.
 check_preconditions() {
     local missing=""
 
@@ -70,18 +57,14 @@ check_preconditions() {
         return 1
     fi
 
-    # The head's lock is what gets set aside and restored around the tag checkout.
     if [ ! -f composer.lock ]; then
         echo "No composer.lock to preserve across the tag checkout; run 'composer install'." >&2
         return 1
     fi
 }
 
-# Installing the module inside the container writes into the bind-mounted checkout
-# as root - PrestaShop generates a mails/<iso> folder per installed language - and
-# the runner cannot replace those files afterwards, so the next checkout dies on
-# "unable to unlink old 'mails/de/index.php': Permission denied". Docker Desktop
-# remaps bind mounts to the host user and hides this locally.
+# Installing writes root-owned files (mails/<iso>) into the bind-mounted checkout, so
+# the next checkout dies on "unable to unlink old". Docker Desktop hides this locally.
 loosen_module_dir() {
     docker exec -i "$PS_CONTAINER" sh -c "chmod -R 777 /var/www/html/modules/${MODULE}"
 }
@@ -90,9 +73,8 @@ console() {
     docker exec -i "$PS_CONTAINER" sh -c "cd /var/www/html && php bin/console $*"
 }
 
-# PrestaShop reports success for a no-op install, and an upgrade that ran nothing at
-# all also leaves a shop that boots, so without asking the shop what it recorded
-# neither leg of this test can fail.
+# PrestaShop reports success for a no-op install, so without asking the shop what it
+# recorded neither leg of this test can fail.
 assert_module_version() {
     local expected="$1" installed
 
@@ -108,16 +90,10 @@ assert_module_version() {
     echo "OK: shop reports module version ${installed}"
 }
 
-# Raised as soon as each is no longer in the state it was found in, so a failure
-# reports only what it actually disturbed. Without them a run that fails before
-# touching anything - no shop up, say - still tells the developer to reinstall
-# dependencies and rebuild a shop.
+# Raised as each thing stops being in the state it was found in.
 shop_touched=0
 tree_checked_out=0
 
-# The steps below leave the checkout detached on $BASE_TAG with an edited
-# composer.json and no composer.lock, so a failure halfway has to put the tree back
-# or it takes the developer's working copy with it.
 cleanup() {
     local status=$?
 
@@ -131,8 +107,6 @@ cleanup() {
             echo "Restoring the working tree to ${HEAD_REF}." >&2
             loosen_module_dir || true
             git checkout --force "$HEAD_REF" || true
-            # The tree is back, the rest of the run is not: vendor/ still holds the
-            # base tag's dependencies, and no checkout can fix that.
             echo "vendor/ now holds ${BASE_TAG} dependencies - run 'composer install'." >&2
         fi
 
@@ -154,40 +128,28 @@ check_preconditions
 git fetch --tags --force
 
 step "Uninstalling ${MODULE} ${HEAD_VERSION}"
-# e2eh<ps-version> leaves the module installed at the version under test, and
-# `module install` on an installed module is a no-op that still exits 0. Without this
-# the shop never goes back to $BASE_TAG and the upgrade leg has nothing to upgrade -
-# the job goes green having tested nothing. Uninstall while the current code is still
-# checked out, so it matches the schema it created.
+# e2eh<ps-version> leaves the module installed and `module install` is then a no-op
+# that still exits 0, so without this the upgrade leg has nothing to upgrade. Uninstall
+# while the current code still matches the schema it created.
 shop_touched=1
 console "prestashop:module uninstall ${MODULE}"
 
 step "Checking out ${BASE_TAG}"
 cp composer.lock "$LOCK_BACKUP"
 loosen_module_dir
-# A real checkout of the tag, not `git checkout <tag> .`. The partial form restores
-# the tag's files but never deletes files added after it, so everything the branch
-# added since - shared/, config/services.yml - stayed behind and got compiled against
-# an autoloader composer had just rebuilt from the tag's composer.json, which knows
-# nothing about them.
+# A real checkout, not `git checkout <tag> .`: the partial form never deletes files
+# added after the tag, so shared/ and config/services.yml stayed behind and got
+# compiled against an autoloader rebuilt from the tag's composer.json.
 tree_checked_out=1
 git checkout --detach --force "$BASE_TAG"
 rm -f composer.lock
 
 step "Resolving ${BASE_TAG} dependencies"
-# The tag's require-dev pins roave/security-advisories dev-latest, which always
-# resolves to today's advisory list and by now conflicts with every guzzlehttp/psr7
-# the tag's runtime constraints allow, so a release this old can no longer be
-# resolved. --no-dev is not enough, composer still solves require-dev. Drop the
-# package outright: it is an install-time guard and the shop only needs the runtime
-# set. The checkout back to $HEAD_REF undoes the composer.json edit.
+# The tag pins roave/security-advisories dev-latest, which now conflicts with every
+# guzzlehttp/psr7 it allows; --no-dev is not enough, composer still solves require-dev.
 composer remove --dev roave/security-advisories --no-update --no-interaction
-# Composer 2.9 refuses to load any package covered by a security advisory, and a
-# release this old is full of them - symfony/http-client ^4.4 and guzzlehttp/psr7 1.x
-# among its runtime requirements - so the resolve dies on the runner while it still
-# succeeds on an older composer. Turn the policy off for the tag: this checkout exists
-# only to be upgraded away from inside a throwaway container, and the head's own
-# dependencies are resolved separately and still audited.
+# Composer 2.9 refuses to load any package covered by an advisory and a release this
+# old is full of them. This tree only exists to be upgraded away inside a container.
 php -r '$f = "composer.json";
         $j = json_decode(file_get_contents($f), true);
         $j["config"]["policy"]["advisories"]["block"] = false;
@@ -200,18 +162,14 @@ assert_module_version "$BASE_VERSION"
 
 step "Checking out the commit under test (${HEAD_REF})"
 loosen_module_dir
-# $HEAD_REF, not develop: the old target ended on `git checkout develop --force`, so
-# the upgrade leg asserted against develop and never saw the commit being tested.
+# $HEAD_REF, not develop: the old target asserted against develop, never the commit.
 git checkout --force "$HEAD_REF"
-# The autoloader is still the tag's at this point.
 mv "$LOCK_BACKUP" composer.lock
 composer install
 
 step "Upgrading ${MODULE} ${BASE_VERSION} to ${HEAD_VERSION}"
-# Not `bin/console prestashop:module upgrade`: ModuleManager::upgrade() calls
-# setModuleOnDiskFromAddons() first, which unpacks the published release over
-# modules/<module> - a bind mount of this checkout - and upgrades that instead of the
-# commit under test. .docker/upgrade-module.php runs the local upgrade/*.php files.
+# Not `bin/console prestashop:module upgrade`: setModuleOnDiskFromAddons() unpacks the
+# published release over the bind mount and upgrades that, not the commit under test.
 docker exec -i "$PS_CONTAINER" \
     sh -c "cd /var/www/html && php modules/${MODULE}/.docker/upgrade-module.php ${MODULE}"
 assert_module_version "$HEAD_VERSION"

--- a/.docker/upgrading-module-test.sh
+++ b/.docker/upgrading-module-test.sh
@@ -1,0 +1,217 @@
+#!/bin/bash
+# Usage: upgrading-module-test.sh <module> <ps-version> [base-tag]
+#
+# Installs the oldest supported release of the module into an already running shop,
+# checks the tree back out to the commit under test, runs that commit's own
+# upgrade/*.php files, and asserts the shop's recorded version at both ends.
+#
+# Expects a shop built by `make VERSION=<ps-version> e2eh<ps-version>`, so run it
+# after that target and not on its own.
+#
+# The tree round trip happens in place because the PrestaShop container bind mounts
+# the checkout as modules/<module>; there is no second copy to point it at.
+
+set -euo pipefail
+
+# bash reads a script file in chunks as it executes, and the tag checkout below
+# replaces this very file with the tag's tree, which does not contain it. Re-exec
+# from a copy held in memory so the rest of the run cannot be pulled out from
+# under the interpreter.
+if [ -n "${BASH_SOURCE[0]:-}" ]; then
+    source_text="$(cat "${BASH_SOURCE[0]}")"
+    exec bash -c "$source_text" "$0" "$@"
+fi
+
+MODULE="${1:-mollie}"
+PS_VERSION="${2:-1785}"
+# The oldest release in the supported window: Mollie's compatibility table pairs
+# PS 1.7.6 - 9.0.0 with Mollie 6, and there is no v6.0.0 tag, only betas. Bump this
+# when Mollie 6 leaves support.
+BASE_TAG="${3:-v6.0.1}"
+
+PS_CONTAINER="prestashop-${MODULE}-${PS_VERSION}"
+DB_CONTAINER="mysql-${MODULE}-${PS_VERSION}"
+
+cd "$(git rev-parse --show-toplevel)"
+
+# Everything read from the tree has to be read now, while the commit under test is
+# still checked out. A branch name when there is one, so a local run ends where it
+# started; CI checks out a detached HEAD and only has the sha.
+HEAD_REF="$(git symbolic-ref --quiet --short HEAD || git rev-parse HEAD)"
+HEAD_VERSION="$(awk -F"'" '/this->version = /{print $2; exit}' "${MODULE}.php")"
+BASE_VERSION="${BASE_TAG#v}"
+# composer.lock is gitignored on the branch and tracked in the old tags, so the round
+# trip would delete the one CI resolved for the head. Keep it outside the checkout,
+# where no checkout can touch it.
+LOCK_BACKUP="$(cd .. && pwd)/composer.lock.${MODULE}-upgrading-module-test"
+
+step() {
+    echo
+    echo "==> $*"
+}
+
+# Everything below needs a shop already built by e2eh<ps-version> and the lock that
+# built it. Checked up front because otherwise the target dies on a raw "No such
+# container" or a bare cp error from whichever step ran first, neither of which says
+# what is actually missing - and by then the module has already been uninstalled.
+check_preconditions() {
+    local missing=""
+
+    for container in "$PS_CONTAINER" "$DB_CONTAINER"; do
+        if [ -z "$(docker ps --quiet --filter "name=^${container}$")" ]; then
+            missing="${missing} ${container}"
+        fi
+    done
+
+    if [ -n "$missing" ]; then
+        echo "Not running:${missing}" >&2
+        echo "This target upgrades a shop that already exists; build one with" >&2
+        echo "  make VERSION=${PS_VERSION} e2eh${PS_VERSION}" >&2
+        return 1
+    fi
+
+    # The head's lock is what gets set aside and restored around the tag checkout.
+    if [ ! -f composer.lock ]; then
+        echo "No composer.lock to preserve across the tag checkout; run 'composer install'." >&2
+        return 1
+    fi
+}
+
+# Installing the module inside the container writes into the bind-mounted checkout
+# as root - PrestaShop generates a mails/<iso> folder per installed language - and
+# the runner cannot replace those files afterwards, so the next checkout dies on
+# "unable to unlink old 'mails/de/index.php': Permission denied". Docker Desktop
+# remaps bind mounts to the host user and hides this locally.
+loosen_module_dir() {
+    docker exec -i "$PS_CONTAINER" sh -c "chmod -R 777 /var/www/html/modules/${MODULE}"
+}
+
+console() {
+    docker exec -i "$PS_CONTAINER" sh -c "cd /var/www/html && php bin/console $*"
+}
+
+# PrestaShop reports success for a no-op install, and an upgrade that ran nothing at
+# all also leaves a shop that boots, so without asking the shop what it recorded
+# neither leg of this test can fail.
+assert_module_version() {
+    local expected="$1" installed
+
+    installed="$(docker exec -i "$DB_CONTAINER" \
+        mysql -uroot -pprestashop -N -B \
+        -e "SELECT version FROM ps_module WHERE name = '${MODULE}'" prestashop 2>/dev/null)"
+
+    if [ "$installed" != "$expected" ]; then
+        echo "FAIL: expected the shop to report module version ${expected}, got '${installed}'" >&2
+        return 1
+    fi
+
+    echo "OK: shop reports module version ${installed}"
+}
+
+# Raised as soon as each is no longer in the state it was found in, so a failure
+# reports only what it actually disturbed. Without them a run that fails before
+# touching anything - no shop up, say - still tells the developer to reinstall
+# dependencies and rebuild a shop.
+shop_touched=0
+tree_checked_out=0
+
+# The steps below leave the checkout detached on $BASE_TAG with an edited
+# composer.json and no composer.lock, so a failure halfway has to put the tree back
+# or it takes the developer's working copy with it.
+cleanup() {
+    local status=$?
+
+    trap - EXIT
+
+    if [ "$status" -ne 0 ]; then
+        echo
+        echo "FAILED (exit ${status})." >&2
+
+        if [ "$tree_checked_out" = 1 ]; then
+            echo "Restoring the working tree to ${HEAD_REF}." >&2
+            loosen_module_dir || true
+            git checkout --force "$HEAD_REF" || true
+            # The tree is back, the rest of the run is not: vendor/ still holds the
+            # base tag's dependencies, and no checkout can fix that.
+            echo "vendor/ now holds ${BASE_TAG} dependencies - run 'composer install'." >&2
+        fi
+
+        if [ "$shop_touched" = 1 ]; then
+            echo "The shop is left mid-upgrade; rebuild it before trusting another run." >&2
+        fi
+    fi
+
+    if [ -f "$LOCK_BACKUP" ]; then
+        mv -f "$LOCK_BACKUP" composer.lock
+    fi
+
+    exit "$status"
+}
+
+trap cleanup EXIT
+
+check_preconditions
+git fetch --tags --force
+
+step "Uninstalling ${MODULE} ${HEAD_VERSION}"
+# e2eh<ps-version> leaves the module installed at the version under test, and
+# `module install` on an installed module is a no-op that still exits 0. Without this
+# the shop never goes back to $BASE_TAG and the upgrade leg has nothing to upgrade -
+# the job goes green having tested nothing. Uninstall while the current code is still
+# checked out, so it matches the schema it created.
+shop_touched=1
+console "prestashop:module uninstall ${MODULE}"
+
+step "Checking out ${BASE_TAG}"
+cp composer.lock "$LOCK_BACKUP"
+loosen_module_dir
+# A real checkout of the tag, not `git checkout <tag> .`. The partial form restores
+# the tag's files but never deletes files added after it, so everything the branch
+# added since - shared/, config/services.yml - stayed behind and got compiled against
+# an autoloader composer had just rebuilt from the tag's composer.json, which knows
+# nothing about them.
+tree_checked_out=1
+git checkout --detach --force "$BASE_TAG"
+rm -f composer.lock
+
+step "Resolving ${BASE_TAG} dependencies"
+# The tag's require-dev pins roave/security-advisories dev-latest, which always
+# resolves to today's advisory list and by now conflicts with every guzzlehttp/psr7
+# the tag's runtime constraints allow, so a release this old can no longer be
+# resolved. --no-dev is not enough, composer still solves require-dev. Drop the
+# package outright: it is an install-time guard and the shop only needs the runtime
+# set. The checkout back to $HEAD_REF undoes the composer.json edit.
+composer remove --dev roave/security-advisories --no-update --no-interaction
+# Composer 2.9 refuses to load any package covered by a security advisory, and a
+# release this old is full of them - symfony/http-client ^4.4 and guzzlehttp/psr7 1.x
+# among its runtime requirements - so the resolve dies on the runner while it still
+# succeeds on an older composer. Turn the policy off for the tag: this checkout exists
+# only to be upgraded away from inside a throwaway container, and the head's own
+# dependencies are resolved separately and still audited.
+php -r '$f = "composer.json";
+        $j = json_decode(file_get_contents($f), true);
+        $j["config"]["policy"]["advisories"]["block"] = false;
+        file_put_contents($f, json_encode($j, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));'
+composer update --no-dev
+
+step "Installing ${MODULE} ${BASE_VERSION}"
+console "prestashop:module install ${MODULE}"
+assert_module_version "$BASE_VERSION"
+
+step "Checking out the commit under test (${HEAD_REF})"
+loosen_module_dir
+# $HEAD_REF, not develop: the old target ended on `git checkout develop --force`, so
+# the upgrade leg asserted against develop and never saw the commit being tested.
+git checkout --force "$HEAD_REF"
+# The autoloader is still the tag's at this point.
+mv "$LOCK_BACKUP" composer.lock
+composer install
+
+step "Upgrading ${MODULE} ${BASE_VERSION} to ${HEAD_VERSION}"
+# Not `bin/console prestashop:module upgrade`: ModuleManager::upgrade() calls
+# setModuleOnDiskFromAddons() first, which unpacks the published release over
+# modules/<module> - a bind mount of this checkout - and upgrades that instead of the
+# commit under test. .docker/upgrade-module.php runs the local upgrade/*.php files.
+docker exec -i "$PS_CONTAINER" \
+    sh -c "cd /var/www/html && php modules/${MODULE}/.docker/upgrade-module.php ${MODULE}"
+assert_module_version "$HEAD_VERSION"

--- a/.github/workflows/upgrading_check.yml
+++ b/.github/workflows/upgrading_check.yml
@@ -20,15 +20,11 @@ jobs:
             yml: 'docker-compose.1785.yml'
             ModuleUpgradeTest: 'make VERSION=1785 upgrading-module-test-1785'
     env:
-      # docker-compose.1785.yml hands this to the PrestaShop container as the
-      # password PS_INSTALL_AUTO uses to reach MySQL, whose root password is
-      # prestashop. Locally the Makefile picks it up from .env; CI has no .env,
-      # so without this the auto-install cannot authenticate, Apache never
-      # starts and the shop stays unreachable on 8002.
+      # MySQL's root password, which PS_INSTALL_AUTO needs to reach it. Locally the
+      # Makefile reads it from .env; CI has none, so without this nothing installs.
       DB_PASSWD: prestashop
-      # The job resolves dependencies twice, once for the head and once for the tag,
-      # and anonymous requests share the runner's rate limit. Without a token composer
-      # gives up with "Could not authenticate against github.com".
+      # The job resolves dependencies twice and anonymous requests share the runner's
+      # GitHub rate limit.
       COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ secrets.GITHUB_TOKEN }}"}}'
     steps:
       - name: Checkout

--- a/.github/workflows/upgrading_check.yml
+++ b/.github/workflows/upgrading_check.yml
@@ -15,6 +15,13 @@ jobs:
             port: '8002'
             yml: 'docker-compose.1785.yml'
             ModuleUpgradeTest: 'make VERSION=1785 upgrading-module-test-1785'
+    env:
+      # docker-compose.1785.yml hands this to the PrestaShop container as the
+      # password PS_INSTALL_AUTO uses to reach MySQL, whose root password is
+      # prestashop. Locally the Makefile picks it up from .env; CI has no .env,
+      # so without this the auto-install cannot authenticate, Apache never
+      # starts and the shop stays unreachable on 8002.
+      DB_PASSWD: prestashop
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/upgrading_check.yml
+++ b/.github/workflows/upgrading_check.yml
@@ -1,4 +1,4 @@
-name: Module upgrade / downgrade testing (last version > v.5.2.0 > `develop` version)
+name: Module upgrade / downgrade testing (oldest supported release v6.0.1 > `develop` version)
 on:
   pull_request:
     types: [opened, reopened]
@@ -22,6 +22,10 @@ jobs:
       # so without this the auto-install cannot authenticate, Apache never
       # starts and the shop stays unreachable on 8002.
       DB_PASSWD: prestashop
+      # The job resolves dependencies twice, once for the head and once for the tag,
+      # and anonymous requests share the runner's rate limit. Without a token composer
+      # gives up with "Could not authenticate against github.com".
+      COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ secrets.GITHUB_TOKEN }}"}}'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/upgrading_check.yml
+++ b/.github/workflows/upgrading_check.yml
@@ -1,8 +1,12 @@
 name: Module upgrade / downgrade testing (oldest supported release v6.0.1 > `develop` version)
 on:
   pull_request:
-    types: [opened, reopened]
     branches: [develop, develop**, develop-**]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Module-upgrading-check:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,6 @@
 ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 module = mollie
 
-# Both captured at parse time, before upgrading-module-test checks out v5.2.0:
-# the commit to come back to (CI leaves a detached HEAD, so there is not always a
-# branch name) and the version the shop must report once the upgrade has run.
-HEAD_REF := $(shell git rev-parse HEAD)
-MODULE_VERSION := $(shell sed -n "s/.*this->version = '\([0-9.]*\)'.*/\1/p" mollie.php | head -1)
-LOCK_BACKUP := $(ROOT_DIR)/../composer.lock.upgrading-module-test
-# The oldest release in the supported window: Mollie's compatibility table pairs
-# PS 1.7.6 - 9.0.0 with Mollie 6, and there is no v6.0.0 tag, only betas.
-BASE_TAG := v6.0.1
-
 # target: fix-lint			- Launch php cs fixer
 fix-lint:
 	docker compose run --rm php sh -c "vendor/bin/php-cs-fixer fix --using-cache=no"
@@ -134,76 +124,11 @@ e2e-tests-ui:
 	npx playwright install chromium
 	cd tests/e2e && npx playwright test --ui
 
-# checking the module upgrading - installs $(BASE_TAG) then upgrades to the commit under test
+# target: upgrading-module-test-$(VERSION)	- Upgrade the oldest supported release to the commit under test, in the shop from e2eh$(VERSION).
+# The recipe lives in a script because it needs state across steps, a failure trap
+# that puts the working tree back, and a checkout that replaces this Makefile.
 upgrading-module-test-$(VERSION):
-	git fetch --tags --force
-	# e2eh$(VERSION) leaves the module installed at the current version, and
-	# `module install` on an installed module is a no-op that still exits 0. Without
-	# this the shop never goes back to $(BASE_TAG) and the upgrade leg has nothing to
-	# upgrade - the job goes green having tested nothing. Uninstall while the
-	# current code is still checked out, so it matches the schema it created.
-	docker exec -i prestashop-$(module)-$(VERSION) sh -c "cd /var/www/html && php  bin/console prestashop:module uninstall $(module)"
-	# A real checkout of the tag, not `git checkout $(BASE_TAG) .`. The partial form
-	# restores the tag's files but never deletes files added after it, so everything
-	# the branch added since - shared/, config/services.yml entries - stayed behind
-	# and got compiled against an autoloader composer had just rebuilt from the tag's
-	# composer.json, which knows nothing about them.
-	# composer.lock is gitignored on the branch and untracked in the tag, so keep the
-	# head's aside: the tag needs its own resolve (league/container 2.5.0 against the
-	# branch's 3.3.3, among others) and the head must not inherit the result.
-	cp composer.lock $(LOCK_BACKUP)
-	# Installing the module inside the container writes into the bind-mounted checkout
-	# as root - PrestaShop generates a mails/<iso> folder per installed language - and
-	# the runner cannot replace those files afterwards, so the checkout dies on
-	# "unable to unlink old 'mails/de/index.php': Permission denied". Docker Desktop
-	# remaps the bind mount to the host user and hides this locally.
-	docker exec -i prestashop-$(module)-$(VERSION) sh -c "chmod -R 777 /var/www/html/modules/$(module)"
-	git checkout --detach --force $(BASE_TAG)
-	rm -f composer.lock
-	# The tag's require-dev pins roave/security-advisories dev-latest, which always
-	# resolves to today's advisory list and by now conflicts with every guzzlehttp/psr7
-	# the tag's runtime constraints allow, so a release this old can no longer be
-	# resolved. --no-dev is not enough, composer still solves require-dev. Drop the
-	# package outright: it is an install-time guard and the shop only needs the runtime
-	# set. The checkout back to HEAD_REF undoes the composer.json edit.
-	composer remove --dev roave/security-advisories --no-update --no-interaction
-	# Composer 2.9 refuses to load any package covered by a security advisory, and a
-	# release this old is full of them - symfony/http-client ^4.4 and guzzlehttp/psr7
-	# 1.x among its runtime requirements - so the resolve dies on the runner while it
-	# still succeeds on an older composer. Turn the policy off for the tag: this
-	# checkout exists only to be upgraded away from inside a throwaway container, and
-	# the head's own dependencies are resolved separately and still audited.
-	php -r '$$f = "composer.json"; $$j = json_decode(file_get_contents($$f), true); $$j["config"]["policy"]["advisories"]["block"] = false; file_put_contents($$f, json_encode($$j, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));'
-	composer update --no-dev
-	# installing $(BASE_TAG) module
-	docker exec -i prestashop-$(module)-$(VERSION) sh -c "cd /var/www/html && php  bin/console prestashop:module install $(module)"
-	$(call assert_module_version,$(patsubst v%,%,$(BASE_TAG)))
-	# the module under test - HEAD_REF, not develop, or the upgrade leg asserts
-	# against develop and never sees the commit being tested
-	docker exec -i prestashop-$(module)-$(VERSION) sh -c "chmod -R 777 /var/www/html/modules/$(module)"
-	git checkout --detach --force $(HEAD_REF)
-	# the autoloader is still the tag's at this point
-	mv $(LOCK_BACKUP) composer.lock
-	composer install
-	# Not `bin/console prestashop:module upgrade`: that pulls the released module from
-	# the Addons marketplace over the bind mount and upgrades that instead of the
-	# commit under test. .docker/upgrade-module.php runs the local upgrade/*.php files.
-	docker exec -i prestashop-$(module)-$(VERSION) sh -c "cd /var/www/html && php  modules/$(module)/.docker/upgrade-module.php $(module)"
-	$(call assert_module_version,$(MODULE_VERSION))
-
-# Asserts the shop really records the version we expect. PrestaShop reports success
-# for no-op installs, so without this the legs above cannot fail. Has to be a canned
-# recipe, not a target: the tag checkout replaces this Makefile on disk with v5.2.0's,
-# so a $(MAKE) recursion would look for a target that does not exist there.
-define assert_module_version
-	@installed=$$(mysql -h 127.0.0.1 -P 9002 --protocol=tcp -u root -pprestashop -N -B \
-		-e "SELECT version FROM ps_module WHERE name = '$(module)'" prestashop 2>/dev/null); \
-	if [ "$$installed" != "$(1)" ]; then \
-		echo "FAIL: expected the shop to report module version $(1), got '$$installed'"; \
-		exit 1; \
-	fi; \
-	echo "OK: shop reports module version $$installed"
-endef
+	/bin/bash .docker/upgrading-module-test.sh $(module) $(VERSION)
 
 prepare-zip:
 	composer install --no-dev --optimize-autoloader --classmap-authoritative

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 module = mollie
 
-# The commit under test, captured at parse time because upgrading-module-test
-# checks out v5.2.0 and has to come back here afterwards. CI leaves a detached
-# HEAD, so there is not always a branch name to return to.
+# Both captured at parse time, before upgrading-module-test checks out v5.2.0:
+# the commit to come back to (CI leaves a detached HEAD, so there is not always a
+# branch name) and the version the shop must report once the upgrade has run.
 HEAD_REF := $(shell git rev-parse HEAD)
+MODULE_VERSION := $(shell sed -n "s/.*this->version = '\([0-9.]*\)'.*/\1/p" mollie.php | head -1)
 
 # target: fix-lint			- Launch php cs fixer
 fix-lint:
@@ -129,25 +130,45 @@ e2e-tests-ui:
 	npx playwright install chromium
 	cd tests/e2e && npx playwright test --ui
 
-# checking the module upgrading - installs older module then installs the commit under test
+# checking the module upgrading - installs v5.2.0 then upgrades to the commit under test
 upgrading-module-test-$(VERSION):
 	git fetch --tags --force
+	# e2eh$(VERSION) leaves the module installed at the current version, and
+	# `module install` on an installed module is a no-op that still exits 0. Without
+	# this the shop never goes back to 5.2.0 and the upgrade leg has nothing to
+	# upgrade - the job goes green having tested nothing. Uninstall while the
+	# current code is still checked out, so it matches the schema it created.
+	docker exec -i prestashop-$(module)-$(VERSION) sh -c "cd /var/www/html && php  bin/console prestashop:module uninstall $(module)"
 	# A real checkout of the tag, not `git checkout v5.2.0 .`. The partial form
 	# restores the tag's files but never deletes files added after it, so
 	# config/services.yml survived and kept declaring
 	# Mollie\Subscription\...\SubscriptionFAQController while composer rebuilt the
 	# autoloader from v5.2.0's composer.json, which has no such namespace. The
-	# module install then died compiling the Symfony container.
+	# install then died compiling the Symfony container.
 	git checkout --detach --force v5.2.0
 	composer install
 	# installing 5.2.0 module
 	docker exec -i prestashop-$(module)-$(VERSION) sh -c "cd /var/www/html && php  bin/console prestashop:module install $(module)"
-	# installing the module under test. HEAD_REF, not develop: checking out develop
-	# made the upgrade leg assert against develop and never see the PR's code.
+	$(MAKE) VERSION=$(VERSION) assert-module-version EXPECTED=5.2.0
+	# the module under test - HEAD_REF, not develop, or the upgrade leg asserts
+	# against develop and never sees the commit being tested
 	git checkout --detach --force $(HEAD_REF)
-	# the autoloader is still v5.2.0's at this point, so rebuild it before install
+	# the autoloader is still v5.2.0's at this point
 	composer install
-	docker exec -i prestashop-$(module)-$(VERSION) sh -c "cd /var/www/html && php  bin/console prestashop:module install $(module)"
+	# upgrade, not install: `install` on an installed module never runs upgrade/*.php
+	docker exec -i prestashop-$(module)-$(VERSION) sh -c "cd /var/www/html && php  bin/console prestashop:module upgrade $(module)"
+	$(MAKE) VERSION=$(VERSION) assert-module-version EXPECTED=$(MODULE_VERSION)
+
+# asserts the shop really records the module version we expect. PrestaShop reports
+# success for no-op installs, so without this the upgrade leg cannot fail.
+assert-module-version:
+	@installed=$$(mysql -h 127.0.0.1 -P 9002 --protocol=tcp -u root -pprestashop -N -B \
+		-e "SELECT version FROM ps_module WHERE name = '$(module)'" prestashop 2>/dev/null); \
+	if [ "$$installed" != "$(EXPECTED)" ]; then \
+		echo "FAIL: expected the shop to report module version $(EXPECTED), got '$$installed'"; \
+		exit 1; \
+	fi; \
+	echo "OK: shop reports module version $$installed"
 
 prepare-zip:
 	composer install --no-dev --optimize-autoloader --classmap-authoritative

--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,13 @@ upgrading-module-test-$(VERSION):
 	# package outright: it is an install-time guard and the shop only needs the runtime
 	# set. The checkout back to HEAD_REF undoes the composer.json edit.
 	composer remove --dev roave/security-advisories --no-update --no-interaction
+	# Composer 2.9 refuses to load any package covered by a security advisory, and a
+	# release this old is full of them - symfony/http-client ^4.4 and guzzlehttp/psr7
+	# 1.x among its runtime requirements - so the resolve dies on the runner while it
+	# still succeeds on an older composer. Turn the policy off for the tag: this
+	# checkout exists only to be upgraded away from inside a throwaway container, and
+	# the head's own dependencies are resolved separately and still audited.
+	php -r '$$f = "composer.json"; $$j = json_decode(file_get_contents($$f), true); $$j["config"]["policy"]["advisories"]["block"] = false; file_put_contents($$f, json_encode($$j, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));'
 	composer update --no-dev
 	# installing $(BASE_TAG) module
 	docker exec -i prestashop-$(module)-$(VERSION) sh -c "cd /var/www/html && php  bin/console prestashop:module install $(module)"

--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,12 @@ upgrading-module-test-$(VERSION):
 	# head's aside: the tag needs its own resolve (league/container 2.5.0 against the
 	# branch's 3.3.3, among others) and the head must not inherit the result.
 	cp composer.lock $(LOCK_BACKUP)
+	# Installing the module inside the container writes into the bind-mounted checkout
+	# as root - PrestaShop generates a mails/<iso> folder per installed language - and
+	# the runner cannot replace those files afterwards, so the checkout dies on
+	# "unable to unlink old 'mails/de/index.php': Permission denied". Docker Desktop
+	# remaps the bind mount to the host user and hides this locally.
+	docker exec -i prestashop-$(module)-$(VERSION) sh -c "chmod -R 777 /var/www/html/modules/$(module)"
 	git checkout --detach --force $(BASE_TAG)
 	rm -f composer.lock
 	# The tag's require-dev pins roave/security-advisories dev-latest, which always
@@ -174,6 +180,7 @@ upgrading-module-test-$(VERSION):
 	$(call assert_module_version,$(patsubst v%,%,$(BASE_TAG)))
 	# the module under test - HEAD_REF, not develop, or the upgrade leg asserts
 	# against develop and never sees the commit being tested
+	docker exec -i prestashop-$(module)-$(VERSION) sh -c "chmod -R 777 /var/www/html/modules/$(module)"
 	git checkout --detach --force $(HEAD_REF)
 	# the autoloader is still the tag's at this point
 	mv $(LOCK_BACKUP) composer.lock

--- a/Makefile
+++ b/Makefile
@@ -155,8 +155,10 @@ upgrading-module-test-$(VERSION):
 	git checkout --detach --force $(HEAD_REF)
 	# the autoloader is still v5.2.0's at this point
 	composer install
-	# upgrade, not install: `install` on an installed module never runs upgrade/*.php
-	docker exec -i prestashop-$(module)-$(VERSION) sh -c "cd /var/www/html && php  bin/console prestashop:module upgrade $(module)"
+	# Not `bin/console prestashop:module upgrade`: that pulls the released module from
+	# the Addons marketplace over the bind mount and upgrades that instead of the
+	# commit under test. .docker/upgrade-module.php runs the local upgrade/*.php files.
+	docker exec -i prestashop-$(module)-$(VERSION) sh -c "cd /var/www/html && php  modules/$(module)/.docker/upgrade-module.php $(module)"
 	$(call assert_module_version,$(MODULE_VERSION))
 
 # Asserts the shop really records the version we expect. PrestaShop reports success

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 module = mollie
 
+# The commit under test, captured at parse time because upgrading-module-test
+# checks out v5.2.0 and has to come back here afterwards. CI leaves a detached
+# HEAD, so there is not always a branch name to return to.
+HEAD_REF := $(shell git rev-parse HEAD)
+
 # target: fix-lint			- Launch php cs fixer
 fix-lint:
 	docker compose run --rm php sh -c "vendor/bin/php-cs-fixer fix --using-cache=no"
@@ -124,16 +129,24 @@ e2e-tests-ui:
 	npx playwright install chromium
 	cd tests/e2e && npx playwright test --ui
 
-# checking the module upgrading - installs older module then installs from master branch
+# checking the module upgrading - installs older module then installs the commit under test
 upgrading-module-test-$(VERSION):
-	git fetch
-	git checkout v5.2.0 .
+	git fetch --tags --force
+	# A real checkout of the tag, not `git checkout v5.2.0 .`. The partial form
+	# restores the tag's files but never deletes files added after it, so
+	# config/services.yml survived and kept declaring
+	# Mollie\Subscription\...\SubscriptionFAQController while composer rebuilt the
+	# autoloader from v5.2.0's composer.json, which has no such namespace. The
+	# module install then died compiling the Symfony container.
+	git checkout --detach --force v5.2.0
 	composer install
 	# installing 5.2.0 module
 	docker exec -i prestashop-$(module)-$(VERSION) sh -c "cd /var/www/html && php  bin/console prestashop:module install $(module)"
-	# installing develop branch module
-	git checkout -- .
-	git checkout develop --force
+	# installing the module under test. HEAD_REF, not develop: checking out develop
+	# made the upgrade leg assert against develop and never see the PR's code.
+	git checkout --detach --force $(HEAD_REF)
+	# the autoloader is still v5.2.0's at this point, so rebuild it before install
+	composer install
 	docker exec -i prestashop-$(module)-$(VERSION) sh -c "cd /var/www/html && php  bin/console prestashop:module install $(module)"
 
 prepare-zip:

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ module = mollie
 # branch name) and the version the shop must report once the upgrade has run.
 HEAD_REF := $(shell git rev-parse HEAD)
 MODULE_VERSION := $(shell sed -n "s/.*this->version = '\([0-9.]*\)'.*/\1/p" mollie.php | head -1)
+LOCK_BACKUP := $(ROOT_DIR)/../composer.lock.upgrading-module-test
 
 # target: fix-lint			- Launch php cs fixer
 fix-lint:
@@ -145,6 +146,11 @@ upgrading-module-test-$(VERSION):
 	# Mollie\Subscription\...\SubscriptionFAQController while composer rebuilt the
 	# autoloader from v5.2.0's composer.json, which has no such namespace. The
 	# install then died compiling the Symfony container.
+	# The branch gitignores composer.lock but v5.2.0 tracks one, so the tag checkout
+	# overwrites the lock `composer update` just produced and the checkout back to the
+	# branch deletes it. Without it the second composer install silently turns into a
+	# full update against github.com. Keep the head's lock aside instead.
+	cp composer.lock $(LOCK_BACKUP)
 	git checkout --detach --force v5.2.0
 	composer install
 	# installing 5.2.0 module
@@ -154,6 +160,7 @@ upgrading-module-test-$(VERSION):
 	# against develop and never sees the commit being tested
 	git checkout --detach --force $(HEAD_REF)
 	# the autoloader is still v5.2.0's at this point
+	mv $(LOCK_BACKUP) composer.lock
 	composer install
 	# Not `bin/console prestashop:module upgrade`: that pulls the released module from
 	# the Addons marketplace over the bind mount and upgrades that instead of the

--- a/Makefile
+++ b/Makefile
@@ -125,8 +125,7 @@ e2e-tests-ui:
 	cd tests/e2e && npx playwright test --ui
 
 # target: upgrading-module-test-$(VERSION)	- Upgrade the oldest supported release to the commit under test, in the shop from e2eh$(VERSION).
-# The recipe lives in a script because it needs state across steps, a failure trap
-# that puts the working tree back, and a checkout that replaces this Makefile.
+# A script, not a recipe: it needs a failure trap and a checkout that replaces this file.
 upgrading-module-test-$(VERSION):
 	/bin/bash .docker/upgrading-module-test.sh $(module) $(VERSION)
 

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ upgrading-module-test-$(VERSION):
 	composer install
 	# installing 5.2.0 module
 	docker exec -i prestashop-$(module)-$(VERSION) sh -c "cd /var/www/html && php  bin/console prestashop:module install $(module)"
-	$(MAKE) VERSION=$(VERSION) assert-module-version EXPECTED=5.2.0
+	$(call assert_module_version,5.2.0)
 	# the module under test - HEAD_REF, not develop, or the upgrade leg asserts
 	# against develop and never sees the commit being tested
 	git checkout --detach --force $(HEAD_REF)
@@ -157,18 +157,21 @@ upgrading-module-test-$(VERSION):
 	composer install
 	# upgrade, not install: `install` on an installed module never runs upgrade/*.php
 	docker exec -i prestashop-$(module)-$(VERSION) sh -c "cd /var/www/html && php  bin/console prestashop:module upgrade $(module)"
-	$(MAKE) VERSION=$(VERSION) assert-module-version EXPECTED=$(MODULE_VERSION)
+	$(call assert_module_version,$(MODULE_VERSION))
 
-# asserts the shop really records the module version we expect. PrestaShop reports
-# success for no-op installs, so without this the upgrade leg cannot fail.
-assert-module-version:
+# Asserts the shop really records the version we expect. PrestaShop reports success
+# for no-op installs, so without this the legs above cannot fail. Has to be a canned
+# recipe, not a target: the tag checkout replaces this Makefile on disk with v5.2.0's,
+# so a $(MAKE) recursion would look for a target that does not exist there.
+define assert_module_version
 	@installed=$$(mysql -h 127.0.0.1 -P 9002 --protocol=tcp -u root -pprestashop -N -B \
 		-e "SELECT version FROM ps_module WHERE name = '$(module)'" prestashop 2>/dev/null); \
-	if [ "$$installed" != "$(EXPECTED)" ]; then \
-		echo "FAIL: expected the shop to report module version $(EXPECTED), got '$$installed'"; \
+	if [ "$$installed" != "$(1)" ]; then \
+		echo "FAIL: expected the shop to report module version $(1), got '$$installed'"; \
 		exit 1; \
 	fi; \
 	echo "OK: shop reports module version $$installed"
+endef
 
 prepare-zip:
 	composer install --no-dev --optimize-autoloader --classmap-authoritative

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ module = mollie
 HEAD_REF := $(shell git rev-parse HEAD)
 MODULE_VERSION := $(shell sed -n "s/.*this->version = '\([0-9.]*\)'.*/\1/p" mollie.php | head -1)
 LOCK_BACKUP := $(ROOT_DIR)/../composer.lock.upgrading-module-test
+# The oldest release in the supported window: Mollie's compatibility table pairs
+# PS 1.7.6 - 9.0.0 with Mollie 6, and there is no v6.0.0 tag, only betas.
+BASE_TAG := v6.0.1
 
 # target: fix-lint			- Launch php cs fixer
 fix-lint:
@@ -131,35 +134,41 @@ e2e-tests-ui:
 	npx playwright install chromium
 	cd tests/e2e && npx playwright test --ui
 
-# checking the module upgrading - installs v5.2.0 then upgrades to the commit under test
+# checking the module upgrading - installs $(BASE_TAG) then upgrades to the commit under test
 upgrading-module-test-$(VERSION):
 	git fetch --tags --force
 	# e2eh$(VERSION) leaves the module installed at the current version, and
 	# `module install` on an installed module is a no-op that still exits 0. Without
-	# this the shop never goes back to 5.2.0 and the upgrade leg has nothing to
+	# this the shop never goes back to $(BASE_TAG) and the upgrade leg has nothing to
 	# upgrade - the job goes green having tested nothing. Uninstall while the
 	# current code is still checked out, so it matches the schema it created.
 	docker exec -i prestashop-$(module)-$(VERSION) sh -c "cd /var/www/html && php  bin/console prestashop:module uninstall $(module)"
-	# A real checkout of the tag, not `git checkout v5.2.0 .`. The partial form
-	# restores the tag's files but never deletes files added after it, so
-	# config/services.yml survived and kept declaring
-	# Mollie\Subscription\...\SubscriptionFAQController while composer rebuilt the
-	# autoloader from v5.2.0's composer.json, which has no such namespace. The
-	# install then died compiling the Symfony container.
-	# The branch gitignores composer.lock but v5.2.0 tracks one, so the tag checkout
-	# overwrites the lock `composer update` just produced and the checkout back to the
-	# branch deletes it. Without it the second composer install silently turns into a
-	# full update against github.com. Keep the head's lock aside instead.
+	# A real checkout of the tag, not `git checkout $(BASE_TAG) .`. The partial form
+	# restores the tag's files but never deletes files added after it, so everything
+	# the branch added since - shared/, config/services.yml entries - stayed behind
+	# and got compiled against an autoloader composer had just rebuilt from the tag's
+	# composer.json, which knows nothing about them.
+	# composer.lock is gitignored on the branch and untracked in the tag, so keep the
+	# head's aside: the tag needs its own resolve (league/container 2.5.0 against the
+	# branch's 3.3.3, among others) and the head must not inherit the result.
 	cp composer.lock $(LOCK_BACKUP)
-	git checkout --detach --force v5.2.0
-	composer install
-	# installing 5.2.0 module
+	git checkout --detach --force $(BASE_TAG)
+	rm -f composer.lock
+	# The tag's require-dev pins roave/security-advisories dev-latest, which always
+	# resolves to today's advisory list and by now conflicts with every guzzlehttp/psr7
+	# the tag's runtime constraints allow, so a release this old can no longer be
+	# resolved. --no-dev is not enough, composer still solves require-dev. Drop the
+	# package outright: it is an install-time guard and the shop only needs the runtime
+	# set. The checkout back to HEAD_REF undoes the composer.json edit.
+	composer remove --dev roave/security-advisories --no-update --no-interaction
+	composer update --no-dev
+	# installing $(BASE_TAG) module
 	docker exec -i prestashop-$(module)-$(VERSION) sh -c "cd /var/www/html && php  bin/console prestashop:module install $(module)"
-	$(call assert_module_version,5.2.0)
+	$(call assert_module_version,$(patsubst v%,%,$(BASE_TAG)))
 	# the module under test - HEAD_REF, not develop, or the upgrade leg asserts
 	# against develop and never sees the commit being tested
 	git checkout --detach --force $(HEAD_REF)
-	# the autoloader is still v5.2.0's at this point
+	# the autoloader is still the tag's at this point
 	mv $(LOCK_BACKUP) composer.lock
 	composer install
 	# Not `bin/console prestashop:module upgrade`: that pulls the released module from

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 # Changelog #
 
+## Changes in release 6.4.6
++ Fixed a fatal error when upgrading the module from a version older than 5.3.0
+
 ## Changes in release 6.4.5
 + New payment method: Wero, available on the Payments API
 + New payment method: Billink, available on the Payments API for consumer purchases up to 2,500.00 EUR

--- a/upgrade/Upgrade-5.3.0.php
+++ b/upgrade/Upgrade-5.3.0.php
@@ -10,7 +10,7 @@
  */
 
 use Mollie\Config\Config;
-use Mollie\Install\Installer;
+use Mollie\Install\OrderStateInstaller;
 
 if (!defined('_PS_VERSION_')) {
     exit;
@@ -24,10 +24,10 @@ function upgrade_module_5_3_0(Mollie $module)
     Configuration::deleteByName('MOLLIE_PROFILE_ID');
     Configuration::updateValue(Config::MOLLIE_MAIL_WHEN_CHARGEBACK, true);
 
-    /** @var Installer $installer */
-    $installer = $module->getService(Installer::class);
+    /** @var OrderStateInstaller $orderStateInstaller */
+    $orderStateInstaller = $module->getService(OrderStateInstaller::class);
 
-    $installer->createChargedbackState();
+    $orderStateInstaller->install();
 
     return true;
 }


### PR DESCRIPTION
The `Module-upgrading-check` job is supposed to install an old release, upgrade it to the code in the PR, and prove the upgrade worked. It was doing none of the three, and every defect was hidden behind the one before it.

### What was broken

**1. The shop never booted.** `docker-compose.1785.yml` hands `DB_PASSWD` to the PrestaShop container and `PS_INSTALL_AUTO` uses it against MySQL, whose root password is `prestashop`. The workflow never set it, so compose substituted an empty string, the auto-install could not authenticate and Apache never started. Every `prestashop:module ...` step then ran against nothing, returned in under 250 ms and exited 0. Locally the Makefile does `include .env`, which is why this only ever failed in CI.

**2. The tag checkout was partial.** `git checkout <tag> .` restores the tag's files but never deletes files added after it, so `config/services.yml` survived, kept declaring `SubscriptionFAQController`, and was compiled against an autoloader composer had just rebuilt from the tag's `composer.json`. Now a real `git checkout --detach --force`.

**3. The install was a no-op.** `e2eh1785` leaves the module installed, and `module install` on an installed module returns 0 without doing anything, so the shop never went back to the old release and the upgrade had nothing to upgrade. The target now uninstalls first, while the current code is still checked out and matches the schema it created.

**4. It upgraded the Addons release, not the PR.** The big one. PS 1.7.8 `ModuleManager::upgrade()` calls `setModuleOnDiskFromAddons()` before running any upgrade file, which downloads the published zip over `/var/www/html/modules/mollie` - a bind mount of the checkout. Locally this rewrote 1473 working-tree files in one second and left `changelog.md` holding the released blob. The console command has no `--source`, so it is replaced by `.docker/upgrade-module.php`, which boots the kernel (upgrade files reach for Symfony services, and `SymfonyContainer::getInstance()` needs a booted `$kernel`), reads `database_version` from `ps_module`, runs the local `upgrade/*.php` through `initUpgradeModule()` + `runUpgradeModule()`, and exits non-zero with the failing file and line instead of a bare fatal.

**5. The return leg had no composer.lock.** It is gitignored on the branch but tracked in the old tags, so the round trip deleted it and `composer install` silently became a full resolve that died on the anonymous GitHub rate limit. The head's lock is now kept aside, and the job sets `COMPOSER_AUTH` since it resolves twice.

**6. The old tag can no longer be resolved.** Its `require-dev` pins `roave/security-advisories dev-latest`, always today's advisory list, which now conflicts with every `guzzlehttp/psr7` the tag allows. `--no-dev` does not help, composer still solves require-dev. The tag is resolved with that package removed.

### What makes it a test now

The target asserts the shop's own `ps_module.version` at both ends, so a vacuous run fails instead of going green. It also returns to the commit under test rather than `develop`, and the base is `v6.0.1`, the oldest release in Mollie's compatibility table (PS 1.7.6 - 9.0.0 pairs with Mollie 6; there is no v6.0.0 tag, only betas). That pin needs bumping when Mollie 6 leaves support.

### Product bug this uncovered

`upgrade/Upgrade-5.3.0.php` called `Installer::createChargedbackState()`, removed in `74ee7c787` on 2023-07-18, so every merchant upgrading from below 5.3.0 hit a fatal. It now calls `OrderStateInstaller::install()`, the same thing `Upgrade-4.2.0.php` does, idempotent through `validateIfStatusExists()`. Changelog entry added under 6.4.6.

The same orphaned calls exist in `Upgrade-4.0.7.php` and `Upgrade-4.1.0.php`, left alone: Mollie 4 only ever supported PrestaShop 1.6.1, outside the module's `ps_versions_compliancy`.

### Verification

Run locally from `docker compose down -v`, on the v6.0.1 base:

```
E2E_EXIT=0
OK: shop reports module version 6.0.1
Upgraded mollie from 6.0.1 to 6.4.5, 13 upgrade file(s) applied.
OK: shop reports module version 6.4.5
UPGRADE_EXIT=0
```

Negative test on a v5.2.0 base, which does run `Upgrade-5.3.0.php`: with the fix it applies 17 upgrade files and lands on 6.4.5; with the old `createChargedbackState()` call put back the runner prints the file and line, exits 1, and `ps_module.version` stays at 5.2.0.

Note the workflow triggers on `pull_request: types: [opened, reopened]` only, so pushing to a branch does not re-run it.
