### PR TITLE
PIPRES-821 Fix wrong attribute value appended in order confirmation mail

### DIFF
--- a/src/Service/MailService.php
+++ b/src/Service/MailService.php
@@ -219,11 +219,10 @@ class MailService
 
             $product_price = PS_TAX_EXC == Product::getTaxCalculationMethod() ? Tools::ps_round($price, 2) : $price_wt;
 
-            $attribute = $this->productAttributeAdapter->getProductAttribute((int) $product['product_attribute_id'], $this->context->language->id);
             $product_var_tpl = [
                 'id_product' => $product['id_product'],
                 'reference' => $product['reference'],
-                'name' => $product['product_name'] . (\Validate::isLoadedObject($attribute) ? ' - ' . $attribute->name : ''),
+                'name' => $product['product_name'],
                 'price' => $this->tools->displayPrice($product_price * $product['product_quantity'], $this->context->currency),
                 'quantity' => $product['product_quantity'],
                 'customization' => [],


### PR DESCRIPTION
## Summary
- Fixes #1497: order confirmation emails could append an unrelated attribute value to the product name for combinations.
- `ProductAttributeAdapter::getProductAttribute()` looked up a combination ID (`id_product_attribute`) as if it were an attribute-value ID (`id_attribute`) — on a numeric collision between the two ID spaces, an unrelated attribute value's name got appended (e.g. `Product name (Flavor: Vanilla) - 5cm`).
- `$product['product_name']` from `Order::getProducts()` already contains the correct, combination-specific text (set by PrestaShop core's `OrderDetail::create()` via `Cart::cacheSomeAttributesLists()`), so the extra lookup is both wrong and redundant. Removed it.

Jira: PIPRES-821

## Test plan
- [ ] Place an order for a product with a combination whose `id_product_attribute` collides with an unrelated `attribute.id_attribute` row and confirm the order confirmation email shows only the correct combination text, with no extra suffix.
- [ ] Regression check: order confirmation emails for simple products and normal combinations (no ID collision) still show the correct product name.