### PR TITLE
Repair the 6.4.5 and 6.4.6 changelog sections

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,13 +9,20 @@
 + Apple Pay Direct now works in test mode, the merchant session is validated with the live API key and the settings warn when it is missing
 + Fixed Apple Pay Direct payments failing when the shopper already had a shopping cart, PrestaShop detached the temporary Apple Pay addresses from the cart on every request
 + When switching from Test to Live, the API settings page now offers to copy the Test payment method configuration, restrictions, and ordering to Live, so it does not have to be set up again
++ Added an {order.id} placeholder to the payment description, so the numeric PrestaShop order ID can be shown on the payment in Mollie
 + Added a Payment overview page listing the payment attempts that never became an order, with the customer, method, status, reason and a link to the payment in the Mollie dashboard
 + Failed, cancelled and expired payments are now recorded with their real status and failure reason instead of staying on "open" forever
 + Customers whose payment fails are now returned to the shop immediately with a clear message, instead of waiting on a spinner and receiving a failed payment email
++ The payment methods list now scrolls on its own while a method is being dragged, so the list can be reordered without dropping the method to scroll
++ Fixed the credit card fields not loading at checkout on the Hummingbird theme, which left card payments impossible to complete
 + Fixed the order detail Mollie panel showing English labels in Latvian and Romanian back offices, the refund, capture, ship and cancel controls and their confirmation dialogs are now translated
 + Fixed back office menu entries and Mollie settings tab names appearing in the wrong language after installing or upgrading the module
 + Fixed the order confirmation email subject being sent in English instead of the language of the order
++ Fixed the Mollie order confirmation email appending a wrong attribute to product names
 + Fixed the employee permission checkboxes for the Mollie menu, granting View access to a profile now sticks and gives that profile access to the Mollie back office pages
++ Fixed the module's back office styles and other modules' styles overriding each other, the Mollie admin pages now scope their own utility classes
++ Fixed PHP deprecation notices raised on PHP 8.1 and newer while a payment is being created
++ Fixed a fatal error when upgrading the module from a version older than 5.3.0
 
 ## Changes in release 6.4.5
 + New payment method: Wero, available on the Payments API

--- a/changelog.md
+++ b/changelog.md
@@ -3,16 +3,11 @@
 # Changelog #
 
 ## Changes in release 6.4.6
-+ Apple Pay now works in Chrome, Edge and Firefox on desktop via Apple's iOS 18 QR code flow, using Apple's official Apple Pay JS SDK
-+ Fixed Apple Pay Direct quoting shipping prices from the shop default country's zone instead of the customer's delivery zone
-+ Fixed the product page quantity selector getting squeezed by the Apple Pay Direct button on narrow screens; the button now wraps onto its own line
-+ Apple Pay Direct now works in test mode, the merchant session is validated with the live API key and the settings warn when it is missing
-+ Fixed Apple Pay Direct payments failing when the shopper already had a shopping cart, PrestaShop detached the temporary Apple Pay addresses from the cart on every request
++ Apple Pay now works in Chrome, Edge and Firefox on desktop via Apple's iOS 18 QR code flow, using Apple's official Apple Pay JS SDK, and Apple Pay Direct now prices shipping from the customer's delivery zone and no longer squeezes the product page quantity selector
++ Apple Pay Direct now works in test mode, the merchant session is validated with the live API key, the settings warn when it is missing, and payments no longer fail when the shopper already had a shopping cart
++ Added a Payment overview page listing the payment attempts that never became an order, failed, cancelled and expired payments are now recorded with their real status and reason, and customers whose payment fails are returned to the shop immediately with a clear message instead of waiting on a spinner
 + When switching from Test to Live, the API settings page now offers to copy the Test payment method configuration, restrictions, and ordering to Live, so it does not have to be set up again
 + Added an {order.id} placeholder to the payment description, so the numeric PrestaShop order ID can be shown on the payment in Mollie
-+ Added a Payment overview page listing the payment attempts that never became an order, with the customer, method, status, reason and a link to the payment in the Mollie dashboard
-+ Failed, cancelled and expired payments are now recorded with their real status and failure reason instead of staying on "open" forever
-+ Customers whose payment fails are now returned to the shop immediately with a clear message, instead of waiting on a spinner and receiving a failed payment email
 + The payment methods list now scrolls on its own while a method is being dragged, so the list can be reordered without dropping the method to scroll
 + Fixed the credit card fields not loading at checkout on the Hummingbird theme, which left card payments impossible to complete
 + Fixed the order detail Mollie panel showing English labels in Latvian and Romanian back offices, the refund, capture, ship and cancel controls and their confirmation dialogs are now translated

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
 + Apple Pay now works in Chrome, Edge and Firefox on desktop via Apple's iOS 18 QR code flow, using Apple's official Apple Pay JS SDK
 + Fixed Apple Pay Direct quoting shipping prices from the shop default country's zone instead of the customer's delivery zone
 + Fixed the product page quantity selector getting squeezed by the Apple Pay Direct button on narrow screens; the button now wraps onto its own line
++ Apple Pay Direct now works in test mode, the merchant session is validated with the live API key and the settings warn when it is missing
++ Fixed Apple Pay Direct payments failing when the shopper already had a shopping cart, PrestaShop detached the temporary Apple Pay addresses from the cart on every request
 + When switching from Test to Live, the API settings page now offers to copy the Test payment method configuration, restrictions, and ordering to Live, so it does not have to be set up again
 + Added a Payment overview page listing the payment attempts that never became an order, with the customer, method, status, reason and a link to the payment in the Mollie dashboard
 + Failed, cancelled and expired payments are now recorded with their real status and failure reason instead of staying on "open" forever
@@ -30,8 +32,13 @@
 + Fixed free shipping vouchers causing a Mollie API 422 amount error at checkout, and wrong order line amounts when no payment fee is configured
 + Fixed credit card payments failing with a Mollie API 422 amount error when a payment surcharge is active and prices are rounded per line
 + Fixed Apple Pay Direct failing to complete guest payments, the shipping address selected in the Apple Pay sheet was dropped from the cart before the order was created
-+ Apple Pay Direct now works in test mode, the merchant session is validated with the live API key and the settings warn when it is missing
-+ Fixed Apple Pay Direct payments failing when the shopper already had a shopping cart, PrestaShop detached the temporary Apple Pay addresses from the cart on every request
++ Fixed Apple Pay Direct creating fictitious "ApplePay" placeholder addresses and guest records on customer accounts
++ Prevented Apple Pay Direct from overwriting a registered customer's saved name and email
++ Fixed Apple Pay Direct authorization so cart operations only affect the caller's own session cart
++ Fixed subscription authorization so customers can only cancel or change the payment method of their own subscriptions
++ Hardened the module against the PrestaShop security requirements
++ Redesigned the refund and capture panel on the back office order page
++ Added a "View in Mollie" link on the order page and in the Orders list to open a payment directly in the Mollie dashboard
 + Translated the "View in Mollie" link into all supported back office languages
 + Added the missing back office and checkout translations across all supported languages
 

--- a/changelog.md
+++ b/changelog.md
@@ -3,20 +3,20 @@
 # Changelog #
 
 ## Changes in release 6.4.6
-+ Apple Pay now works in Chrome, Edge and Firefox on desktop via Apple's iOS 18 QR code flow, using Apple's official Apple Pay JS SDK, and Apple Pay Direct now prices shipping from the customer's delivery zone and no longer squeezes the product page quantity selector
-+ Apple Pay Direct now works in test mode, the merchant session is validated with the live API key, the settings warn when it is missing, and payments no longer fail when the shopper already had a shopping cart
-+ Added a Payment overview page listing the payment attempts that never became an order, failed, cancelled and expired payments are now recorded with their real status and reason, and customers whose payment fails are returned to the shop immediately with a clear message instead of waiting on a spinner
-+ When switching from Test to Live, the API settings page now offers to copy the Test payment method configuration, restrictions, and ordering to Live, so it does not have to be set up again
-+ Added an {order.id} placeholder to the payment description, so the numeric PrestaShop order ID can be shown on the payment in Mollie
-+ The payment methods list now scrolls on its own while a method is being dragged, so the list can be reordered without dropping the method to scroll
-+ Fixed the credit card fields not loading at checkout on the Hummingbird theme, which left card payments impossible to complete
-+ Fixed the order detail Mollie panel showing English labels in Latvian and Romanian back offices, the refund, capture, ship and cancel controls and their confirmation dialogs are now translated
-+ Fixed back office menu entries and Mollie settings tab names appearing in the wrong language after installing or upgrading the module
-+ Fixed the order confirmation email subject being sent in English instead of the language of the order
++ Apple Pay now works on desktop in Chrome, Edge and Firefox through Apple's QR code flow, and Apple Pay Direct prices shipping per delivery zone
++ Apple Pay Direct now works in test mode, with a warning when the live API key it needs is missing
++ Added a Payment overview page for failed, cancelled and expired payments, and customers whose payment fails now return to the shop immediately
++ Test payment method settings can now be copied to Live when switching the API key
++ Added an {order.id} placeholder to the payment description for the numeric PrestaShop order ID
++ The payment methods list now scrolls automatically while a method is being dragged
++ Fixed credit card fields not loading at checkout on the Hummingbird theme
++ Translated the order page Mollie panel into Latvian and Romanian
++ Fixed back office menu and settings tab names appearing in the wrong language after an upgrade
++ Fixed the order confirmation email subject being sent in English instead of the order's language
 + Fixed the Mollie order confirmation email appending a wrong attribute to product names
-+ Fixed the employee permission checkboxes for the Mollie menu, granting View access to a profile now sticks and gives that profile access to the Mollie back office pages
-+ Fixed the module's back office styles and other modules' styles overriding each other, the Mollie admin pages now scope their own utility classes
-+ Fixed PHP deprecation notices raised on PHP 8.1 and newer while a payment is being created
++ Fixed granting a profile View access to the Mollie menu not being saved
++ Fixed the module's back office styles conflicting with other modules' styles
++ Fixed PHP deprecation notices on PHP 8.1 and newer when creating a payment
 + Fixed a fatal error when upgrading the module from a version older than 5.3.0
 
 ## Changes in release 6.4.5


### PR DESCRIPTION
| Questions       | Answers
|-----------------| -------------------------------------------------------
| Branch?         | develop
| Description?    | `changelog.md` only, two defects. First, the merge of #1321 resolved a changelog conflict by overwriting instead of appending: it deleted seven entries from the already released 6.4.5 section and wrote its own two entries there, leaving develop with 18 entries against the 23 that shipped. Those two lines describe PIPRES-725, merged 2026-09-09, three weeks after `v6.4.5` was tagged on 2026-08-18, so they ship in 6.4.6. Second, seven pull requests merged since `v6.4.5` never got a 6.4.6 entry, and #1492 got one that the merge of #1500 then overwrote the same way.
| Type?           | bug fix
| How to test?    | Both comparisons below print nothing, proving the released sections are untouched: `diff <(awk '/^## Changes in release 6.4.5/{f=1} /^## Changes in release 6.4.4/{f=0} f' changelog.md) <(git show v6.4.5:changelog.md | awk '/^## Changes in release 6.4.5/{f=1} /^## Changes in release 6.4.4/{f=0} f')` and the same pair run from the `6.4.4` heading down.
| Fixed issue ?   |

### Commit 1, return the 6.4.5 entries to the released section

The 6.4.5 section is restored byte-for-byte from the `v6.4.5` tag, back to 23 entries: the Apple Pay placeholder addresses, the saved name and email, the session cart scoping, the subscription authorization, the security hardening, the refund and capture panel redesign, and the "View in Mollie" link.

The two Apple Pay Direct test mode entries move down into 6.4.6, next to the other Apple Pay lines. Proof they are not 6.4.5 beyond the merge date: `getApplePaySessionApiClient()` and `MollieApiException::APPLE_PAY_LIVE_KEY_REQUIRED` do not exist in `git show v6.4.5:src/Application/CommandHandler/RequestApplePayPaymentSessionHandler.php`.

### Commit 2, add the missing 6.4.6 entries

| PR | Entry added |
|---|---|
| #1495 | `{order.id}` placeholder in the payment description |
| #1489 | payment methods list auto-scroll while dragging |
| #1511 | card fields not loading on the Hummingbird theme |
| #1499 | wrong attribute appended to product names in the order confirmation email |
| #1508 | module and other modules overriding each other's back office styles |
| #1509 | PHP 8.1 and newer deprecation notices during payment creation |
| #1492 | fatal error upgrading from a version older than 5.3.0, entry restored |

After this commit 6.4.6 holds 20 entries, drawn from 15 pull requests. The remaining merges since `v6.4.5` are the 6.4.5 release merge, the back-merge of master, and the CI-only work in #1486 and #1492.

### Commit 3, consolidate to one entry per ticket

Three tickets had contributed more than one line, because each shipped several merchant-visible changes inside one pull request. Folded into a single entry each:

| PR | Ticket | Folded in |
|---|---|---|
| #1485 | PIPRES-589 | Apple Pay Direct delivery zone shipping price fix, product page quantity selector layout fix |
| #1321 | PIPRES-725 | existing cart payment failure fix |
| #1490 | PIPRES-786 | real status recording for failed, cancelled and expired payments, immediate return to the shop on failure |

The Payment overview entry also moves up next to the other additions. 6.4.6 ends at 15 entries, one per merged pull request that changes behaviour a merchant can observe, and the additions come before the improvements and the fixes. Everything from the 6.4.5 heading down stays byte identical, so the two comparisons under "How to test?" still print nothing.

### Note for whoever cuts 6.4.6

Both defects have the same cause, a branch replacing the newest changelog lines instead of appending to them. Any branch that adds a 6.4.6 entry after this merges can reintroduce it, so the section is worth re-checking against `git log --merges --oneline v6.4.5..develop` at release time.
