### PR TITLE
Install php-cs-fixer directly instead of via the EOL Docker action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          coverage: none
+
+      - name: Install PHP-CS-Fixer
+        run: |
+          mkdir -p "$RUNNER_TEMP/cs"
+          composer require --no-interaction --no-progress --working-dir="$RUNNER_TEMP/cs" \
+            prestashop/php-dev-tools:v5 friendsofphp/php-cs-fixer:v2.19.3
+
       - name: Run PHP-CS-Fixer
-        uses: prestashopcorp/github-action-php-cs-fixer-new@master
+        run: |
+          "$RUNNER_TEMP/cs/vendor/bin/php-cs-fixer" fix . \
+            --path-mode=intersection --dry-run --diff --using-cache=no --diff-format udiff
 
   eslint:
     name: ESLint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,21 +15,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '7.4'
-          coverage: none
-
       - name: Install PHP-CS-Fixer
         run: |
           mkdir -p "$RUNNER_TEMP/cs"
-          composer require --no-interaction --no-progress --working-dir="$RUNNER_TEMP/cs" \
+          echo '{"config":{"platform":{"php":"7.4"}}}' > "$RUNNER_TEMP/cs/composer.json"
+          docker run --rm -v "$RUNNER_TEMP/cs":/cs --workdir=/cs composer:2.2 \
+            require --no-interaction --no-progress \
             prestashop/php-dev-tools:v5 friendsofphp/php-cs-fixer:v2.19.3
 
       - name: Run PHP-CS-Fixer
         run: |
-          "$RUNNER_TEMP/cs/vendor/bin/php-cs-fixer" fix . \
+          docker run --rm -v "$PWD":/code -v "$RUNNER_TEMP/cs":/cs --workdir=/code php:7.4-cli \
+            php /cs/vendor/bin/php-cs-fixer fix . \
             --path-mode=intersection --dry-run --diff --using-cache=no --diff-format udiff
 
   eslint:


### PR DESCRIPTION
## Problem

Every `Tests` run in this repository has failed on the `php-cs-fixer` job since 2026-09-08 22:33 UTC, on every branch, including branches that touch no PHP at all. The last green run was 2026-09-07 10:46 UTC. Nothing in our code changed.

The job used `prestashopcorp/github-action-php-cs-fixer-new@master`, a Docker action built `FROM php:7.3`. That base image is Debian 11 "bullseye", whose LTS window ended on 2026-08-31. The action's Dockerfile runs `apt-get update` while the image is being built, and since the `bullseye-security` `InRelease` file passed its `Valid-Until` date on 2026-09-08, apt now refuses the repository and exits 100. The image build fails, so the job dies before a single step of ours runs. Nobody has to release anything for this to break, and nobody can fix it on our side while we depend on that action.

## Change

Install PHP-CS-Fixer ourselves from pinned Docker images, which is the shape the `phpstan` job in the same file already uses:

- `composer:2.2` installs `prestashop/php-dev-tools:v5` and `friendsofphp/php-cs-fixer:v2.19.3` into `RUNNER_TEMP`
- `php:7.4-cli` runs the fixer over the checkout with the same flags the action passed by default

Two details worth calling out:

- The versions are the ones already pinned in our `composer.lock`, so the linter behaves exactly as before. Moving to PHP-CS-Fixer v3 is not an option here: I measured it, and v3 rewrites 866 of our 873 PHP files.
- The install writes a `config.platform.php` of `7.4` before resolving. Without it the tool tree pulls Symfony 6 and a PHP 8.1 floor, and the fixer then refuses to start under `php:7.4-cli`.

`actions/checkout` is the only action left in the job, and it is on this repository's allowed-actions list.

## Verification

Run locally against this branch inside `php:7.4-cli`, with the exact commands the workflow now uses:

- clean tree: `Checked all files in 9.259 seconds`, exit code `0`, config reported as `Loaded config PrestaShop coding standard`
- with a deliberately misformatted file added: exit code `8` and a correct udiff, so the job still fails when it should

`act` cannot run the job end to end, because it executes the job inside a container and the nested `docker run -v "$RUNNER_TEMP/cs"` then points at a host path that does not exist. On a GitHub-hosted runner the job runs on the VM itself, so the bind mount is a real directory, exactly as in the `phpstan` job.

## Effect on other pull requests

Workflows for `pull_request` events run against the merge branch, so once this is on `develop` every open pull request targeting `develop` picks it up on its next run, without rebasing. A re-run of an old run replays the old workflow file, so use "Re-run all jobs" only after a new event, or push/reopen.

The 7 Dependabot pull requests target `master`, which needs the same change. Either cherry-pick it there or fold it into the pending back-merge #1491.

Note that no status check is required on `develop` or `master` (`enforcement_level: off`), so this red X has not been blocking merges. It is still worth fixing, because the job is our only automated formatting gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hz2reacu9duXoAo1Xt8c7N
