### PR TITLE
PIPRES-822 Fix untranslated Mollie order/subscription email subjects

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 # Changelog #
 
+## Changes in release 6.4.6
++ Fixed the order confirmation email subject being sent in English instead of the language of the order
+
 ## Changes in release 6.4.5
 + New payment method: Wero, available on the Payments API
 + New payment method: Billink, available on the Payments API for consumer purchases up to 2,500.00 EUR

--- a/src/Service/MailService.php
+++ b/src/Service/MailService.php
@@ -111,7 +111,7 @@ class MailService
         Mail::Send(
             (int) $order->id_lang,
             'order_conf',
-            $this->context->getTranslator()->trans('Order confirmation', [], 'Emails.Subject', $orderLanguage->locale),
+            $this->context->getTranslatorFromLocale($orderLanguage->locale)->trans('Order confirmation', [], 'Emails.Subject'),
             $data,
             $customer->email,
 

--- a/src/Service/MailService.php
+++ b/src/Service/MailService.php
@@ -71,10 +71,12 @@ class MailService
 
     public function sendSecondChanceMail(Customer $customer, $checkoutUrl, $methodName, $shopId)
     {
+        $customerLanguage = new Language((int) $customer->id_lang);
+
         Mail::send(
             $customer->id_lang,
             'mollie_payment',
-            Mail::l('Order payment'),
+            $this->module->l('Order payment', self::FILE_NAME, $customerLanguage->locale),
             [
                 '{checkoutUrl}' => $checkoutUrl,
                 '{firstName}' => $customer->firstname,
@@ -104,11 +106,12 @@ class MailService
         $data = $this->getOrderConfData($order, $orderStateId);
         $fileAttachment = $this->getFileAttachment($orderStateId, $order);
         $customer = $order->getCustomer();
+        $orderLanguage = new Language((int) $order->id_lang);
 
         Mail::Send(
             (int) $order->id_lang,
             'order_conf',
-            Mail::l('Order confirmation', (int) $order->id_lang),
+            $this->context->getTranslator()->trans('Order confirmation', [], 'Emails.Subject', $orderLanguage->locale),
             $data,
             $customer->email,
 
@@ -126,11 +129,12 @@ class MailService
     public function sendSubscriptionCancelWarningEmail(int $recurringOrderId): void
     {
         $data = $this->generalSubscriptionMailDataProvider->run($recurringOrderId);
+        $subscriptionLanguage = new Language($data->getLangId());
 
         Mail::Send(
             $data->getLangId(),
             'mollie_subscription_cancel',
-            sprintf(Mail::l('Your payment for the subscription of %s failed', $data->getLangId()), $data->getProductName()),
+            sprintf($this->module->l('Your payment for the subscription of %s failed', self::FILE_NAME, $subscriptionLanguage->locale), $data->getProductName()),
             $data->toArray(),
             $data->getCustomerEmail(),
             implode(' ', [$data->getFirstName(), $data->getLastName()]),
@@ -150,11 +154,12 @@ class MailService
     public function sendSubscriptionPaymentFailWarningMail(int $recurringOrderId): void
     {
         $data = $this->generalSubscriptionMailDataProvider->run($recurringOrderId);
+        $subscriptionLanguage = new Language($data->getLangId());
 
         Mail::Send(
             $data->getLangId(),
             'mollie_subscription_payment_failed',
-            sprintf(Mail::l('Your subscription for %s cancelled', $data->getLangId()), $data->getProductName()),
+            sprintf($this->module->l('Your subscription for %s cancelled', self::FILE_NAME, $subscriptionLanguage->locale), $data->getProductName()),
             $data->toArray(),
             $data->getCustomerEmail(),
             implode(' ', [$data->getFirstName(), $data->getLastName()]),
@@ -174,11 +179,12 @@ class MailService
     public function sendSubscriptionCarrierUpdateMail(int $recurringOrderId): bool
     {
         $data = $this->generalSubscriptionMailDataProvider->run($recurringOrderId);
+        $subscriptionLanguage = new Language($data->getLangId());
 
         $result = Mail::Send(
             $data->getLangId(),
             'mollie_subscription_carrier_update',
-            sprintf(Mail::l('Your subscription for %s carrier was updated', $data->getLangId()), $data->getProductName()),
+            sprintf($this->module->l('Your subscription for %s carrier was updated', self::FILE_NAME, $subscriptionLanguage->locale), $data->getProductName()),
             $data->toArray(),
             $data->getCustomerEmail(),
             implode(' ', [$data->getFirstName(), $data->getLastName()]),


### PR DESCRIPTION
## Summary
- Fixes #1498: order confirmation, second-chance, and subscription warning email subjects always render in English regardless of shop language.
- `Mail::l()` only reads legacy `mails/<iso>/lang.php` catalogues. PrestaShop core no longer ships these (removed in favor of the Symfony translator), so `Mail::l()` is now a permanent no-op for every subject built with it in `MailService`.
- `sendOrderConfMail()` — "Order confirmation" is a core PrestaShop string with a real `Emails.Subject` translation. Switched to `$this->context->getTranslator()->trans(..., 'Emails.Subject', $orderLanguage->locale)`, matching what core's own `PaymentModule::validateOrder()` already does for the same subject.
- `sendSecondChanceMail()` and the three subscription warning senders use Mollie-specific strings that were never part of any core/theme mail catalogue, so `Mail::l()` could never resolve them regardless of PrestaShop version. Switched these to `$this->module->l($string, self::FILE_NAME, $locale)` — the module's own working translation mechanism (backed by `translations/<iso>.php`), already used elsewhere in this same class (e.g. the `{carrier}` fallback).
- Each call site now resolves the actual recipient/order language explicitly via `new Language($idLang)`, rather than relying on ambient context language.

Jira: PIPRES-822

## Test plan
- [ ] Set the shop/order language to a non-English locale with translated `Emails.Subject` content (e.g. German) and confirm the `order_conf` email subject is translated.
- [ ] Trigger the second-chance and subscription warning emails and confirm the subject resolves without error (falls back to the English source string until module translations are added for those Mollie-specific strings, but no longer permanently breaks via `Mail::l()`).
- [ ] Regression check: default English-shop emails still send with the same subjects as before.