### PR TITLE
PIPRES-818 Add numeric order ID as a placeholder in the payment method description

### DIFF
--- a/controllers/admin/AdminMolliePaymentMethodsController.php
+++ b/controllers/admin/AdminMolliePaymentMethodsController.php
@@ -218,7 +218,7 @@ class AdminMolliePaymentMethodsController extends ModuleAdminController
                 'saveSettings' => $this->module->l('Save Settings', self::FILE_NAME),
 
                 'transactionDescriptionHelp' => $this->module->l('Use any of the following variables to create a transaction description for payments that use this method:', self::FILE_NAME),
-                'transactionDescriptionVariables' => $this->module->l('{orderNumber}, {storeName}, {countryCode}, {cart.id}, {order.reference}, {customer.firstname}, {customer.lastname}, {customer.company}', self::FILE_NAME),
+                'transactionDescriptionVariables' => $this->module->l('{orderNumber}, {storeName}, {countryCode}, {cart.id}, {order.id}, {order.reference}, {customer.firstname}, {customer.lastname}, {customer.company}', self::FILE_NAME),
 
                 'paymentMethodNotFound' => $this->module->l('Payment method not found', self::FILE_NAME),
                 'settingsSavedSuccessfully' => $this->module->l('Settings saved successfully!', self::FILE_NAME),

--- a/src/Utility/TextGeneratorUtility.php
+++ b/src/Utility/TextGeneratorUtility.php
@@ -55,6 +55,7 @@ class TextGeneratorUtility
         $filters = [
             '%' => $cart->id,
             '{cart.id}' => $cart->id,
+            '{order.id}' => $order->id,
             '{order.reference}' => $order->reference,
             '{customer.firstname}' => null === $buyer ? '' : $buyer->firstname,
             '{customer.lastname}' => null === $buyer ? '' : $buyer->lastname,


### PR DESCRIPTION
## Summary
- A merchant testing on PrestaShop wants to include PrestaShop's numeric order ID (the "ID" column in the back-office Orders list, `Order::$id`) in the Mollie payment method description.
- Previously only the alphanumeric order reference was available via `{order.reference}` / `{orderNumber}`.
- Adds a new `{order.id}` placeholder mapped to `$order->id` in `TextGeneratorUtility::generateDescriptionFromCart()` and lists it in the admin UI's placeholder hint.

## Jira
PIPRES-818

## Test plan
- [ ] Configure a payment method description using `{order.id}` in the Mollie back office settings.
- [ ] Place a test order and confirm the generated payment description contains the numeric order ID (not the alphanumeric reference).
- [ ] Confirm existing placeholders (`{order.reference}`, `{orderNumber}`, etc.) still resolve as before.