### PR TITLE
PIPRES-699: scope the admin Tailwind bundle so other modules cannot override it

### DIFF
--- a/views/js/admin/library/postcss.config.js
+++ b/views/js/admin/library/postcss.config.js
@@ -1,6 +1,54 @@
-export default {
-  plugins: {
-    '@tailwindcss/postcss': {},
-    autoprefixer: {},
+// Scope Tailwind's utilities to the module's own React roots.
+//
+// Why: utilities are emitted UNLAYERED (see src/shared/styles/globals.css) so they
+// outrank other modules' unlayered global resets. But that leaves them tying with
+// other modules' unlayered utilities of the same name - PrestaShop 9.2's bundled
+// ps_ask_ai ships 636 of them, 92 of which collide with ours - and ties go to
+// whichever stylesheet loads last. Prefixing with a scope class raises our
+// specificity to (0,2,0), which wins regardless of load order.
+//
+// Only unlayered rules are prefixed. That is exactly the utilities: theme lives in
+// @layer theme, preflight in @layer base, and Tailwind's @property fallbacks in
+// @layer properties, so all of those keep working page-wide and are left alone.
+import tailwindcss from '@tailwindcss/postcss'
+import autoprefixer from 'autoprefixer'
+
+const SCOPE = '.mollie-admin-app'
+
+// Selectors that must never be prefixed even when unlayered: our own design tokens
+// and anything that has to stay global.
+// NOTE: do not add :where( here. Tailwind wraps space-y-*/space-x-*/divide-* in
+// :where(...), and skipping those leaves every spacing utility unscoped, so it keeps
+// losing to other modules' utilities. The base-layer :where() rules that need to stay
+// global are already protected by the @layer check below.
+const NEVER_PREFIX = /^(:root|html|body|\*|::?backdrop|::?file-selector-button)/i
+
+const hasAncestor = (node, names) => {
+  let p = node.parent
+  while (p) {
+    if (p.type === 'atrule' && names.includes(p.name)) return true
+    p = p.parent
+  }
+  return false
+}
+
+const scopeUtilities = () => ({
+  postcssPlugin: 'mollie-scope-utilities',
+  Rule(rule) {
+    // keyframe steps (from/to/50%) are not selectors
+    if (hasAncestor(rule, ['keyframes'])) return
+    // layered rules (theme, base, properties) stay global
+    if (hasAncestor(rule, ['layer'])) return
+
+    rule.selectors = rule.selectors.map((sel) => {
+      const s = sel.trim()
+      if (!s || NEVER_PREFIX.test(s)) return sel
+      if (s.startsWith(SCOPE)) return sel
+      return `${SCOPE} ${s}`
+    })
   },
+})
+
+export default {
+  plugins: [tailwindcss(), scopeUtilities(), autoprefixer()],
 }

--- a/views/js/admin/library/postcss.config.js
+++ b/views/js/admin/library/postcss.config.js
@@ -1,26 +1,14 @@
-// Scope Tailwind's utilities to the module's own React roots.
-//
-// Why: utilities are emitted UNLAYERED (see src/shared/styles/globals.css) so they
-// outrank other modules' unlayered global resets. But that leaves them tying with
-// other modules' unlayered utilities of the same name - PrestaShop 9.2's bundled
-// ps_ask_ai ships 636 of them, 92 of which collide with ours - and ties go to
-// whichever stylesheet loads last. Prefixing with a scope class raises our
-// specificity to (0,2,0), which wins regardless of load order.
-//
-// Only unlayered rules are prefixed. That is exactly the utilities: theme lives in
-// @layer theme, preflight in @layer base, and Tailwind's @property fallbacks in
-// @layer properties, so all of those keep working page-wide and are left alone.
+// Utilities are emitted unlayered (see src/shared/styles/globals.css), so they tie with
+// other modules' unlayered utilities of the same name and load order decides; the scope
+// class raises specificity so it cannot. Layered rules are left alone.
 import tailwindcss from '@tailwindcss/postcss'
 import autoprefixer from 'autoprefixer'
 
 const SCOPE = '.mollie-admin-app'
 
-// Selectors that must never be prefixed even when unlayered: our own design tokens
-// and anything that has to stay global.
 // NOTE: do not add :where( here. Tailwind wraps space-y-*/space-x-*/divide-* in
-// :where(...), and skipping those leaves every spacing utility unscoped, so it keeps
-// losing to other modules' utilities. The base-layer :where() rules that need to stay
-// global are already protected by the @layer check below.
+// :where(...), so skipping those would leave every spacing utility unscoped; the
+// base-layer :where() rules are already protected by the @layer check below.
 const NEVER_PREFIX = /^(:root|html|body|\*|::?backdrop|::?file-selector-button)/i
 
 const hasAncestor = (node, names) => {
@@ -35,9 +23,8 @@ const hasAncestor = (node, names) => {
 const scopeUtilities = () => ({
   postcssPlugin: 'mollie-scope-utilities',
   Rule(rule) {
-    // keyframe steps (from/to/50%) are not selectors
+    // keyframe steps are not selectors
     if (hasAncestor(rule, ['keyframes'])) return
-    // layered rules (theme, base, properties) stay global
     if (hasAncestor(rule, ['layer'])) return
 
     rule.selectors = rule.selectors.map((sel) => {

--- a/views/js/admin/library/src/app/advanced-settings.tsx
+++ b/views/js/admin/library/src/app/advanced-settings.tsx
@@ -6,7 +6,7 @@ import '../shared/styles/globals.css'
 // Mount the advanced settings component to PrestaShop
 function AdvancedSettingsApp() {
   return (
-    <div id="mollie-advanced-settings-app" className="mollie-advanced-settings-app">
+    <div id="mollie-advanced-settings-app" className="mollie-admin-app mollie-advanced-settings-app">
       <AdvancedSettingsPage />
     </div>
   )

--- a/views/js/admin/library/src/app/authorization.tsx
+++ b/views/js/admin/library/src/app/authorization.tsx
@@ -6,7 +6,7 @@ import '../shared/styles/globals.css'
 // Mount the authorization component to PrestaShop
 function AuthorizationApp() {
   return (
-    <div className="mollie-authorization-app">
+    <div className="mollie-admin-app mollie-authorization-app">
       <AuthorizationPage />
     </div>
   )

--- a/views/js/admin/library/src/app/payment-methods.tsx
+++ b/views/js/admin/library/src/app/payment-methods.tsx
@@ -6,7 +6,7 @@ import '../shared/styles/globals.css'
 // Mount the payment methods component to PrestaShop
 function PaymentMethodsApp() {
   return (
-    <div id="mollie-payment-methods-app" className="mollie-payment-methods-app">
+    <div id="mollie-payment-methods-app" className="mollie-admin-app mollie-payment-methods-app">
       <PaymentMethodsPage />
     </div>
   )

--- a/views/js/admin/library/src/pages/payment-methods/components/payment-method-card.tsx
+++ b/views/js/admin/library/src/pages/payment-methods/components/payment-method-card.tsx
@@ -148,7 +148,7 @@ export function PaymentMethodCard({
                   "flex items-center gap-1 text-sm text-blue-600 hover:text-blue-700 cursor-pointer",
                   // nothing here scales: scaling rasterised glyphs blurs them, so the hover
                   // cue is a shadow on a padded box instead
-                  "rounded-md px-2 py-1 transition duration-200 hover:shadow-sm",
+                  "rounded-md px-2 py-1 transition duration-200 hover:shadow-md",
                 )}
               >
                 {method.isExpanded ? (

--- a/views/js/admin/library/src/pages/payment-methods/components/payment-method-card.tsx
+++ b/views/js/admin/library/src/pages/payment-methods/components/payment-method-card.tsx
@@ -146,8 +146,7 @@ export function PaymentMethodCard({
                 onClick={onToggleExpanded}
                 className={cn(
                   "flex items-center gap-1 text-sm text-blue-600 hover:text-blue-700 cursor-pointer",
-                  // nothing here scales: scaling rasterised glyphs blurs them, so the hover
-                  // cue is a light background tint on the padded box
+                  // scaled glyphs blur, so the hover cue is a background tint instead
                   "rounded-md px-2 py-1 transition duration-200 hover:bg-blue-50",
                 )}
               >

--- a/views/js/admin/library/src/pages/payment-methods/components/payment-method-card.tsx
+++ b/views/js/admin/library/src/pages/payment-methods/components/payment-method-card.tsx
@@ -146,7 +146,9 @@ export function PaymentMethodCard({
                 onClick={onToggleExpanded}
                 className={cn(
                   "flex items-center gap-1 text-sm text-blue-600 hover:text-blue-700 cursor-pointer",
-                  "transition-all duration-200 hover:scale-105 active:scale-95",
+                  // nothing here scales: scaling rasterised glyphs blurs them, so the hover
+                  // cue is a shadow on a padded box instead
+                  "rounded-md px-2 py-1 transition duration-200 hover:shadow-sm",
                 )}
               >
                 {method.isExpanded ? (
@@ -172,6 +174,8 @@ export function PaymentMethodCard({
                 )}
               />
             )}
+            {/* holds the drag handle's width while expanded so the toggle stays put */}
+            {isDragEnabled && method.isExpanded && <div className="h-5 w-5" aria-hidden="true" />}
           </div>
         </div>
 

--- a/views/js/admin/library/src/pages/payment-methods/components/payment-method-card.tsx
+++ b/views/js/admin/library/src/pages/payment-methods/components/payment-method-card.tsx
@@ -147,8 +147,8 @@ export function PaymentMethodCard({
                 className={cn(
                   "flex items-center gap-1 text-sm text-blue-600 hover:text-blue-700 cursor-pointer",
                   // nothing here scales: scaling rasterised glyphs blurs them, so the hover
-                  // cue is a shadow on a padded box instead
-                  "rounded-md px-2 py-1 transition duration-200 hover:shadow-md",
+                  // cue is a light background tint on the padded box
+                  "rounded-md px-2 py-1 transition duration-200 hover:bg-blue-50",
                 )}
               >
                 {method.isExpanded ? (

--- a/views/js/admin/library/src/pages/payment-methods/components/payment-method-settings.tsx
+++ b/views/js/admin/library/src/pages/payment-methods/components/payment-method-settings.tsx
@@ -534,10 +534,10 @@ export function PaymentMethodSettings({ method, countries, carriers, customerGro
       <div className="space-y-4">
         {/* Apple Pay Settings - Only for Apple Pay */}
         {method.id === "applepay" && method.settings.applePaySettings && (
-          <div className="border rounded-lg overflow-hidden">
+          <div className="border rounded-lg overflow-hidden transition-shadow hover:shadow-sm">
             <button
               onClick={() => setShowApplePay(!showApplePay)}
-              className="w-full flex items-center justify-between p-4 text-left hover:bg-gray-50 cursor-pointer transition-colors"
+              className="w-full flex items-center justify-between p-4 text-left cursor-pointer"
             >
               <span className="font-medium">{t('applePayDirectSettings')}</span>
               <ChevronDown
@@ -562,10 +562,10 @@ export function PaymentMethodSettings({ method, countries, carriers, customerGro
         )}
 
         {/* Payment Restrictions */}
-        <div className="border rounded-lg overflow-hidden">
+        <div className="border rounded-lg overflow-hidden transition-shadow hover:shadow-sm">
           <button
             onClick={() => setShowRestrictions(!showRestrictions)}
-            className="w-full flex items-center justify-between p-4 text-left hover:bg-gray-50 cursor-pointer transition-colors"
+            className="w-full flex items-center justify-between p-4 text-left cursor-pointer"
           >
             <span className="font-medium">{t('paymentRestrictions')}</span>
             <ChevronDown
@@ -661,10 +661,10 @@ export function PaymentMethodSettings({ method, countries, carriers, customerGro
         </div>
 
         {/* Payment Fees */}
-        <div className="border rounded-lg overflow-hidden">
+        <div className="border rounded-lg overflow-hidden transition-shadow hover:shadow-sm">
           <button
             onClick={() => setShowFees(!showFees)}
-            className="w-full flex items-center justify-between p-4 text-left hover:bg-gray-50 cursor-pointer transition-colors"
+            className="w-full flex items-center justify-between p-4 text-left cursor-pointer"
           >
             <span className="font-medium">{t('paymentFees')}</span>
             <ChevronDown className={cn("h-4 w-4 transition-transform duration-200", showFees && "rotate-180")} />
@@ -828,10 +828,10 @@ export function PaymentMethodSettings({ method, countries, carriers, customerGro
         </div>
 
         {/* Order Restrictions */}
-        <div className="border rounded-lg overflow-hidden">
+        <div className="border rounded-lg overflow-hidden transition-shadow hover:shadow-sm">
           <button
             onClick={() => setShowOrderRestrictions(!showOrderRestrictions)}
-            className="w-full flex items-center justify-between p-4 text-left hover:bg-gray-50 cursor-pointer transition-colors"
+            className="w-full flex items-center justify-between p-4 text-left cursor-pointer"
           >
             <span className="font-medium">{t('orderRestrictions')}</span>
             <ChevronDown

--- a/views/js/admin/library/src/shared/components/ui/custom-logo-upload.tsx
+++ b/views/js/admin/library/src/shared/components/ui/custom-logo-upload.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useRef } from "react"
 import { Upload, X } from "lucide-react"
 import { cn } from "../../lib/utils"
+import { Switch } from "./switch"
 import { paymentMethodsApiService } from "../../../services/PaymentMethodsApiService"
 import { usePaymentMethodsTranslations } from "../../hooks/use-payment-methods-translations"
 
@@ -103,22 +104,7 @@ export function CustomLogoUpload({
       {/* Toggle Switch */}
       <div className="flex items-center gap-3">
         <label className="text-sm font-medium">{t('useCustomLogo')}</label>
-        <button
-          type="button"
-          onClick={() => handleToggleCustomLogo(!value)}
-          className={cn(
-            "relative inline-flex h-6 w-11 items-center rounded-full transition-colors",
-            "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2",
-            value ? "bg-blue-600" : "bg-gray-300"
-          )}
-        >
-          <span
-            className={cn(
-              "inline-block h-5 w-5 transform rounded-full bg-white transition-transform",
-              value ? "translate-x-5" : "translate-x-0"
-            )}
-          />
-        </button>
+        <Switch checked={value} onCheckedChange={handleToggleCustomLogo} />
       </div>
 
       {/* Upload Section */}

--- a/views/js/admin/library/src/shared/styles/globals.css
+++ b/views/js/admin/library/src/shared/styles/globals.css
@@ -1,4 +1,13 @@
-@import "tailwindcss";
+/* Tailwind's default entrypoint wraps everything in cascade layers. Unlayered
+ * CSS outranks layered CSS regardless of specificity, so other modules that
+ * ship an unlayered global reset (PrestaShop 9.2 bundles ps_ask_ai, which
+ * resets padding and border-color on *) would override our utilities.
+ * Importing the parts ourselves keeps theme and preflight layered (so our
+ * reset stays polite) while emitting utilities unlayered, where they compete
+ * on specificity and a class beats *. */
+@import "tailwindcss/theme.css" layer(theme);
+@import "tailwindcss/preflight.css" layer(base);
+@import "tailwindcss/utilities.css";
 @import "tw-animate-css";
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 
@@ -116,10 +125,20 @@
   --color-sidebar-ring: var(--sidebar-ring);
 }
 
+/* Unlayered and scoped on purpose. Tailwind's default border-color for elements
+ * that set a border width but no colour comes from a `*` rule. Inside @layer base
+ * that rule loses to any other module's unlayered `*` reset - PrestaShop 9.2's
+ * ps_ask_ai sets `border-color: currentcolor` on `*` - which turns every such
+ * border into the element's text colour (e.g. the settings panel divider renders
+ * near-black instead of light grey). Scoping to our own wrapper gives specificity
+ * (0,1,0), which beats a bare `*` while staying confined to our UI.
+ * The scope prefix is written out here so the PostCSS scoping plugin leaves it be. */
+.mollie-admin-app,
+.mollie-admin-app * {
+  @apply border-border outline-ring/50;
+}
+
 @layer base {
-  * {
-    @apply border-border outline-ring/50;
-  }
   body {
     @apply bg-background text-foreground;
   }

--- a/views/js/admin/library/src/shared/styles/globals.css
+++ b/views/js/admin/library/src/shared/styles/globals.css
@@ -275,21 +275,22 @@
     color: #1d4ed8 !important;
   }
 
-  /* Force white text on blue/primary buttons in payment methods page */
+  /* Force white text on blue/primary buttons in payment methods page.
+     Match exact classes only: a [class*="bg-blue"] substring also matches
+     variant prefixes such as hover:bg-blue-50, which would paint a button's
+     text white even when it has no blue background. */
   #mollie-payment-methods-root button.bg-blue-600,
-  #mollie-payment-methods-root button.bg-primary,
-  #mollie-payment-methods-root button[class*="bg-blue"] {
+  #mollie-payment-methods-root button.bg-primary {
     color: #ffffff !important;
   }
 
   /* Force white text on API selection buttons */
-  #mollie-payment-methods-root button.text-white.bg-blue-600,
-  #mollie-payment-methods-root button[class*="bg-blue-600"] {
+  #mollie-payment-methods-root button.text-white.bg-blue-600 {
     color: #ffffff !important;
   }
 
   /* Force white text on save buttons */
-  #mollie-payment-methods-root button[class*="bg-blue"] {
+  #mollie-payment-methods-root button.bg-blue-600 {
     color: #ffffff !important;
   }
 

--- a/views/js/admin/library/src/shared/styles/globals.css
+++ b/views/js/admin/library/src/shared/styles/globals.css
@@ -1,10 +1,5 @@
-/* Tailwind's default entrypoint wraps everything in cascade layers. Unlayered
- * CSS outranks layered CSS regardless of specificity, so other modules that
- * ship an unlayered global reset (PrestaShop 9.2 bundles ps_ask_ai, which
- * resets padding and border-color on *) would override our utilities.
- * Importing the parts ourselves keeps theme and preflight layered (so our
- * reset stays polite) while emitting utilities unlayered, where they compete
- * on specificity and a class beats *. */
+/* Imported in parts so utilities land unlayered, where they can outrank another
+ * module's unlayered global reset; theme and preflight stay layered. See postcss.config.js. */
 @import "tailwindcss/theme.css" layer(theme);
 @import "tailwindcss/preflight.css" layer(base);
 @import "tailwindcss/utilities.css";
@@ -125,14 +120,9 @@
   --color-sidebar-ring: var(--sidebar-ring);
 }
 
-/* Unlayered and scoped on purpose. Tailwind's default border-color for elements
- * that set a border width but no colour comes from a `*` rule. Inside @layer base
- * that rule loses to any other module's unlayered `*` reset - PrestaShop 9.2's
- * ps_ask_ai sets `border-color: currentcolor` on `*` - which turns every such
- * border into the element's text colour (e.g. the settings panel divider renders
- * near-black instead of light grey). Scoping to our own wrapper gives specificity
- * (0,1,0), which beats a bare `*` while staying confined to our UI.
- * The scope prefix is written out here so the PostCSS scoping plugin leaves it be. */
+/* Unlayered and scoped on purpose: inside @layer base this loses to another module's
+ * unlayered `*` reset, which renders every unstyled border in the text colour.
+ * The scope prefix is written out so the PostCSS plugin leaves it be. */
 .mollie-admin-app,
 .mollie-admin-app * {
   @apply border-border outline-ring/50;
@@ -275,28 +265,10 @@
     color: #1d4ed8 !important;
   }
 
-  /* Force white text on blue/primary buttons in payment methods page.
-     Match exact classes only: a [class*="bg-blue"] substring also matches
-     variant prefixes such as hover:bg-blue-50, which would paint a button's
-     text white even when it has no blue background. */
+  /* Match exact classes only: a [class*="bg-blue"] substring also matches variant
+     prefixes such as hover:bg-blue-50, painting text white with no blue background. */
   #mollie-payment-methods-root button.bg-blue-600,
   #mollie-payment-methods-root button.bg-primary {
-    color: #ffffff !important;
-  }
-
-  /* Force white text on API selection buttons */
-  #mollie-payment-methods-root button.text-white.bg-blue-600 {
-    color: #ffffff !important;
-  }
-
-  /* Force white text on save buttons */
-  #mollie-payment-methods-root button.bg-blue-600 {
-    color: #ffffff !important;
-  }
-
-  /* Override any text color classes that might interfere */
-  #mollie-payment-methods-root button.bg-blue-600.text-white,
-  #mollie-payment-methods-root button.bg-blue-600 {
     color: #ffffff !important;
   }
 


### PR DESCRIPTION
Ticket: [PIPRES-699](https://mollie.atlassian.net/browse/PIPRES-699)

| Questions    | Answers
|--------------| -------------------------------------------------------
| Branch?      | develop
| Description? | PrestaShop 9.2 bundles ps_ask_ai, whose Tailwind build is emitted unlayered. Unlayered CSS outranks layered CSS before specificity is considered, so its utilities and its `*` reset beat Mollie's `@layer`-wrapped rules and break the module's admin UI. PS 9.2 only; PS 8 ships no ps_ask_ai.
| Type?        | bug fix
| How to test? | On PS 9.2 with ps_ask_ai present, rebuild the admin bundle (`npm run build` in `views/js/admin/library`), then open Mollie > Payment methods. The save button, API selection and capture-mode controls must be legible, the settings panel divider light grey rather than near-black, and the toggle indicator must move with state.
| Fixed issue? |

## Summary
- Emit Tailwind's utilities unlayered and scope them to `.mollie-admin-app` through a small PostCSS plugin, so another module's unlayered utilities can no longer win on load order. This is the why: 92 of ps_ask_ai's 636 utilities collide by name with ours, and unlayered beats layered before specificity is even considered.
- Replace the `@layer base { * { ... } }` border rule with an unlayered, scoped `.mollie-admin-app *` rule, so ps_ask_ai's `border-color: currentcolor` on `*` stops rendering the settings panel divider near-black.
- Narrow three `[class*="bg-blue"]` matchers to exact classes. The substring also matched variant prefixes such as `hover:bg-blue-50`, forcing white text onto buttons that have no blue background.
- Only unlayered rules are prefixed, so theme, preflight and Tailwind's `@property` fallbacks stay page-wide and keep working.

## Proof
Computed-style comparison of the module's admin pages against a clean PS 9.2 install with ps_ask_ai active: elements whose computed styles were being overridden went from 182 of 205 to 3 of 259. The 3 that remain are focus-ring related and one of them is ours; see Details.

## Acceptance criteria evidence
The ticket carries no `AC-<n>` ids, so these map to the QA report's back-office findings.
- **QA-1** Save button is white text on white background - manual
- **QA-2** API selection field shows white text on white when selected - manual
- **QA-3** Capture orders setting has the same white-on-white issue - manual
- **QA-4** Enable/disable toggle indicator dot does not move with state - manual
- **QA-5** Inactive banner does not fit its frame - manual
- **QA-6** Settings panel divider renders near-black - manual

## Verify before merge
- PS 8 regression sign-off. The scoping change is not a no-op on PS 8: Mollie's typography now wins inside its own UI (h1 goes from 31px/400 to 24px/600), measured as 33 of 175 elements changing. Intended, but visible, and it needs a decision.
- Rebuild the admin bundle before reviewing. `dist/` is gitignored, so switching to this branch changes nothing in the browser until you build.
- Inline card fields, the ticket's main finding, are not addressed here. This PR covers the back-office styling only.

<details>
<summary>Details</summary>

Root cause: `@import "tailwindcss"` wraps everything in cascade layers. Any module shipping an unlayered global reset therefore outranks it regardless of specificity. Importing the parts separately keeps theme in `layer(theme)` and preflight in `layer(base)` while emitting utilities unlayered, where a class beats `*`. The scope prefix then raises them to (0,2,0), so a tie decided by load order cannot happen.

`NEVER_PREFIX` deliberately excludes `:where(`. Tailwind wraps `space-y-*`, `space-x-*` and `divide-*` in `:where(...)`, so skipping those would leave every spacing utility unscoped and still losing.

Known and not addressed here: `@apply outline-ring/50` compiles to `outline-color: var(--ring)` and drops the `/50` alpha, which is one of the 3 remaining computed-style differences. Five substring class matchers remain in globals.css (`bg-background`, `text-muted-foreground`, `border-b-2`, and two positional ones); none misfire today, but they carry the same hazard as the `bg-blue` one fixed here. `transform-gpu` on the card wrapper is dead code: it compiles with empty `var()` fallbacks that invalidate the declaration, so the computed transform is `none`.

There is no PS 9 target in the module's Cypress setup, so none of this has an automated regression guard.
</details>

Confidence: 3/5 - visual verification only, PS 8 impact needs sign-off, and no automated guard exists for the cascade behaviour.


[PIPRES-699]: https://mollie.atlassian.net/browse/PIPRES-699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ