### PR TITLE
PIPRES-827: mount the card fields on the Hummingbird theme

### DIFF
--- a/views/js/front/mollie_iframe.js
+++ b/views/js/front/mollie_iframe.js
@@ -16,7 +16,7 @@ $(document).ready(function () {
     }
 
     var overridePrestaShopsAdditionalInformationHideFunctionality = function ($mollieContainer) {
-      var $additionalInformationContainer = $mollieContainer.closest('.additional-information');
+      var $additionalInformationContainer = $mollieContainer.closest('.js-additional-information');
 
       // this allows for us to have our custom hide functionality
       $additionalInformationContainer.addClass('mollie-credit-card-container__hide')
@@ -41,8 +41,12 @@ $(document).ready(function () {
 
     // if credit card is somehow preselected its hidden content will be displayed
     var isMollieCreditCardPreselected = function ($iframeContainer) {
-      var $additionalInformation = $iframeContainer.closest('.additional-information')
+      var $additionalInformation = $iframeContainer.closest('.js-additional-information')
       var id = $additionalInformation.attr('id')
+
+      if (!id) {
+        return false
+      }
 
       var paymentOptionPrefix = id.replace('-additional-information', '')
       var $paymentOption = $('#' + paymentOptionPrefix)
@@ -51,7 +55,7 @@ $(document).ready(function () {
     }
 
     if (isMollieCreditCardPreselected($mollieContainers)) {
-      showAdditionalInformation($mollieContainers.closest('.additional-information'))
+      showAdditionalInformation($mollieContainers.closest('.js-additional-information'))
     }
 
     var options = {
@@ -111,7 +115,7 @@ $(document).ready(function () {
         return;
       }
 
-      var $additionalInformation = $mollieContainers.closest('.additional-information')
+      var $additionalInformation = $mollieContainers.closest('.js-additional-information')
 
       hideAdditionalInformation($additionalInformation)
     })
@@ -169,7 +173,7 @@ $(document).ready(function () {
         inputHolder.addEventListener("focus", function () {
             var $formGroup =   $('.form-group-' + methodName + '.' + methodId)
 
-            var $additionalInformation = $formGroup.closest('.additional-information')
+            var $additionalInformation = $formGroup.closest('.js-additional-information')
 
             if ($additionalInformation.hasClass('mollie-credit-card-container__hide')) {
               // if mollie is hidden do nothing with focus

--- a/views/js/front/mollie_iframe.js
+++ b/views/js/front/mollie_iframe.js
@@ -15,8 +15,11 @@ $(document).ready(function () {
         return;
     }
 
+    // Hummingbird renames the wrapper, and a custom theme may carry only the plain class.
+    var additionalInformationSelector = '.js-additional-information, .additional-information';
+
     var overridePrestaShopsAdditionalInformationHideFunctionality = function ($mollieContainer) {
-      var $additionalInformationContainer = $mollieContainer.closest('.js-additional-information');
+      var $additionalInformationContainer = $mollieContainer.closest(additionalInformationSelector);
 
       // this allows for us to have our custom hide functionality
       $additionalInformationContainer.addClass('mollie-credit-card-container__hide')
@@ -41,7 +44,7 @@ $(document).ready(function () {
 
     // if credit card is somehow preselected its hidden content will be displayed
     var isMollieCreditCardPreselected = function ($iframeContainer) {
-      var $additionalInformation = $iframeContainer.closest('.js-additional-information')
+      var $additionalInformation = $iframeContainer.closest(additionalInformationSelector)
       var id = $additionalInformation.attr('id')
 
       if (!id) {
@@ -55,7 +58,7 @@ $(document).ready(function () {
     }
 
     if (isMollieCreditCardPreselected($mollieContainers)) {
-      showAdditionalInformation($mollieContainers.closest('.js-additional-information'))
+      showAdditionalInformation($mollieContainers.closest(additionalInformationSelector))
     }
 
     var options = {
@@ -115,7 +118,7 @@ $(document).ready(function () {
         return;
       }
 
-      var $additionalInformation = $mollieContainers.closest('.js-additional-information')
+      var $additionalInformation = $mollieContainers.closest(additionalInformationSelector)
 
       hideAdditionalInformation($additionalInformation)
     })
@@ -173,7 +176,7 @@ $(document).ready(function () {
         inputHolder.addEventListener("focus", function () {
             var $formGroup =   $('.form-group-' + methodName + '.' + methodId)
 
-            var $additionalInformation = $formGroup.closest('.js-additional-information')
+            var $additionalInformation = $formGroup.closest(additionalInformationSelector)
 
             if ($additionalInformation.hasClass('mollie-credit-card-container__hide')) {
               // if mollie is hidden do nothing with focus


### PR DESCRIPTION
Ticket: [PIPRES-827](https://mollie.atlassian.net/browse/PIPRES-827)

## Summary
- The checkout script looked the payment option's wrapper up by the `.additional-information` class. Classic carries it; Hummingbird names the same element `payment-option__additional-information`, so `closest()` matched nothing, `.attr('id')` gave `undefined` and `.replace()` threw.
- That threw inside the `ready` handler before `mountMollieComponents()` ran, so none of the four fields ever got an iframe. They still rendered their labels, which is why the form looked complete but accepted no input, and why nothing reached the module log.
- Look the wrapper up by `js-additional-information` instead. Both themes carry it, back to 1.7.6, and PrestaShop reserves `js-` prefixed classes as JavaScript hooks, so this is a strict superset of the old selector.
- Return early when the wrapper is missing, so a theme that drops it degrades instead of taking the whole card form down.

## Proof
No screenshots committed: this repo has no `docs/` directory and tracks only images the module ships, so there is no screenshot precedent to follow here. Verified instead with a scripted Chrome (Playwright) pass driving the real checkout end to end on both major versions.

```
BEFORE  PS 9.2 + Hummingbird : components=NOT MOUNTED  typing=FAILS  jsErrors=1
        TypeError: Cannot read properties of undefined (reading 'replace')
            at isMollieCreditCardPreselected
AFTER   PS 9.2 + Hummingbird : components=MOUNTED      typing=WORKS  jsErrors=0
BEFORE  PS 8.2.7 + classic   : components=MOUNTED      typing=WORKS  jsErrors=0
AFTER   PS 8.2.7 + classic   : components=MOUNTED      typing=WORKS  jsErrors=0   (identical)
```

Keyboard reachability on the fixed shop, one click into the first field and Tab thereafter:

```
tab order : card-holder -> card-number -> expiry-date -> verification-code
filled    : "Test Buyer" | "4242 4242 4242 4242" | "12 / 30" | "123"
            all four form groups is-dirty
```

Switching payment methods, PS 9.2 + Hummingbird:

```
card selected -> __show, opacity 1, 4 iframes mounted
switch away   -> __hide, opacity 0, height 0
back to card  -> __show, still mounted, typing still works
```

## Acceptance criteria evidence
- **AC-1** The card fields accept focus and typing on Hummingbird, and are reachable with the Tab key - browser pass above, on PS 9.2 + Hummingbird: mouse click, Tab traversal across all four components, and typing accepted by each.
- **AC-2** Classic is unaffected - manual: the PS 8.2.7 classic runs before and after are identical on every measured property (wrapper classes, computed styles, iframe counts, typed value).

The ticket's Expected line carries a second clause, that the payment completes with the card entered. Confirmed with the reporter that only the first clause is in scope here, so no payment was placed.

## Verify before merge
- No automated regression test ships with this fix. The module's Cypress suite is keyed to PrestaShop `8` / `1785` and has no PS 9 target, so there is nowhere in-repo to hold Hummingbird behaviour. Verified manually instead. A PS 9 e2e target would be worth a follow-up.
- `views/js/front/payment_fee.js:20` and `views/css/mollie_iframe.css:110` still key on the Classic-only `.additional-information`. Both degrade quietly rather than break (the fee label still renders through the `else` branch, and the CSS rule is a max-width 412px margin tweak), so they are deliberately left out of this change. Flagging so the decision is explicit rather than an oversight.
- Pre-existing, not introduced here, but newly reachable on Hummingbird because of this fix: `mountMollieComponents()` binds a `submit` handler every time it runs, and it runs again on each change of the Mollie radio. Measured on a live shop: 2 handlers after selecting Card once, 5 after four times. They all fire on one submit before `isResubmit` latches, so a checkout can mint several card tokens. Classic has this behaviour today.

<details>
<summary>Details</summary>

### Why `js-additional-information`

Wrapper markup read directly from each theme's `checkout/_partials/steps/payment.tpl`:

| Theme | class on `#<option>-additional-information` |
| --- | --- |
| PS 1.7.6.9 classic | `js-additional-information definition-list additional-information` |
| PS 8.2.7 classic | `js-additional-information definition-list additional-information` |
| PS 9 classic | `js-additional-information definition-list additional-information` |
| PS 9 hummingbird | `payment-option__additional-information js-additional-information` |

Only Hummingbird lacks the plain class, and every theme has the `js-` one. Matching on it therefore covers everywhere the old selector matched plus Hummingbird, which is what makes the PS 8 result identical rather than merely passing.

The alternatives were an `[id$="-additional-information"]` suffix match, or listing both class names. The `js-` class wins because PrestaShop documents `js-` prefixed classes as styling-free JavaScript hooks, so it is the one a future theme is most likely to keep.

### Checked and found clean

The fix activates `mollie-credit-card-container__hide` on Hummingbird for the first time (`opacity: 0; height: 0; position: absolute; z-index: -1`, with no `inert`), which looks like it should leave invisible card fields in the tab order. Tested rather than assumed: tabbing 14 times from the other payment method never reaches the card iframes, because the zero height and clipping take them out. No change needed.

### Verification environments

PS 9.2 + Hummingbird and PS 8.2.7 + classic, each a throwaway Docker stack against a Mollie test API key. The PS 9 shop served this branch directly; the PS 8 run replaced the module's JS in-browser with this branch's bytes, asserting all five selector sites and the guard were present before each run.

</details>

Confidence: 3/5 - the behaviour was exercised for real on both major versions rather than mocked, but nothing in-repo holds it, so an entry under Verify before merge needs a reviewer decision.


[PIPRES-827]: https://mollie.atlassian.net/browse/PIPRES-827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ