### PR TITLE
Fix the 6.4.6 upgrade failing on the first back office upload

### DIFF
--- a/upgrade/Upgrade-6.4.6.php
+++ b/upgrade/Upgrade-6.4.6.php
@@ -21,6 +21,13 @@ if (!defined('_PS_VERSION_')) {
  */
 function upgrade_module_6_4_6($module)
 {
+    // A back office zip upload instantiates the module before it replaces the files, so the
+    // autoloader registered in this request is still the installed version's. Release builds are
+    // dumped with --classmap-authoritative, which drops the PSR-4 fallback, and mollie.php loads
+    // vendor/autoload.php through require_once on a path that is already included, so the new
+    // autoloader never registers. Classes this version adds have to be loaded by path.
+    require_once __DIR__ . '/../src/Utility/TabTranslationUtility.php';
+
     try {
         // Bypasses the service container, which is not reliably available during an upgrade.
         $installTabFunction = function ($module, $className, $parent, $name) {
@@ -107,7 +114,9 @@ function upgrade_module_6_4_6($module)
         \Mollie\Utility\TabTranslationUtility::repairTabNames($module);
 
         return true;
-    } catch (Exception $e) {
+    } catch (Throwable $e) {
+        // Not Exception: a class the stale autoloader cannot resolve throws ClassNotFoundError,
+        // which extends Error, so the merchant would only see a blank upload failure.
         PrestaShopLogger::addLog(
             'Mollie module upgrade to 6.4.6 failed: ' . $e->getMessage(),
             3,


### PR DESCRIPTION
## Problem

Uploading the 6.4.6 zip over an installed 6.4.5 in Module Manager returns HTTP 500 on the first
attempt. The merchant sees only "Oops... Upload failed.", `ps_module.version` stays 6.4.5 and
nothing is written to `ps_log`. A second identical upload succeeds.

The fatal is in `var/logs/dev-*.log`:

```
Symfony\Component\ErrorHandler\Error\ClassNotFoundError: Attempted to load class
"TabTranslationUtility" from namespace "Mollie\Utility"
at modules/mollie/upgrade/Upgrade-6.4.6.php line 49
```

## Cause

1. Release builds are dumped with `--classmap-authoritative` (`Makefile:133`), so Composer never
   consults PSR-4, only the generated classmap.
2. `mollie.php:58` is `require_once __DIR__ . '/vendor/autoload.php'`. A back office upload
   instantiates the module before it replaces the files, so that path is already included and the
   6.4.6 autoloader never registers.
3. `Mollie\Utility\TabTranslationUtility` is new in 6.4.6, so the in-memory 6.4.5 classmap cannot
   resolve it.
4. The second upload works because the 6.4.6 files are on disk at request start.

`ClassNotFoundError` extends `Error`, so `catch (Exception $e)` never fired. The failed run also
leaves `ps_tab` renamed to `AdminMollieModuleMTR` while the version still reads 6.4.5. The rename
is idempotent so a retry recovers, but a merchant who does not retry stays there.

Any upgrade script that references a class absent from the previous version hits this. Earlier
scripts only touch classes that existed in both versions, which is why it never surfaced. The
closest precedent is PIPRES-545, where the 6.2.7 rename of `MolPaymentMethodLang` was fought with
`Tools::clearAllCache()` and `exec('composer dumpautoload')` before the class reference was
dropped instead.

## Change

`upgrade_module_6_4_6()` loads the new class by path before it runs, and catches `Throwable` so a
future `Error` reaches `ps_log` instead of vanishing behind a blank upload failure.

## Testing

PS 8.2.3, PHP 8.1. A/B on the same fresh 6.4.5 install, patching only that one entry inside the
real 6.4.6 zip so the rest of the build was untouched.

Unpatched, first upload: failure box, version stuck at 6.4.5, `ps_tab` already renamed, a new
`ClassNotFoundError` in the log.

Patched, first upload: "Module installed!", version 6.4.6, no new `ClassNotFoundError`, zero
CRITICAL lines. Root tab renamed keeping its id and its four role slugs with their grants, both
new tabs created under the right parents, `mollie_payments_status_created` and
`mollie_payments_created_at` added, `repairTabNames()` corrected the language bleed, API key and
`ps_mollie_payments` rows preserved, Mollie menu and Payment overview render.

## Not in this PR

Dropping `--classmap-authoritative` from the Makefile and the release workflows. That restores the
PSR-4 fallback and would prevent this from 6.4.7 onwards, but it cannot help an upgrade from 6.4.5,
which is already released. Worth deciding separately since it changes every release build.
