### PR TITLE
Correct the supported PrestaShop version range and stale readme claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 | PrestaShop version | Mollie module                                                       |
 |------------------|---------------------------------------------------------------------|
-| 1.7.6 - 9.0.0    | [Mollie 6](https://github.com/mollie/PrestaShop/releases)           |
+| 1.7.6 and later  | [Mollie 6](https://github.com/mollie/PrestaShop/releases)           |
 | 1.7.0 - 1.7.5    | [Mollie 5](https://github.com/mollie/PrestaShop1.7.0-1.7.8/releases) |
 | 1.6.1 - 1.6.1.24 | [Mollie 4](https://github.com/mollie/PrestaShop1.6/releases)        |
 | 1.5              | [Mollie 3](https://addons.prestashop.com/en/payment-card-wallet/40307-mollie-payments.html)     |
@@ -18,10 +18,8 @@ Receive payments from European customers with ease. Mollie provides payment meth
 
 Choose the best payment provider available for your online PrestaShop store. Create your merchant account at [Mollie.com](https://www.mollie.com/). 
 
-Mollie supports the following payment methods: iDEAL, Credit card, Bancontact, SOFORT Banking, ING Home’Pay, Bank transfers, PayPal, KBC / CBC Payment Button, Belfius, CartaSi, Cartes Bancaires, EPS, Klarna: Pay later, Klarna: Slice it
+Mollie supports the following payment methods: iDEAL, Credit card, Bancontact, SOFORT Banking, ING Home’Pay, Bank transfers, PayPal, KBC / CBC Payment Button, Belfius, Cartes Bancaires, EPS, Klarna: Pay later, Klarna: Slice it
 
-[![Build Status](https://travis-ci.org/mollie/PrestaShop.svg?branch=master)](https://travis-ci.org/mollie/PrestaShop)
-[![Greenkeeper badge](https://badges.greenkeeper.io/mollie/PrestaShop.svg)](https://greenkeeper.io/)
 [![Release badge](https://img.shields.io/github/release/mollie/PrestaShop.svg)](https://github.com/mollie/PrestaShop/releases/latest)
 
 ## Installation PrestaShop 1.7 ##

--- a/README_DE.md
+++ b/README_DE.md
@@ -4,7 +4,7 @@
 
 | PrestaShop version | Mollie modul                                                       |
 |------------------|----------------------------------------------------------------------|
-| 1.7.6 - 9.0.0    | [Mollie 6](https://github.com/mollie/PrestaShop/releases)            |
+| 1.7.6 und höher  | [Mollie 6](https://github.com/mollie/PrestaShop/releases)            |
 | 1.7.0 - 1.7.5    | [Mollie 5](https://github.com/mollie/PrestaShop1.7.0-1.7.8/releases) |
 | 1.6.1 - 1.6.1.24 | [Mollie 4](https://github.com/mollie/PrestaShop1.6/releases)         |
 | 1.5              | [Mollie 3](https://addons.prestashop.com/en/payment-card-wallet/40307-mollie-payments.html)                            |
@@ -119,11 +119,6 @@ KBC konzentriert sich auf Flandern, CBC auf die Wallonie.
 
 ### Belfius-Zahlungsschaltfläche
 [Belfius](https://www.mollie.com/en/payments/belfius) ist eine der größten Banken Belgiens. Durch die Einführung der Belfius-Zahlungsschaltfläche bietet die Bank ihren Kunden ihre eigene Zahlungslösung.
-
-### CartaSi
-[CartaSi](https://www.mollie.com/en/payments/cartasi) ist eine der am weitesten verbreiteten Zahlungsmethoden Italiens. 
-
-Es sind über 13 Millionen CartaSi-Karten im Umlauf.
 
 ### Cartes Bancaires
 [Cartes Bancaires](https://www.mollie.com/en/payments/cartes-bancaires) sind die am häufigsten verwendeten Kreditkarten Frankreichs, es sind mehr als 64 Millionen Karten im Umlauf. 

--- a/README_DEV.md
+++ b/README_DEV.md
@@ -2,9 +2,15 @@
 
 ## Module production build
 
-After each pull request you can download module production build artifacts
+A production build of the module is uploaded as a workflow artifact every time a pull request is closed.
 
 ## PHP-CS-FIXER
 
-Its being applied automatically after each commit but if you want to run them locally the recommended way would be:
-`make fl`
+The `php-cs-fixer` job runs in CI on every pull request. There is no local git hook, so nothing is
+reformatted for you on commit. To fix the coding style before pushing, run:
+`make fix-lint`
+
+## React admin library
+
+The back office React apps live in `views/js/admin/library`. Rebuild the compiled bundles with:
+`make build-react`

--- a/README_ES.md
+++ b/README_ES.md
@@ -4,7 +4,7 @@
 
 | PrestaShop versión | Mollie módulo                                                       |
 |------------------|----------------------------------------------------------------------|
-| 1.7.6 - 9.0.0    | [Mollie 6](https://github.com/mollie/PrestaShop/releases)            |
+| 1.7.6 y superior | [Mollie 6](https://github.com/mollie/PrestaShop/releases)            |
 | 1.7.0 - 1.7.5    | [Mollie 5](https://github.com/mollie/PrestaShop1.7.0-1.7.8/releases) |
 | 1.6.1 - 1.6.1.24 | [Mollie 4](https://github.com/mollie/PrestaShop1.6/releases)         |
 | 1.5              | [Mollie 3](https://addons.prestashop.com/en/payment-card-wallet/40307-mollie-payments.html)                            |
@@ -119,11 +119,6 @@ KBC se enfoca en Flandes y CBC en Valonia.
 
 ### Botón de Pago de Belfius
 [Belfius](https://www.mollie.com/en/payments/belfius) es uno de los bancos más grandes de Bélgica. Al introducir el botón de pago Belfius, el banco ofrece a sus clientes su propia solución de pago.
-
-### CartaSi
-[CartaSi](https://www.mollie.com/en/payments/cartasi) es uno de los tipos de pago más utilizados en Italia. 
-
-Hay más de 13 millones de tarjetas de crédito CartaSi en circulación.
 
 ### Cartes Bancaires
 [Cartes Bancaires](https://www.mollie.com/en/payments/cartes-bancaires) son las tarjetas de crédito más usadas en Francia, con más de 64 millones de tarjetas en circulación. 

--- a/README_FR.md
+++ b/README_FR.md
@@ -2,7 +2,7 @@
 
 | PrestaShop version | Mollie modul                                                       |
 |------------------|----------------------------------------------------------------------|
-| 1.7.6 - 9.0.0    | [Mollie 6](https://github.com/mollie/PrestaShop/releases)            |
+| 1.7.6 et plus    | [Mollie 6](https://github.com/mollie/PrestaShop/releases)            |
 | 1.7.0 - 1.7.5    | [Mollie 5](https://github.com/mollie/PrestaShop1.7.0-1.7.8/releases) |
 | 1.6.1 - 1.6.1.24 | [Mollie 4](https://github.com/mollie/PrestaShop1.6/releases)         |
 | 1.5              | [Mollie 3](https://addons.prestashop.com/en/payment-card-wallet/40307-mollie-payments.html)                            |
@@ -119,11 +119,6 @@ KBC se concentre sur la Flandre et CBC sur la Wallonie.
 
 ### Bouton de paiement Belfius
 [Belfius](https://www.mollie.com/en/payments/belfius) est l'une des plus grandes banques de Belgique. En introduisant le bouton de paiement Belfius, la banque met à la disposition de ses clients sa propre solution de paiement.
-
-### CartaSi
-[CartaSi](https://www.mollie.com/en/payments/cartasi) est l'un des modes de paiement les plus utilisés en Italie. 
-
-Il y a plus de 13 millions de cartes de crédit CartaSi en circulation.
 
 ### Cartes Bancaires
 [Cartes Bancaires](https://www.mollie.com/en/payments/cartes-bancaires) est la carte de crédit la plus utilisée en France, avec plus de 64 millions de cartes en circulation. 

--- a/README_NL.md
+++ b/README_NL.md
@@ -4,7 +4,7 @@
 
 | PrestaShop version | Mollie module                                                      |
 |------------------|----------------------------------------------------------------------|
-| 1.7.6 - 9.0.0    | [Mollie 6](https://github.com/mollie/PrestaShop/releases)            |
+| 1.7.6 en hoger   | [Mollie 6](https://github.com/mollie/PrestaShop/releases)            |
 | 1.7.0 - 1.7.5    | [Mollie 5](https://github.com/mollie/PrestaShop1.7.0-1.7.8/releases) |
 | 1.6.1 - 1.6.1.24 | [Mollie 4](https://github.com/mollie/PrestaShop1.6/releases)         |
 | 1.5              | [Mollie 3](https://addons.prestashop.com/en/payment-card-wallet/40307-mollie-payments.html)                            |
@@ -110,9 +110,6 @@ KBC richt zich op Vlaanderen en CBC op Wallonië.
 
 ### Belfius Pay Button
 [Belfius](https://www.mollie.com/nl/payments/belfius) is een van de grootste banken van België. Met de Belfius Pay Button voorziet de bank haar klanten van een eigen betaaloplossing.
-
-### CartaSi
-[CartaSi](https://www.mollie.com/nl/payments/cartasi) is een van de meest gebruikte betaalmethoden in Italië. Er zijn ruim 13 miljoen CartaSi-creditcards in circulatie en het is een van de meest gebruikte betaalmethoden in Italië. 
 
 ### Cartes Bancaires
 [Cartes Bancaires](https://www.mollie.com/nl/payments/cartes-bancaires) zijn de meest gebruikte creditcards in Frankrijk, met meer dan 64 miljoen kaarten in circulatie. 

--- a/views/js/admin/library/README.md
+++ b/views/js/admin/library/README.md
@@ -1,36 +1,45 @@
-# Mollie Authentication React Component
+# Mollie admin React apps
 
-Clean React authentication page for Mollie PrestaShop module admin interface.
+React front ends for the Mollie PrestaShop module back office pages.
 
 ## Structure
 
 ```
 library/
-├── src/pages/authentication/          # Authentication page
-│   ├── index.tsx                      # Entry point
-│   ├── AuthenticationPage.tsx         # Main component
-│   ├── components/                    # Your authentication components
-│   └── services/                      # API service layer
-├── components/ui/                     # Essential UI components only
-│   ├── badge.tsx, button.tsx         # Used components
-│   ├── card.tsx, input.tsx
-│   ├── label.tsx, tabs.tsx
-├── dist/assets/authentication.js      # Built bundle
-└── Build configuration files
+├── src/app/                           # Vite entry points, one per back office page
+│   ├── authorization.tsx
+│   ├── payment-methods.tsx
+│   └── advanced-settings.tsx
+├── src/pages/                         # Page implementations
+│   ├── authorization/
+│   ├── payment-methods/
+│   └── advanced-settings/
+├── src/services/                      # API service layer
+│   ├── AuthenticationApiService.ts
+│   ├── PaymentMethodsApiService.ts
+│   └── AdvancedSettingsApiService.ts
+├── src/shared/                        # Shared UI components, hooks, types and styles
+└── dist/assets/                       # Build output, git ignored
+    ├── authorization.js
+    ├── mollie-payment-methods.js
+    └── mollie-advanced-settings.js
 ```
 
 ## Commands
 
-- `npm install` - Install dependencies  
-- `npm run build` - Build for production
+- `npm install` - Install dependencies
 - `npm run dev` - Development server
+- `npm run build` - Type check and build for production
+- `npm run lint` - Run ESLint
 
-## Usage
+From the module root, `make build-react` installs and builds in one step.
 
-1. Add your authentication components to `src/pages/authentication/components/`
-2. Add API service to `src/pages/authentication/services/`
-3. Build with `npm run build`
-4. Include `dist/assets/authentication.js` in your PHP template
+## Notes
 
-
-
+- `dist/` is git ignored. The release workflow builds it, and a local environment only picks up a
+  source change after `make build-react`.
+- The admin controllers register the bundles from `views/js/admin/library/dist/assets/`, so the
+  built file names are part of the contract and must match the Vite entry names.
+- All page styles are scoped to `.mollie-admin-app` by `postcss.config.js` so they cannot leak into
+  the PrestaShop back office theme or other modules.
+- `src/` and the build configuration are stripped from the release ZIP; only `dist/` ships.


### PR DESCRIPTION
## Description

The readme version table advertised `1.7.6 - 9.0.0`, which is wrong on two counts. `mollie.php:120` sets `ps_versions_compliancy` to `['min' => '1.7.6', 'max' => _PS_VERSION_]`, so the module declares no upper bound at all, and PrestaShop 9.1.x is already out. The ceiling was a marketing claim that goes stale on every PrestaShop minor, so it is now open ended: `1.7.6 and later`, localized in each of the five merchant readmes.

While auditing the readmes, four more claims turned out to be false against the code. All of them ship to merchants inside `mollie.zip` (`release.yml` strips `views/js/admin/library/README.md` but no root `README*.md`), so they are merchant facing:

1. **CartaSi is advertised but unsupported.** `cartasi` is absent from `Config::$methods`, the allow-list `Config::isMethodSupported()` reads (`src/Config/Config.php:468`), so the method can never be enabled. Removed from the method list in `README.md` and from the `### CartaSi` documentation section in the four translated readmes.
2. **Two dead badges.** The Travis badge points at a service the repo left when `.travis.yml` was deleted in `ae3fd5925`, and Greenkeeper shut down in 2020. Both render as broken images on the repo front page. The shields.io Release badge still resolves and is kept.
3. **`README_DEV.md` was wrong on both of its technical claims.** It told developers to run `make fl`, which is not a target (`Makefile:5` defines `fix-lint`), and said php-cs-fixer is "applied automatically after each commit". There is no `.husky` and no `.git/hooks/pre-commit`; the job runs in CI on pull requests only (`test.yml:12`). Added a pointer to `make build-react` while there.
4. **`views/js/admin/library/README.md` documented a page that no longer exists.** It described `src/pages/authentication/`, `AuthenticationPage.tsx` and a `dist/assets/authentication.js` bundle. The library now builds three Vite entry points from `src/app` (`authorization`, `mollie-payment-methods`, `mollie-advanced-settings`), and `dist` is git ignored. Rewritten against the real tree, the real npm scripts, and the `.mollie-admin-app` PostCSS scoping.

## Type

Documentation

## How to test

No functional change, nothing to install. Review the rendered readmes on the branch and confirm:

- the version table reads `1.7.6 and later` in all five languages
- `grep -ri cartasi README*.md` returns nothing
- the repo front page shows one badge instead of three, and it is not broken
- `make fix-lint` and `make build-react` both exist in the `Makefile`

## Left out deliberately

Two things need a decision rather than a code check, so they are not in this PR:

- the `## Installation PrestaShop 1.6 ##` sections and the three "compatible with PrestaShop 1.6 to 1.7" sentences, which need a call on what the readmes should say about 1.6
- the rest of the per-method documentation sections, which need Mollie to confirm which methods are retired (SOFORT, ING Home'Pay and Bitcoin are the candidates) before four translations are edited

## Fixed issue

None, internal cleanup.